### PR TITLE
text2fhir now supports UMLS vocabulary definitions as URL

### DIFF
--- a/cumulus/text2fhir.py
+++ b/cumulus/text2fhir.py
@@ -1,6 +1,7 @@
 """NLP extension using ctakes"""
 
-from typing import List
+from enum import Enum
+from typing import List, Optional
 
 from fhirclient.models.resource import Resource
 from fhirclient.models.domainresource import DomainResource
@@ -31,8 +32,32 @@ FHIR_DERIVATION_REF_URL = 'http://hl7.org/fhir/StructureDefinition/derivation-re
 NLP_SOURCE_URL = 'http://fhir-registry.smarthealthit.org/StructureDefinition/nlp-source'
 NLP_POLARITY_URL = 'http://fhir-registry.smarthealthit.org/StructureDefinition/nlp-polarity'
 
-UMLS_SYSTEM_URL = 'http://terminology.hl7.org/CodeSystem/umls'  # TODO: refactor
+class Vocab(Enum):
+    """
+    https://build.fhir.org/terminologies-systems.html
+    """
+    SNOMEDCT_US = 'http://snomed.info/sct'
+    RXNORM = 'http://www.nlm.nih.gov/research/umls/rxnorm'
+    LOINC = 'http://loinc.org'
+    LNC = 'http://loinc.org'
+    CPT = 'http://www.ama-assn.org/go/cpt'
+    MEDRT = 'http://va.gov/terminology/medrt'
+    NDFRT = 'http://hl7.org/fhir/ndfrt'
+    NDC = 'http://hl7.org/fhir/sid/ndc'
+    CVX = 'http://hl7.org/fhir/sid/cvx'
+    ICD9 = 'ICD-9'
+    ICD10 = 'ICD-10'
+    UMLS = 'http://terminology.hl7.org/CodeSystem/umls'
 
+def url_vocab(umls_sab: str) -> Optional[str]:
+    """
+    https://www.nlm.nih.gov/research/umls/sourcereleasedocs/index.html
+    :param umls_sab: UMLS SAB = "Source Abbreviation"
+    :return: URL of UMLS vocab
+    """
+    if umls_sab == 'custom':
+        return None
+    return Vocab[umls_sab].value
 
 ###############################################################################
 # Common extension helper methods
@@ -213,8 +238,8 @@ def nlp_concept(match: MatchText) -> CodeableConcept:
     """
     coded = []
     for concept in match.conceptAttributes:
-        coded.append(fhir_coding(vocab=concept.codingScheme, code=concept.code))
-        coded.append(fhir_coding(vocab=UMLS_SYSTEM_URL, code=concept.cui))
+        coded.append(fhir_coding(vocab=url_vocab(concept.codingScheme), code=concept.code))
+        coded.append(fhir_coding(vocab=Vocab.UMLS.value, code=concept.cui))
 
     return fhir_concept(match.text, coded)
 

--- a/test/test_text2fhir.py
+++ b/test/test_text2fhir.py
@@ -119,7 +119,7 @@ class TestText2Fhir(unittest.TestCase):
             'coding': [
                 {
                     'code': '66076007',
-                    'system': 'SNOMEDCT_US',
+                    'system': 'http://snomed.info/sct',
                 },
                 {
                     'code': 'C0304290',
@@ -127,7 +127,7 @@ class TestText2Fhir(unittest.TestCase):
                 },
                 {
                     'code': '91058',
-                    'system': 'RXNORM',
+                    'system': 'http://www.nlm.nih.gov/research/umls/rxnorm',
                 },
                 {
                     'code': 'C0304290',
@@ -163,7 +163,7 @@ class TestText2Fhir(unittest.TestCase):
                 'coding': [
                     {
                         'code': '33962009',
-                        'system': 'SNOMEDCT_US',
+                        'system': 'http://snomed.info/sct',
                     },
                     {
                         'code': 'C0277786',
@@ -171,7 +171,7 @@ class TestText2Fhir(unittest.TestCase):
                     },
                     {
                         'code': '409586006',
-                        'system': 'SNOMEDCT_US',
+                        'system': 'http://snomed.info/sct',
                     },
                     {
                         'code': 'C0277786',
@@ -236,7 +236,7 @@ class TestText2Fhir(unittest.TestCase):
                 'coding': [
                     {
                         'code': '66076007',
-                        'system': 'SNOMEDCT_US',
+                        'system': 'http://snomed.info/sct',
                     },
                     {
                         'code': 'C0304290',
@@ -244,7 +244,7 @@ class TestText2Fhir(unittest.TestCase):
                     },
                     {
                         'code': '91058',
-                        'system': 'RXNORM',
+                        'system': 'http://www.nlm.nih.gov/research/umls/rxnorm',
                     },
                     {
                         'code': 'C0304290',
@@ -323,7 +323,7 @@ class TestText2Fhir(unittest.TestCase):
             'coding': [
                 {
                     'code': '8205005',
-                    'system': 'SNOMEDCT_US',
+                    'system': 'http://snomed.info/sct',
                 },
                 {
                     'code': 'C0043262',
@@ -332,6 +332,11 @@ class TestText2Fhir(unittest.TestCase):
             ],
             'text': 'wrist',
         }, bodysites[0])
+
+    def test_url_vocab(self):
+        # defaults preloaded with ctakes
+        for umls_sab in ['SNOMEDCT_US', 'RXNORM', 'UMLS', 'custom']:
+            text2fhir.url_vocab(umls_sab)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
for FHIR compatibility, text2fhir now uses names as defined by 
https://fhir-ru.github.io/terminologies-systems.html