### PR TITLE
build: add support for Python 3.6

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -4,10 +4,10 @@ on: [push]
 jobs:
   unittest:
     name: unit tests
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-20.04 # Can bump once we drop support for py3.6
     strategy:
       matrix:
-        python-version: ["3.7", "3.8", "3.9", "3.10"]
+        python-version: ["3.6", "3.7", "3.8", "3.9", "3.10"]
 
     steps:
       - uses: actions/checkout@v3

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,7 @@
 [project]
 name = "cumulus"
-requires-python = ">= 3.7"
+# We'll want to officially support 3.6 until we no longer care about CentOS 7
+requires-python = ">= 3.6"
 dependencies = [
     "ctakesclient >= 1.0.0",
     "cx-oracle",


### PR DESCRIPTION
While it's end-of-life, it's still the Python3-of-record for CentOS 7