### PR TITLE
fix: handle Synthea style references when unref'ing

### DIFF
--- a/test/test_config.py
+++ b/test/test_config.py
@@ -8,7 +8,7 @@ import freezegun
 from cumulus import config
 
 
-class TestI2b2ConfigSummary(unittest.TestCase):
+class TestConfigSummary(unittest.TestCase):
     """Test case for JobSummary"""
 
     @freezegun.freeze_time('Sep 15th, 2021 1:23:45')

--- a/test/test_fhir_common.py
+++ b/test/test_fhir_common.py
@@ -1,0 +1,47 @@
+"""Tests for fhir_common.py"""
+
+import ddt
+import unittest
+
+from fhirclient.models.fhirreference import FHIRReference
+
+from cumulus import fhir_common
+
+
+@ddt.ddt
+class TestReferenceHandlers(unittest.TestCase):
+    """Tests for the unref_ and ref_ methods"""
+
+    @ddt.data(
+        ({'reference': 'Patient/123'}, 'Patient', '123'),
+        ({'reference': '123', 'type': 'Patient'}, 'Patient', '123'),
+        # Synthea style reference
+        ({'reference': 'Patient?identifier=http://example.com|123'}, 'Patient', 'identifier=http://example.com|123'),
+    )
+    @ddt.unpack
+    def test_unref_successes(self, full_reference, expected_type, expected_id):
+        fhir_reference = FHIRReference(full_reference)
+        parsed = fhir_common.unref_resource(fhir_reference)
+        self.assertEqual((expected_type, expected_id), parsed)
+
+    @ddt.data(
+        None,
+        '',
+        '#Contained/123',
+        '123',  # with no type field
+        '?/123',
+        'http://example.com/Patient/123',
+    )
+    def test_unref_failures(self, reference):
+        fhir_reference = FHIRReference({'reference': reference})
+        with self.assertRaises(ValueError):
+            fhir_common.unref_resource(fhir_reference)
+
+    def test_ref_resource(self):
+        self.assertEqual({'reference': 'Patient/123'}, fhir_common.ref_resource('Patient', '123').as_json())
+
+    def test_ref_subject(self):
+        self.assertEqual({'reference': 'Patient/123'}, fhir_common.ref_subject('123').as_json())
+
+    def test_ref_encounter(self):
+        self.assertEqual({'reference': 'Encounter/123'}, fhir_common.ref_encounter('123').as_json())


### PR DESCRIPTION
We were refusing to parse a reference like the following: `Practitioner?identifier=http://example.org|123`

Which is what Synthea might generate. But since that's easy enough to parse, unref_reference will now treat that as two parts:

- type: `Practitioner`
- id: `identifier=http://example.org|123`

I felt like trying to parse down the id further was more complication than it's worth, and if anything on the right side of the question mark changes, we probably want to treat it as a separate id anyway.

And add some tests around this.