### PR TITLE
s3: add some fixes for more locked down access

### DIFF
--- a/cumulus/common.py
+++ b/cumulus/common.py
@@ -93,7 +93,9 @@ def fake_id(category: str) -> str:
 def open_file(path: str, mode: str):
     """A version of open() that handles remote access, like to S3"""
     root = store.Root(path)
-    return fsspec.open(path, mode, encoding='utf8', **root.fsspec_options())
+    # We pass auto_mkdir because on some backends (like S3), we may not have permissions that fsspec might want,
+    # like CreateBucket. We elsewhere call Root.makedirs as needed.
+    return fsspec.open(path, mode, encoding='utf8', auto_mkdir=False, **root.fsspec_options())
 
 
 def read_text(path: str) -> str:

--- a/cumulus/ctakes.py
+++ b/cumulus/ctakes.py
@@ -1,6 +1,7 @@
 """Interface for talking to a cTAKES server"""
 
 import hashlib
+import os
 
 import ctakesclient
 
@@ -21,6 +22,7 @@ def extract(cache: store.Root, sentence: str) -> ctakesclient.typesystem.CtakesJ
         result = ctakesclient.typesystem.CtakesJSON(source=cached_response)
     except Exception:  # pylint: disable=broad-except
         result = ctakesclient.client.extract(sentence)
+        cache.makedirs(os.path.dirname(full_path))
         common.write_json(full_path, result.as_json())
 
     return result

--- a/test/test_etl.py
+++ b/test/test_etl.py
@@ -243,9 +243,11 @@ class TestI2b2EtlOnS3(S3Mixin, BaseI2b2EtlSimple):
     """Test case for our support of writing to S3"""
 
     def test_etl_job_s3(self):
+        fs = s3fs.S3FileSystem()
+        fs.makedirs('s3://mockbucket/')
+
         etl.main(['--input-format=i2b2', self.input_path, 's3://mockbucket/root', self.phi_path])
 
-        fs = s3fs.S3FileSystem()
         all_files = {x for x in fs.find('mockbucket/root') if '/JobConfig/' not in x}
         self.assertEqual({
             'mockbucket/root/condition/fhir_conditions.000.ndjson',
@@ -292,7 +294,9 @@ class TestI2b2EtlCachedCtakes(BaseI2b2EtlSimple):
 
         for index, checksum in enumerate(expected_checksums):
             # Write out some fake results to the cache location
-            common.write_json(self.path_for_checksum(checksum), {
+            filename = self.path_for_checksum(checksum)
+            os.makedirs(os.path.dirname(filename))
+            common.write_json(filename, {
                 'SignSymptomMention': [
                     {
                         'begin': 123,


### PR DESCRIPTION
- Avoid using fsspec in a way that would result in CreateBucket calls.
- Allow specifying an S3 region (doesn't seem to be pulled from environment or config file for us)