### PR TITLE
fix: update to ctakesclient 1.0.0

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -23,7 +23,7 @@ NLP Physician Notes
 ============================
 * Support physician notes as `FHIR DocumentReference <https://www.hl7.org/fhir/documentreference-definitions.html#DocumentReference.content.attachment>`_
 * Support `Unified Medical Language System <https://www.nlm.nih.gov/research/umls/index.html>`_ concept extraction.
-* Use the provided `cTAKES client <https://github.com/comorbidity/ctakes-client-python>`_ to query `cTAKES COVID container <https://github.com/Machine-Learning-for-Medical-Language/ctakes-covid-container>`_ and `clinical NLP Transformers <https://github.com/Machine-Learning-for-Medical-Language/cnlp_transformers#negation-api>`_
+* Use the provided `cTAKES client <https://github.com/Machine-Learning-for-Medical-Language/ctakes-client-py>`_ to query `cTAKES COVID container <https://github.com/Machine-Learning-for-Medical-Language/ctakes-covid-container>`_ and `clinical NLP Transformers <https://github.com/Machine-Learning-for-Medical-Language/cnlp_transformers#negation-api>`_
 
 DEID: Patient Privacy
 =====================

--- a/cumulus/i2b2/etl.py
+++ b/cumulus/i2b2/etl.py
@@ -7,7 +7,7 @@ from cumulus import common, store
 from cumulus import i2b2
 from cumulus.i2b2.config import JobConfig, JobSummary
 from cumulus.codebook import Codebook, CodebookDB
-import ctakes
+import ctakesclient
 
 #######################################################################################################################
 #

--- a/cumulus/i2b2/transform.py
+++ b/cumulus/i2b2/transform.py
@@ -21,7 +21,7 @@ from fhirclient.models.documentreference import DocumentReferenceContext, Docume
 from fhirclient.models.attachment import Attachment
 from fhirclient.models.codeableconcept import CodeableConcept
 
-from ctakes.client import CtakesJSON
+from ctakesclient.client import CtakesJSON
 
 from cumulus import common, fhir_template
 from cumulus.i2b2.schema import PatientDimension, VisitDimension, ObservationFact

--- a/cumulus/labelstudio.py
+++ b/cumulus/labelstudio.py
@@ -1,7 +1,7 @@
 import os
 import json
 from cumulus import common, store
-from ctakes.typesystem import Polarity, MatchText, CtakesJSON, UmlsTypeMention
+from ctakesclient.typesystem import Polarity, MatchText, CtakesJSON, UmlsTypeMention
 
 COVID_SYMPTOMS_BSV = os.path.join(os.getcwd(), '../resources/covid_symptoms.bsv')
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,4 +2,4 @@
 requests
 pandas
 fhirclient
--e ../ctakes-client-python
+-e ../ctakes-client-py

--- a/tests/test_labelstudio.py
+++ b/tests/test_labelstudio.py
@@ -2,8 +2,8 @@ import os
 import random
 import unittest
 
-from ctakes.filesystem import map_cui_pref
-from ctakes.typesystem import CtakesJSON, Polarity
+from ctakesclient.filesystem import map_cui_pref
+from ctakesclient.typesystem import CtakesJSON, Polarity
 
 from cumulus import store, common
 from cumulus.labelstudio import COVID_SYMPTOMS_BSV


### PR DESCRIPTION
The module import name has changed from ctakes to ctakesclient.

(And the homepage for the project moved, update a couple URLs.)

See https://github.com/Machine-Learning-for-Medical-Language/ctakes-client-py/pull/1