### PR TITLE
etl: clean up type hinting for callables

### DIFF
--- a/cumulus/i2b2/schema.py
+++ b/cumulus/i2b2/schema.py
@@ -24,12 +24,16 @@ class Table(Enum):
     mrn_patient_failed = 'mrn_patuuid_patnum_failed'
 
 
+class Dimension:
+    """Base class for any i2b2 entry"""
+
+
 ###############################################################################
 # i2b2 PatientDimension --> FHIR Patient
 ###############################################################################
 
 
-class PatientDimension:
+class PatientDimension(Dimension):
     """
     desc patient_dimension
 
@@ -75,7 +79,7 @@ class PatientDimension:
 ###############################################################################
 # i2b2 ProviderDimension --> FHIR Practitioner (Future)
 ###############################################################################
-class ProviderDimension:
+class ProviderDimension(Dimension):
     """
     desc provider_dimension
 
@@ -110,7 +114,7 @@ class ProviderDimension:
 ###############################################################################
 
 
-class VisitDimension:
+class VisitDimension(Dimension):
     """
     desc visit_dimension
 
@@ -147,7 +151,7 @@ class VisitDimension:
 #                           (future: FHIR Medication, ...)
 #
 ###############################################################################
-class ConceptDimension:
+class ConceptDimension(Dimension):
     """
     desc concept_dimension
 
@@ -245,7 +249,7 @@ class ValueFlagNormality(Enum):
     encrypted = 'X'
 
 
-class ObservationFact:
+class ObservationFact(Dimension):
     """
     desc observation_fact
 

--- a/cumulus/store.py
+++ b/cumulus/store.py
@@ -50,10 +50,10 @@ class Root:
         if not path.startswith(self.path):
             raise ValueError(f'Path "{path}" is not inside root "{self.path}"')
 
-    def exists(self, path: str) -> None:
+    def exists(self, path: str) -> bool:
         """Alias for os.path.exists"""
         self._confirm_in_root(path)
-        self.fs.exists(path)
+        return self.fs.exists(path)
 
     def makedirs(self, path: str) -> None:
         """Ensures the given path and all parents are created"""


### PR DESCRIPTION
This adds some typing helper variables to define the complicated Callable types. Hopefully makes code easier to read and also tightens up the typing to avoid uses of 'Any'.

Also while I was there, I noticed a bug with the Root.exists method not returning anything - fixed that.