### PR TITLE
Minor fixes to allow an initial bare-bones run to finish

### DIFF
--- a/cumulus/codebook.py
+++ b/cumulus/codebook.py
@@ -32,7 +32,10 @@ class Codebook:
         """
         :param saved: saved codebook or None (initialize empty)
         """
-        self.db = CodebookDB(saved)
+        try:
+            self.db = CodebookDB(saved)
+        except FileNotFoundError:
+            self.db = CodebookDB()
 
     def fhir_patient(self, patient: Patient) -> Patient:
         mrn = patient.identifier[0].value

--- a/cumulus/i2b2/config.py
+++ b/cumulus/i2b2/config.py
@@ -76,6 +76,9 @@ class JobSummary:
         :param show_every: print success rate
         :return: % success rate
         """
+        if not self.attempt:
+            return 1.0
+
         prct = float(len(self.success)) / float(len(self.attempt))
 
         if 0 == len(self.attempt) % show_every:

--- a/cumulus/i2b2/etl.py
+++ b/cumulus/i2b2/etl.py
@@ -199,10 +199,13 @@ def etl_notes(config:JobConfig) -> JobSummary:
                 docref = i2b2.transform.to_fhir_documentreference(i2b2_physician_note)
 
                 mrn = docref.subject.reference
-                enc = docref.context.encounter.reference
-
                 deid = codebook.fhir_documentreference(docref)
 
+                # TODO: confirm what we should do with multiple/zero encounters
+                if len(docref.context.encounter) != 1:
+                    raise ValueError("Cumulus only supports single-encounter notes right now")
+
+                enc = docref.context.encounter[0].reference
                 path = store.path_file(config.dir_output_encounter(mrn, enc), f'fhir_docref_{deid.id}.json')
 
                 job.success.append(store.write_json(path, deid.as_json()))

--- a/tests/test_codebook_fhir.py
+++ b/tests/test_codebook_fhir.py
@@ -119,23 +119,7 @@ class TestCodebookFHIR(unittest.TestCase):
 
         UUID(docref.id)
 
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
+    def test_missing_db_file(self):
+        """Ensure we gracefully handle a saved db file that doesn't exist yet"""
+        codebook = Codebook('/missing-codebook-file.json')
+        self.assertEqual({}, codebook.db.mrn)

--- a/tests/test_i2b2_config.py
+++ b/tests/test_i2b2_config.py
@@ -1,0 +1,27 @@
+"""Tests for config.py"""
+
+import unittest
+from socket import gethostname
+
+import freezegun
+
+from cumulus.i2b2 import config
+
+
+class TestI2b2ConfigSummary(unittest.TestCase):
+    """Test case for JobSummary"""
+
+    @freezegun.freeze_time('Sep 15th, 2021 1:23:45')
+    def test_empty_summary(self):
+        summary = config.JobSummary('empty')
+        expected = {
+            'attempt': 0,
+            'csv': [],
+            'failed': [],
+            'hostname': gethostname(),
+            'label': 'empty',
+            'success': [],
+            'success_rate': 1.0,
+            'timestamp': '2021-09-15 01:23:45',
+        }
+        self.assertEqual(expected, summary.as_json())


### PR DESCRIPTION
- Allow Codebook's saved file to not exist yet (helps on first run)
- If a folder is empty of csv files, don't raise an exception when printing a summary. Instead, report a 1.0 success rate.
- Fix another instance of context.encounter being a list now.
- Add tests for some of the above.