### PR TITLE
Add a Dockerfile and wait for cTAKES on startup

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,11 @@
+# syntax=docker/dockerfile:1
+
+FROM python:3.10-slim
+WORKDIR /app
+
+COPY . .
+RUN pip3 install .
+
+RUN rm -r /app
+
+ENTRYPOINT ["cumulus-etl"]


### PR DESCRIPTION
This adds a toplevel Dockerfile to build a tiny little docker image for cumulus. That will eventually help with deployments.

And also wait on the cTAKES port to be available on startup, which also helps reduce some deployment scripting and prints a nice error message for the user if a cTAKES server isn't running.