### PR TITLE
i2b2: fix Patient.gender to be a proper AdministrativeGender code

### DIFF
--- a/cumulus/i2b2/fhir_template.py
+++ b/cumulus/i2b2/fhir_template.py
@@ -17,7 +17,7 @@ def template(name: str) -> dict:
     :param name: FHIR resource from saved JSON definition (Note: usage will be *deprecated*)
     :return: JSON of FHIR resource
     """
-    return common.read_json(os.path.join(os.path.dirname(__file__), 'resources', name))
+    return common.read_json(os.path.join(os.path.dirname(__file__), '..', 'resources', name))
 
 
 def fhir_patient() -> dict:
@@ -44,12 +44,13 @@ RACE = {
     'Not Hispanic or Latino': '2186-5'
 }
 
+# FHIR AdministrativeGender code (not a full gender spectrum, but quite limited)
+# https://www.hl7.org/fhir/valueset-administrative-gender.html
+# Anything not in this dictionary maps should map to 'other'
 GENDER = {
     'F': 'female',
     'M': 'male',
-    'T': 'transgender',
-    'U': 'Unknown',
-    'NB': 'non-binary'
+    'U': 'unknown',
 }
 
 LOINC = {

--- a/cumulus/i2b2/transform.py
+++ b/cumulus/i2b2/transform.py
@@ -1,7 +1,7 @@
 """Transformations from i2b2 to FHIR"""
 
 import logging
-from typing import List
+from typing import List, Optional
 
 from fhirclient.models.identifier import Identifier
 from fhirclient.models.fhirreference import FHIRReference
@@ -20,9 +20,10 @@ from fhirclient.models.documentreference import DocumentReferenceContext, Docume
 from fhirclient.models.attachment import Attachment
 from fhirclient.models.codeableconcept import CodeableConcept
 
-from cumulus import common, ctakes, fhir_template, store, text2fhir
+from cumulus import common, ctakes, store, text2fhir
 from cumulus.fhir_common import parse_fhir_date
 from cumulus.fhir_common import parse_fhir_date_isostring
+from cumulus.i2b2 import fhir_template
 from cumulus.i2b2.schema import PatientDimension, VisitDimension, ObservationFact
 
 
@@ -290,17 +291,13 @@ def parse_zip_code(i2b2_zip_code) -> str:
             return i2b2_zip_code
 
 
-def parse_gender(i2b2_sex_cd) -> str:
+def parse_gender(i2b2_sex_cd) -> Optional[str]:
     """
     :param i2b2_sex_cd:
-    :return: M,F,T,U, NB
+    :return: FHIR AdministrativeGender code
     """
     if i2b2_sex_cd and isinstance(i2b2_sex_cd, str):
-        if i2b2_sex_cd in fhir_template.GENDER:
-            return fhir_template.GENDER[i2b2_sex_cd]
-        else:
-            logging.warning('i2b2_sex_cd unknown code %s', i2b2_sex_cd)
-    logging.warning('i2b2_sex_cd missing: %s', i2b2_sex_cd)
+        return fhir_template.GENDER.get(i2b2_sex_cd, 'other')
 
 
 def parse_race(i2b2_race_cd) -> str:

--- a/test/test_i2b2_fhir_template.py
+++ b/test/test_i2b2_fhir_template.py
@@ -4,7 +4,7 @@ import unittest
 from fhirclient.models.patient import Patient
 from fhirclient.models.encounter import Encounter
 
-from cumulus import fhir_template
+from cumulus.i2b2 import fhir_template
 
 
 class TestResourcesFhirTemplates(unittest.TestCase):


### PR DESCRIPTION
Before, we were including some codes that didn't match (transgender, non-binary) -- but those aren't technically AdministrativeGender codes, which is what Patient.gender is.

Those values look more like GenderIdentity (though even then, you'd use transgender-female or transgender-male).

Anyway, simplify our gender parsing to only look for the AdministrativeGender values.

And also move fhir_template.py into i2b2/ because it's only used for that.