### PR TITLE
etl: add --comment argument

### DIFF
--- a/cumulus/i2b2/config.py
+++ b/cumulus/i2b2/config.py
@@ -10,7 +10,7 @@ class JobConfig:
     """Configuration for an ETL job"""
 
     def __init__(self, dir_input: store.Root, dir_phi: store.Root,
-                 store_format: store.Format):
+                 store_format: store.Format, comment: str = None):
         """
         :param dir_input: sources stored in csv_* folders
         :param dir_phi: where to place PHI build artifacts like the codebook
@@ -21,6 +21,7 @@ class JobConfig:
         self.format = store_format
         self.timestamp = common.timestamp_filename()
         self.hostname = gethostname()
+        self.comment = comment or ''
 
     def path_codebook(self) -> str:
         return self.dir_phi.joinpath('codebook.json')
@@ -64,6 +65,7 @@ class JobConfig:
             'list_csv_notes': self.list_csv_notes(),
             'list_csv_diagnosis': self.list_csv_diagnosis(),
             'format': type(self.format).__name__,
+            'comment': self.comment,
         }
 
 

--- a/cumulus/i2b2/etl.py
+++ b/cumulus/i2b2/etl.py
@@ -224,6 +224,7 @@ def main(args: List[str]):
     parser.add_argument('--format',
                         choices=['json', 'ndjson', 'parquet'],
                         default='json')
+    parser.add_argument('--comment', help='add the comment to the log file')
     args = parser.parse_args(args)
 
     logging.info('Input Directory: %s', args.dir_input)
@@ -241,7 +242,7 @@ def main(args: List[str]):
     else:
         config_store = store_json_tree.JsonTreeFormat(root_output)
 
-    config = JobConfig(root_input, root_phi, config_store)
+    config = JobConfig(root_input, root_phi, config_store, comment=args.comment)
     print(json.dumps(config.as_json(), indent=4))
 
     common.write_json(config.path_config(), config.as_json())


### PR DESCRIPTION
This will place the given comment into the JobConfig json file, for logging purposes. For example:

etl --comment="My Good Comment" ./input ./output ./phi

Will put "My Good Comment" into the job_config.json file for later review.