### PR TITLE
Put the job config files in the output folder

### DIFF
--- a/cumulus/common.py
+++ b/cumulus/common.py
@@ -1,12 +1,12 @@
 """Utility methods"""
 
+import datetime
 import os
 import logging
 import json
 import pandas
 import uuid
 import hashlib
-from datetime import datetime
 
 import fsspec
 from fhirclient.models.resource import Resource
@@ -214,23 +214,21 @@ def print_fhir(fhir_resource):
 # Helper Functions: Timedatestamp
 #
 ###############################################################################
-def timestamp_date() -> str:
-    """
-    :return: MMMM-DD-YYY
-    """
-    return datetime.now().strftime('%Y-%m-%d')
-
 
 def timestamp_datetime() -> str:
     """
+    Human-readable UTC date and time
     :return: MMMM-DD-YYY hh:mm:ss
     """
-    return datetime.now().strftime('%Y-%m-%d %H:%M:%S')
+    return datetime.datetime.now(datetime.timezone.utc).strftime('%Y-%m-%d %H:%M:%S')
 
 
-def timestamp() -> str:
+def timestamp_filename() -> str:
     """
-    Human-readable without escape characters on filesystem path
+    Human-readable UTC date and time suitable for a filesystem path
+
+    In particular, there are no characters that need awkward escaping.
+
     :return: MMMM-DD-YYY__hh.mm.ss
     """
-    return datetime.now().strftime('%Y-%m-%d__%H.%M.%S')
+    return datetime.datetime.now(datetime.timezone.utc).strftime('%Y-%m-%d__%H.%M.%S')

--- a/cumulus/i2b2/config.py
+++ b/cumulus/i2b2/config.py
@@ -9,28 +9,28 @@ from cumulus import common, store
 class JobConfig:
     """Configuration for an ETL job"""
 
-    def __init__(self, dir_input: store.Root, dir_cache: store.Root,
+    def __init__(self, dir_input: store.Root, dir_phi: store.Root,
                  store_format: store.Format):
         """
         :param dir_input: sources stored in csv_* folders
-        :param dir_cache: where to place build artifacts like the codebook
+        :param dir_phi: where to place PHI build artifacts like the codebook
         :param store_format: where to place output files and how, like ndjson
         """
         self.dir_input = dir_input
-        self.dir_cache = dir_cache
+        self.dir_phi = dir_phi
         self.format = store_format
-        self.timestamp = common.timestamp()
+        self.timestamp = common.timestamp_filename()
         self.hostname = gethostname()
 
     def path_codebook(self) -> str:
-        return self.dir_cache.joinpath('codebook.json')
+        return self.dir_phi.joinpath('codebook.json')
 
     def path_config(self) -> str:
-        return os.path.join(self.dir_cache_config(), 'job_config.json')
+        return os.path.join(self.dir_job_config(), 'job_config.json')
 
-    def dir_cache_config(self) -> str:
-        path = self.dir_cache.joinpath(f'JobConfig_{self.timestamp}')
-        self.dir_cache.makedirs(path)
+    def dir_job_config(self) -> str:
+        path = self.format.root.joinpath(f'JobConfig/{self.timestamp}')
+        self.format.root.makedirs(path)
         return path
 
     def list_csv(self, folder) -> list:
@@ -55,7 +55,7 @@ class JobConfig:
         return {
             'dir_input': self.dir_input.path,
             'dir_output': self.format.root.path,
-            'dir_cache': self.dir_cache.path,
+            'dir_phi': self.dir_phi.path,
             'path': self.path_config(),
             'codebook': self.path_codebook(),
             'list_csv_patient': self.list_csv_patient(),

--- a/cumulus/i2b2/etl.py
+++ b/cumulus/i2b2/etl.py
@@ -203,7 +203,7 @@ def etl_job(config: JobConfig) -> List[JobSummary]:
         summary = task(config)
         summary_list.append(summary)
 
-        path = os.path.join(config.dir_cache_config(), f'{summary.label}.json')
+        path = os.path.join(config.dir_job_config(), f'{summary.label}.json')
         common.write_json(path, summary.as_json())
 
     return summary_list
@@ -220,7 +220,7 @@ def main(args: List[str]):
     parser = argparse.ArgumentParser()
     parser.add_argument('dir_input', metavar='/my/i2b2/input')
     parser.add_argument('dir_output', metavar='/my/i2b2/processed')
-    parser.add_argument('dir_cache', metavar='/my/i2b2/cache')
+    parser.add_argument('dir_phi', metavar='/my/i2b2/phi')
     parser.add_argument('--format',
                         choices=['json', 'ndjson', 'parquet'],
                         default='json')
@@ -228,11 +228,11 @@ def main(args: List[str]):
 
     logging.info('Input Directory: %s', args.dir_input)
     logging.info('Output Directory: %s', args.dir_output)
-    logging.info('Cache Directory: %s', args.dir_cache)
+    logging.info('PHI Build Directory: %s', args.dir_phi)
 
     root_input = store.Root(args.dir_input, create=True)
     root_output = store.Root(args.dir_output, create=True)
-    root_cache = store.Root(args.dir_cache, create=True)
+    root_phi = store.Root(args.dir_phi, create=True)
 
     if args.format == 'ndjson':
         config_store = store_ndjson.NdjsonFormat(root_output)
@@ -241,7 +241,7 @@ def main(args: List[str]):
     else:
         config_store = store_json_tree.JsonTreeFormat(root_output)
 
-    config = JobConfig(root_input, root_cache, config_store)
+    config = JobConfig(root_input, root_phi, config_store)
     print(json.dumps(config.as_json(), indent=4))
 
     common.write_json(config.path_config(), config.as_json())

--- a/cumulus/store.py
+++ b/cumulus/store.py
@@ -17,7 +17,7 @@ class Root:
     Usually there are three roots in a given etl run:
     - Input folder
     - Output folder
-    - Cache folder
+    - PHI build folder (for codebook, etc.)
 
     This is mostly a coupling of a target path and the fsspec filesystem
     to use. With some useful methods mixed in.


### PR DESCRIPTION
Also:
- Internally rename cache dir to PHI dir
- Put all job config files under a toplevel JobConfig/ folder to avoid output dir spam
- Use UTC time for all timestamps

Fixes https://github.com/smart-on-fhir/cumulus-etl/issues/33