### PR TITLE
codebook: also ignore PermissionError when reading codebook

### DIFF
--- a/cumulus/codebook.py
+++ b/cumulus/codebook.py
@@ -24,7 +24,7 @@ class Codebook:
         """
         try:
             self.db = CodebookDB(saved)
-        except FileNotFoundError:
+        except (FileNotFoundError, PermissionError):
             self.db = CodebookDB()
 
         self.docrefs = {}


### PR DESCRIPTION
It can be raised if the file doesn't exist but you don't have ListBucket permission on S3.