### PR TITLE
refactor: reduce some redundancy in etl.py

### DIFF
--- a/test/test_i2b2_etl.py
+++ b/test/test_i2b2_etl.py
@@ -45,8 +45,8 @@ class TestI2b2EtlSimple(unittest.TestCase):
         filecmp.dircmp by itself likes to only do shallow comparisons that
         notice changes like timestamps. But we want the contents themselves.
         """
-        self.assertEqual([], dircmp.left_only)
-        self.assertEqual([], dircmp.right_only)
+        self.assertEqual([], dircmp.left_only, dircmp.left)
+        self.assertEqual([], dircmp.right_only, dircmp.right)
 
         for filename in dircmp.common_files:
             left_path = os.path.join(dircmp.left, filename)


### PR DESCRIPTION
Specifically, allow each etl job to only provide a processor function for one entry from csv, and add a main loop helper that loads the data and saves the result to the job config.

Fixes: https://github.com/smart-on-fhir/cumulus-etl/issues/2