### PR TITLE
Support bulk exports from FHIR servers

### DIFF
--- a/cumulus/etl.py
+++ b/cumulus/etl.py
@@ -341,6 +341,9 @@ def main(args: List[str]):
     parser.add_argument('--comment', help='add the comment to the log file')
     parser.add_argument('--s3-region', help='if using S3 paths (s3://...), this is their region')
     parser.add_argument('--s3-kms-key', help='if using S3 paths (s3://...), this is the KMS key ID to use')
+    parser.add_argument('--smart-client-id', metavar='CLIENT_ID', help='Client ID registered with SMART FHIR server '
+                                                                       '(can be a filename with ID inside it')
+    parser.add_argument('--smart-jwks', metavar='/path/to/jwks', help='JWKS file registered with SMART FHIR server')
     parser.add_argument('--skip-init-checks', action='store_true', help=argparse.SUPPRESS)
     args = parser.parse_args(args)
 
@@ -361,7 +364,7 @@ def main(args: List[str]):
     if args.input_format == 'i2b2':
         config_loader = loaders.I2b2Loader(root_input)
     else:
-        config_loader = loaders.FhirNdjsonLoader(root_input)
+        config_loader = loaders.FhirNdjsonLoader(root_input, client_id=args.smart_client_id, jwks=args.smart_jwks)
 
     if args.output_format == 'json':
         config_store = formats.JsonTreeFormat(root_output)

--- a/cumulus/loaders/fhir/backend_service.py
+++ b/cumulus/loaders/fhir/backend_service.py
@@ -1,0 +1,218 @@
+"""Support for SMART App Launch Backend Services"""
+
+import re
+import time
+import urllib.parse
+import uuid
+from json import JSONDecodeError
+from typing import List
+
+import requests
+from fhirclient.client import FHIRClient
+from jwcrypto import jwk, jwt
+
+
+class FatalError(Exception):
+    """An unrecoverable error"""
+
+
+class BackendServiceServer:
+    """
+    Manages authentication and requests for a server that supports the Backend Service SMART profile.
+
+    See https://hl7.org/fhir/smart-app-launch/backend-services.html for details.
+    """
+    def __init__(self, url: str, client_id: str, jwks: dict, resources: List[str]):
+        """
+        Initialize and authorize a BackendServiceServer instance.
+
+        :param url: base URL of the SMART FHIR server
+        :param client_id: the ID assigned by the FHIR server when registering a new backend service app
+        :param jwks: content of a JWK Set file, containing the private key for the registered public key
+        :param resources: a list of FHIR resource names to tightly scope our own permissions
+        """
+        super().__init__()
+        self._base_url = url  # all requests are relative to this URL
+        if not self._base_url.endswith('/'):
+            self._base_url += '/'
+        # The base URL may not be the server root (like it may be a Group export URL). Let's find the root.
+        self._server_root = self._base_url
+        self._server_root = re.sub(r'/Patient/$', '/', self._server_root)
+        self._server_root = re.sub(r'/Group/[^/]+/$', '/', self._server_root)
+        self._client_id = client_id
+        self._jwks = jwks
+        self._resources = list(resources)
+        self._server = None
+        self._token_endpoint = self._get_token_endpoint()
+        self._authorize()
+
+    def request(self, method: str, path: str, headers: dict = None, stream: bool = False) -> requests.Response:
+        """
+        Issues an HTTP request.
+
+        This is a lightly modified version of FHIRServer._get(), but additionally supports streaming and
+        reauthorization.
+
+        Will raise a FatalError for an HTTP error, except for 429 which gets returned like a success code.
+
+        :param method: HTTP method to issue
+        :param path: relative path from the server root to request
+        :param headers: optional header dictionary
+        :param stream: whether to stream content in or load it all into memory at once
+        :returns: The response object
+        """
+        url = urllib.parse.urljoin(self._base_url, path)
+
+        final_headers = {
+            'Accept': 'application/fhir+json',
+            'Accept-Charset': 'UTF-8',
+        }
+        # merge in user headers with defaults
+        final_headers.update(headers or {})
+
+        response = self._request_with_signed_headers(method, url, final_headers, stream=stream)
+
+        # Check if our access token expired and thus needs to be refreshed
+        if response.status_code == 401:
+            if not self._server.reauthorize():
+                # We must not have been issued a refresh token, let's just authorize from scratch
+                self._authorize()
+            response = self._request_with_signed_headers(method, url, final_headers, stream=stream)
+
+        try:
+            response.raise_for_status()
+        except requests.exceptions.HTTPError as exc:
+            if exc.response.status_code == 429:
+                # 429 is a special kind of error -- it's not fatal, just a request to wait a bit. So let it pass.
+                return exc.response
+
+            # All other 4xx or 5xx codes are treated as fatal errors
+            message = None
+            try:
+                json_response = exc.response.json()
+                if json_response.get('resourceType') == 'OperationOutcome':
+                    issue = json_response['issue'][0]  # just grab first issue
+                    message = issue.get('details', {}).get('text')
+                    message = message or issue.get('diagnostics')
+            except JSONDecodeError:
+                message = exc.response.text
+            if not message:
+                message = str(exc)
+
+            raise FatalError(f'An error occurred when connecting to "{url}": {message}') from exc
+
+        return response
+
+    ###################################################################################################################
+    #
+    # Helpers
+    #
+    ###################################################################################################################
+
+    def _authorize(self) -> None:
+        """
+        Authenticates against a SMART FHIR server using the Backend Services profile.
+
+        See https://hl7.org/fhir/smart-app-launch/backend-services.html for details.
+        """
+        signed_jwt = self._make_signed_jwt()
+        scope = ' '.join([f'system/{resource}.read' for resource in self._resources])
+        client = FHIRClient(settings={
+            'api_base': self._server_root,
+            'app_id': self._client_id,
+            'jwt_token': signed_jwt,
+            'scope': scope,
+        })
+        client.wants_patient = False
+        client.prepare()
+
+        try:
+            client.authorize()
+        except Exception as exc:  # pylint: disable=broad-except
+            # This handles both the normal HTTPError and the custom errors that fhirclient uses
+            message = None
+            if hasattr(exc, 'response') and exc.response:
+                response_json = exc.response.json()
+                message = response_json.get('error_description')  # oauth2 error field
+            if not message:
+                message = str(exc)
+
+            raise FatalError(f'Could not authenticate with the FHIR server: {message}') from exc
+
+        self._server = client.server
+
+    def _request_with_signed_headers(self, method: str, url: str, headers: dict = None, **kwargs) -> requests.Response:
+        """
+        Issues a GET request and sign the headers with the current access token.
+
+        :param method: HTTP method to issue
+        :param url: full server url to request
+        :param headers: header dictionary
+        :returns: The response object
+        """
+        headers = self._server.auth.signed_headers(headers)
+        return self._server.session.request(method, url, headers=headers, **kwargs)
+
+    def _get_token_endpoint(self) -> str:
+        """
+        Returns the oauth2 token endpoint for a SMART FHIR server.
+
+        See https://hl7.org/fhir/smart-app-launch/client-confidential-asymmetric.html for details.
+
+        If the server does not support the client-confidential-asymmetric protocol, an exception will be raised.
+
+        :returns: URL for the server's oauth2 token endpoint
+        """
+        response = requests.get(
+            urllib.parse.urljoin(self._server_root, '.well-known/smart-configuration'),
+            headers={
+                'Accept': 'application/json',
+            },
+            timeout=300,  # five minutes
+        )
+        response.raise_for_status()
+
+        # Validate that the server can talk the client-confidential-asymmetric protocol with us.
+        # Some servers (like Cerner) don't advertise their support with the 'client-confidential-asymmetric'
+        # capability keyword, so let's not bother checking for it. But we can confirm that the pieces are there.
+        config = response.json()
+        if (
+                'private_key_jwt' not in config.get('token_endpoint_auth_methods_supported', []) or
+                not {'ES384', 'RS384'} & set(config.get('token_endpoint_auth_signing_alg_values_supported', [])) or
+                not config.get('token_endpoint')
+        ):
+            raise FatalError(f'Server {self._server_root} does not support the client-confidential-asymmetric protocol')
+
+        return config['token_endpoint']
+
+    def _make_signed_jwt(self) -> str:
+        """
+        Creates a signed JWT for use in the client-confidential-asymmetric protocol.
+
+        See https://hl7.org/fhir/smart-app-launch/client-confidential-asymmetric.html for details.
+
+        :returns: a signed JWT string, ready for authentication with the FHIR server
+        """
+        # Find a usable singing JWK from JWKS
+        for key in self._jwks.get('keys', []):
+            if key.get('alg') in ['ES384', 'RS384'] and 'sign' in key.get('key_ops', []) and key.get('kid'):
+                break
+        else:  # no valid private JWK found
+            raise FatalError('No private ES384 or RS384 key found in the provided JWKS file.')
+
+        # Now generate a signed JWT based off the given JWK
+        header = {
+            'alg': key['alg'],
+            'kid': key['kid'],
+            'typ': 'JWT',
+        }
+        claims = {
+            'iss': self._client_id,
+            'sub': self._client_id,
+            'aud': self._token_endpoint,
+            'exp': int(time.time()) + 299,  # expires inside five minutes
+            'jti': str(uuid.uuid4()),
+        }
+        token = jwt.JWT(header=header, claims=claims)
+        token.make_signed_token(key=jwk.JWK(**key))
+        return token.serialize()

--- a/cumulus/loaders/fhir/bulk_export.py
+++ b/cumulus/loaders/fhir/bulk_export.py
@@ -1,0 +1,166 @@
+"""Support for FHIR bulk exports"""
+
+import os
+import time
+from typing import List
+
+import requests
+
+from cumulus import common
+from cumulus.loaders.fhir.backend_service import BackendServiceServer, FatalError
+
+
+class BulkExporter:
+    """
+    Perform a bulk export from a FHIR server that supports the Backend Service SMART profile.
+
+    This has been manually tested against:
+    - The bulk-data-server test server (https://github.com/smart-on-fhir/bulk-data-server)
+    - Cerner Millennium (https://www.cerner.com/)
+    """
+
+    _TIMEOUT_THRESHOLD = 60 * 60 * 24  # a day, which is probably an overly generous timeout
+
+    def __init__(self, server: BackendServiceServer, resources: List[str], destination: str):
+        """
+        Initialize a bulk exporter (but does not start an export).
+
+        :param server: a server instance ready to make requests
+        :param resources: a list of resource names to export
+        :param destination: a local folder to store all the files
+        """
+        super().__init__()
+        self._server = server
+        self._resources = resources
+        self._destination = destination
+        self._total_wait_time = 0  # in seconds, across all our requests
+
+    def export(self) -> None:
+        """
+        Bulk export resources from a FHIR server into local ndjson files.
+
+        This call will block for a while, as resources tend to be large, and we may also have to wait if the server is
+        busy. Because it is a slow operation, this function will also print status updates to the console.
+
+        After this completes, the destination folder will be full of files that look like Resource.000.ndjson, like so:
+
+        destination/
+          Encounter.000.ndjson
+          Encounter.001.ndjson
+          Patient.000.ndjson
+
+        See http://hl7.org/fhir/uv/bulkdata/export/index.html for details.
+        """
+        # Initiate bulk export
+        common.print_header('Starting bulk FHIR export...')
+        # Use a crazy old _since value because we want *everything* and some EHRs will assume a value if absent.
+        # (e.g. Smile will default 24h.)
+        response = self._request_with_delay(f'$export?_type={",".join(self._resources)}&_since=1800-01-01T00:00:00Z',
+                                            headers={'Prefer': 'respond-async'},
+                                            target_status_code=202)
+
+        # Grab the poll location URL for status updates
+        poll_location = response.headers['Content-Location']
+
+        try:
+            # Request status report, until export is done
+            response = self._request_with_delay(poll_location, headers={'Accept': 'application/json'})
+
+            # Finished! We're done waiting and can download all the files
+            response_json = response.json()
+
+            # Were there any server-side errors during the export?
+            errors = response_json.get('error', [])
+            if errors:
+                message = 'Errors occurred during export:'
+                for error in errors:
+                    if error.get('type') == 'OperationOutcome':  # per spec as of writing, the only allowed type
+                        outcome = self._request_with_delay(error['url']).json()
+                        message += f"\n - {outcome['issue'][0]['diagnostics']}"
+                raise FatalError(message)
+
+            # Download all the files
+            print('Bulk FHIR export finished, now downloading resources...')
+            files = response_json.get('output', [])
+            self._download_all_ndjson_files(files)
+        finally:
+            self._delete_export(poll_location)
+
+    ###################################################################################################################
+    #
+    # Helpers
+    #
+    ###################################################################################################################
+
+    def _delete_export(self, poll_url: str) -> None:
+        """As a kindness, send a DELETE to the polling location. Then the server knows it can delete the files."""
+        try:
+            self._request_with_delay(poll_url, method='DELETE', target_status_code=202)
+        except FatalError:
+            # Ignore any fatal issue with this, since we don't actually need this to succeed
+            pass
+
+    def _request_with_delay(self, path: str, headers: dict = None, target_status_code: int = 200,
+                            method: str = 'GET') -> requests.Response:
+        """
+        Requests a file, while respecting any requests to wait longer.
+
+        :param path: path to request
+        :param headers: headers for request
+        :param target_status_code: retries until this status code is returned
+        :param method: HTTP method to request
+        :returns: the HTTP response
+        """
+        while self._total_wait_time < self._TIMEOUT_THRESHOLD:
+            response = self._server.request(method, path, headers=headers)
+
+            if response.status_code == target_status_code:
+                return response
+
+            # 202 == server is still working on it, 429 == server is busy -- in both cases, we wait
+            if response.status_code in [202, 429]:
+                # Print a message to the user, so they don't see us do nothing for a while
+                print(f'  {response.headers.get("X-Progress", "waiting...")} ({self._total_wait_time}s so far)')
+
+                # And wait as long as the server requests
+                delay = int(response.headers.get('Retry-After', 60))
+                time.sleep(delay)
+                self._total_wait_time += delay
+
+            else:
+                # It feels silly to abort on an unknown *success* code, but the spec has such clear guidance on
+                # what the expected response codes are, that it's not clear if a code outside those parameters means
+                # we should keep waiting or stop waiting. So let's be strict here for now.
+                raise FatalError(f'Unexpected status code {response.status_code} from the bulk FHIR export server.')
+
+        raise FatalError('Timed out waiting for the bulk FHIR export to finish.')
+
+    def _download_all_ndjson_files(self, files: List[dict]) -> None:
+        """
+        Downloads all exported ndjson files from the bulk export server.
+
+        :param files: info about each file from the bulk FHIR server
+        """
+        resource_counts = {}  # how many of each resource we've seen
+        for file in files:
+            count = resource_counts.get(file['type'], -1) + 1
+            resource_counts[file['type']] = count
+            filename = f'{file["type"]}.{count:03}.ndjson'
+            self._download_ndjson_file(file['url'], os.path.join(self._destination, filename))
+            print(f'  Downloaded {filename}')
+
+    def _download_ndjson_file(self, url: str, filename: str) -> None:
+        """
+        Downloads a single ndjson file from the bulk export server.
+
+        :param url: URL location of file to download
+        :param filename: local path to write data to
+        """
+        response = self._server.request('GET', url, headers={'Accept': 'application/fhir+ndjson'}, stream=True)
+        with open(filename, 'w', encoding='utf8') as file:
+            # Make sure iter_content() returns a string (rather than bytes) by enforcing an encoding
+            response.encoding = response.encoding or 'utf8'
+
+            # Now actually iterate over the stream and write straight to disk
+            for block in response.iter_content(chunk_size=None, decode_unicode=True):
+                file.write(block)

--- a/cumulus/loaders/fhir/fhir_ndjson.py
+++ b/cumulus/loaders/fhir/fhir_ndjson.py
@@ -1,19 +1,39 @@
 """Ndjson FHIR loader"""
 
+import sys
 import tempfile
 
+from cumulus import common, store
 from cumulus.loaders import base
+from cumulus.loaders.fhir.backend_service import BackendServiceServer, FatalError
+from cumulus.loaders.fhir.bulk_export import BulkExporter
 
 
 class FhirNdjsonLoader(base.Loader):
     """
-    Loader for fhir ndjson data.
+    Loader for fhir ndjson data, either locally or from a FHIR server.
 
     Expected local-folder format is a folder with ndjson files labeled by resource type.
     (i.e. Condition.000.ndjson or Condition.ndjson)
     """
 
+    def __init__(self, root: store.Root, client_id: str = None, jwks: str = None):
+        """
+        :param root: location to load ndjson from
+        :param jwks: path to a JWKS file, used if root points at a FHIR server
+        """
+        super().__init__(root)
+        try:
+            self.client_id = common.read_text(client_id).strip() if client_id else None
+        except FileNotFoundError:
+            self.client_id = client_id
+        self.jwks = common.read_json(jwks) if jwks else None
+
     def load_all(self) -> tempfile.TemporaryDirectory:
+        # Are we doing a bulk FHIR export from a server?
+        if self.root.protocol in ['http', 'https']:
+            return self._load_from_bulk_export()
+
         # Are we reading from a local directory?
         if self.root.protocol == 'file':
             # We can actually just re-use the input dir without copying the files, since everything is local.
@@ -24,4 +44,35 @@ class FhirNdjsonLoader(base.Loader):
         # Fall back to copying from a remote directory (like S3 buckets) to a local one
         tmpdir = tempfile.TemporaryDirectory()  # pylint: disable=consider-using-with
         self.root.get(self.root.joinpath('*.ndjson'), f'{tmpdir.name}/')
+        return tmpdir
+
+    def _load_from_bulk_export(self) -> tempfile.TemporaryDirectory:
+        # First, check that the extra arguments we need were provided
+        errors = []
+        if not self.client_id:
+            errors.append('You must provide a client ID with --smart-client-id to connect to a SMART FHIR server.')
+        if not self.jwks:
+            errors.append('You must provide a JWKS file with --smart-jwks to connect to a SMART FHIR server.')
+        if errors:
+            print('\n'.join(errors), file=sys.stderr)
+            raise SystemExit(1)
+
+        tmpdir = tempfile.TemporaryDirectory()  # pylint: disable=consider-using-with
+
+        resources = [
+            'Condition',
+            'DocumentReference',
+            'Encounter',
+            'Observation',
+            'Patient',
+        ]
+
+        try:
+            server = BackendServiceServer(self.root.path, self.client_id, self.jwks, resources)
+            bulk_exporter = BulkExporter(server, resources, tmpdir.name)
+            bulk_exporter.export()
+        except FatalError as exc:
+            print(str(exc), file=sys.stderr)
+            raise SystemExit(2) from exc  # just to differentiate from the 1 system exit above in tests
+
         return tmpdir

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,9 @@ requires-python = ">= 3.7"
 dependencies = [
     "ctakesclient >= 1.3",
     "cx-oracle",
-    "fhirclient",
+    # This branch includes some jwt fixes we need (and will hopefully be in mainline in future)
+    "fhirclient @ git+https://github.com/mikix/client-py.git@mikix/oauth2-jwt",
+    "jwcrypto",
     "pandas",
     "pyarrow",
     "s3fs",
@@ -48,4 +50,6 @@ tests = [
     "freezegun",
     "moto[s3]",
     "pytest",
+    "responses",
+    "urllib3",
 ]

--- a/test/test_bulk_export.py
+++ b/test/test_bulk_export.py
@@ -1,0 +1,629 @@
+"""Tests for bulk export support"""
+
+import os
+import tempfile
+import time
+import unittest
+from io import BytesIO
+from json import dumps
+from unittest import mock
+
+import ddt
+import freezegun
+import responses
+from jwcrypto import jwk, jwt
+from requests.adapters import HTTPAdapter
+from responses import matchers
+from urllib3 import HTTPResponse
+
+from cumulus import common, etl, loaders, store
+from cumulus.loaders.fhir.backend_service import BackendServiceServer, FatalError
+from cumulus.loaders.fhir.bulk_export import BulkExporter
+
+
+def make_response(status_code=200, json=None, text=None, reason=None, headers=None):
+    """Makes a fake response for ease of testing"""
+    headers = dict(headers or {})
+    headers.setdefault('Content-Type', 'application/json' if json else 'text/plain; charset=utf-8')
+    json = dumps(json) if json else None
+    body = (json or text or '').encode('utf8')
+    http_response = HTTPResponse(
+        status=status_code,
+        body=BytesIO(body),
+        reason=reason,
+        headers=headers or {},
+    )
+    response = HTTPAdapter().build_response(mock.MagicMock(url='fake_request_url'), http_response)
+    response.raw = BytesIO(body)
+    return response
+
+
+class TestBulkLoader(unittest.TestCase):
+    """
+    Test case for bulk export support in the etl pipeline and ndjson loader.
+
+    i.e. tests for fhir_ndjson.py
+
+    This does no actual bulk loading.
+    """
+
+    def setUp(self):
+        super().setUp()
+        self.root = store.Root('http://localhost:9999')
+
+        self.jwks_file = tempfile.NamedTemporaryFile()  # pylint: disable=consider-using-with
+        self.jwks_path = self.jwks_file.name
+        self.jwks_file.write(b'{"fake":"jwks"}')
+        self.jwks_file.flush()
+
+        # Mock out the backend service and bulk export code by default. We don't care about actually doing any
+        # bulk work in this test case, just confirming the flow.
+
+        server_patcher = mock.patch('cumulus.loaders.fhir.fhir_ndjson.BackendServiceServer')
+        self.addCleanup(server_patcher.stop)
+        self.mock_server = server_patcher.start()
+
+        exporter_patcher = mock.patch('cumulus.loaders.fhir.fhir_ndjson.BulkExporter')
+        self.addCleanup(exporter_patcher.stop)
+        self.mock_exporter = exporter_patcher.start()
+
+    @mock.patch('cumulus.etl.loaders.FhirNdjsonLoader')
+    def test_etl_passes_args(self, mock_loader):
+        """Verify that we are passed the client ID and JWKS from the command line"""
+        mock_loader.side_effect = ValueError  # just to stop the etl pipeline once we get this far
+
+        with self.assertRaises(ValueError):
+            etl.main(['http://localhost:9999', '/tmp/output', '/tmp/phi', '--skip-init-checks', '--input-format=ndjson',
+                      '--smart-client-id=x', '--smart-jwks=y'])
+
+        self.assertEqual(1, mock_loader.call_count)
+        self.assertEqual('x', mock_loader.call_args[1]['client_id'])
+        self.assertEqual('y', mock_loader.call_args[1]['jwks'])
+
+    def test_required_arguments(self):
+        """Verify that we require both a client ID and a JWK Set"""
+        # No SMART args at all
+        with self.assertRaises(SystemExit):
+            loaders.FhirNdjsonLoader(self.root).load_all()
+
+        # No JWKS
+        with self.assertRaises(SystemExit):
+            loaders.FhirNdjsonLoader(self.root, client_id='foo').load_all()
+
+        # No client ID
+        with self.assertRaises(SystemExit):
+            loaders.FhirNdjsonLoader(self.root, jwks=self.jwks_path).load_all()
+
+        # Works fine if both given
+        loaders.FhirNdjsonLoader(self.root, client_id='foo', jwks=self.jwks_path).load_all()
+
+    def test_reads_client_id_from_file(self):
+        """Verify that we require both a client ID and a JWK Set."""
+        # First, confirm string is used directly if file doesn't exist
+        loader = loaders.FhirNdjsonLoader(self.root, client_id='/direct-string')
+        self.assertEqual('/direct-string', loader.client_id)
+
+        # Now read from a file that exists
+        with tempfile.NamedTemporaryFile() as file:
+            file.write(b'\ninside-file\n')
+            file.flush()
+            loader = loaders.FhirNdjsonLoader(self.root, client_id=file.name)
+            self.assertEqual('inside-file', loader.client_id)
+
+    def test_export_flow(self):
+        """
+        Verify that we make all the right calls into the bulk export helper classes.
+
+        This is a little lower-level than I would normally test, but the benefit of ensuring this flow here is that
+        the other test cases can focus on just the helper classes and trust that the flow works, without us needing to
+        do the full flow each time.
+        """
+        mock_server_instance = mock.MagicMock()
+        self.mock_server.return_value = mock_server_instance
+        mock_exporter_instance = mock.MagicMock()
+        self.mock_exporter.return_value = mock_exporter_instance
+
+        loaders.FhirNdjsonLoader(self.root, client_id='foo', jwks=self.jwks_path).load_all()
+
+        expected_resources = [
+            'Condition',
+            'DocumentReference',
+            'Encounter',
+            'Observation',
+            'Patient',
+        ]
+
+        self.assertEqual(1, self.mock_server.call_count)
+        self.assertEqual(((self.root.path, 'foo', {'fake': 'jwks'}, expected_resources), ), self.mock_server.call_args)
+
+        self.assertEqual(1, self.mock_exporter.call_count)
+        self.assertEqual(mock_server_instance, self.mock_exporter.call_args[0][0])
+        self.assertEqual(expected_resources, self.mock_exporter.call_args[0][1])
+
+        self.assertEqual(1, mock_exporter_instance.export.call_count)
+
+    def test_fatal_errors_are_fatal(self):
+        """Verify that when a FatalError is raised, we do really quit"""
+        self.mock_server.side_effect = FatalError
+
+        with self.assertRaises(SystemExit) as cm:
+            loaders.FhirNdjsonLoader(self.root, client_id='foo', jwks=self.jwks_path).load_all()
+
+        self.assertEqual(1, self.mock_server.call_count)
+        self.assertEqual(2, cm.exception.code)
+
+
+@ddt.ddt
+@freezegun.freeze_time('Sep 15th, 2021 1:23:45')
+@mock.patch('cumulus.loaders.fhir.backend_service.uuid.uuid4', new=lambda: '1234')
+class TestBulkServer(unittest.TestCase):
+    """
+    Test case for bulk export server oauth2 / request support.
+
+    i.e. tests for backend_service.py
+    """
+
+    def setUp(self):
+        super().setUp()
+
+        # By default, set up a working server and auth. Tests can break things as needed.
+
+        self.client_id = 'my-client-id'
+        self.jwk = jwk.JWK.generate(kty='RSA', alg='RS384', kid='a', key_ops=['sign', 'verify']).export(as_dict=True)
+        self.jwks = {'keys': [self.jwk]}
+        self.server_url = 'https://example.com/fhir'
+        self.token_url = 'https://auth.example.com/token'
+
+        # Generate expected JWT
+        token = jwt.JWT(
+            header={
+                'alg': 'RS384',
+                'kid': 'a',
+                'typ': 'JWT',
+            },
+            claims={
+                'iss': self.client_id,
+                'sub': self.client_id,
+                'aud': self.token_url,
+                'exp': int(time.time()) + 299,  # aided by freezegun not changing time under us
+                'jti': '1234',
+            },
+        )
+        token.make_signed_token(key=jwk.JWK(**self.jwk))
+        self.expected_jwt = token.serialize()
+
+        # Initialize responses mock
+        self.responses = responses.RequestsMock(assert_all_requests_are_fired=False)
+        self.addCleanup(self.responses.stop)
+        self.responses.start()
+
+        # We ask for smart-configuration to discover the token endpoint
+        self.smart_configuration = {
+            'capabilities': ['client-confidential-asymmetric'],
+            'token_endpoint': self.token_url,
+            'token_endpoint_auth_methods_supported': ['private_key_jwt'],
+            'token_endpoint_auth_signing_alg_values_supported': ['RS384'],
+        }
+        self.responses.get(
+            f'{self.server_url}/.well-known/smart-configuration',
+            match=[matchers.header_matcher({'Accept': 'application/json'})],
+            json=self.smart_configuration,
+        )
+
+        # Set up mocks for fhirclient (we don't need to test its oauth code by mocking server responses there)
+        self.mock_client = mock.MagicMock()  # FHIRClient instance
+        self.mock_server = self.mock_client.server  # FHIRServer instance
+        client_patcher = mock.patch('cumulus.loaders.fhir.backend_service.FHIRClient')
+        self.addCleanup(client_patcher.stop)
+        self.mock_client_class = client_patcher.start()  # FHIRClient class
+        self.mock_client_class.return_value = self.mock_client
+
+    def test_auth_initial_authorize(self):
+        """Verify that we authorize correctly upon class initialization"""
+        BackendServiceServer(self.server_url, self.client_id, self.jwks, ['Condition', 'Patient'])
+
+        # Check initialization of FHIRClient
+        self.assertListEqual([mock.call(settings={
+            'api_base': f'{self.server_url}/',
+            'app_id': self.client_id,
+            'jwt_token': self.expected_jwt,
+            'scope': 'system/Condition.read system/Patient.read',
+        })], self.mock_client_class.call_args_list)
+
+        # Check authorization calls to FHIRClient
+        self.assertFalse(self.mock_client.wants_patient)  # otherwise fhirclient adds scopes
+        self.assertListEqual([mock.call()], self.mock_client.prepare.call_args_list)
+        self.assertListEqual([mock.call()], self.mock_client.authorize.call_args_list)
+
+    def test_get_with_new_header(self):
+        """Verify that we issue a GET correctly for the happy path"""
+        server = BackendServiceServer(self.server_url, self.client_id, self.jwks, [])
+
+        # This is mostly confirming that we call mocks correctly, but that's important since we're mocking out all
+        # of fhirclient. Since we do that, we need to confirm we're driving it well.
+
+        # With new header and stream
+        server.request('GET', 'foo', headers={'Test': 'Value'}, stream=True)
+        self.assertEqual([mock.call({
+            'Accept': 'application/fhir+json',
+            'Accept-Charset': 'UTF-8',
+            'Test': 'Value',
+        })], self.mock_server.auth.signed_headers.call_args_list)
+        self.assertEqual([mock.call(
+            'GET',
+            f'{self.server_url}/foo',
+            headers=self.mock_server.auth.signed_headers.return_value,
+            stream=True,
+        )], self.mock_server.session.request.call_args_list)
+
+    def test_get_with_overriden_header(self):
+        """Verify that we issue a GET correctly for the happy path"""
+        server = BackendServiceServer(self.server_url, self.client_id, self.jwks, [])
+
+        # With overriding a header and default stream (False)
+        server.request('GET', 'bar', headers={'Accept': 'text/plain'})
+        self.assertEqual([mock.call({
+            'Accept': 'text/plain',
+            'Accept-Charset': 'UTF-8',
+        })], self.mock_server.auth.signed_headers.call_args_list)
+        self.assertEqual([mock.call(
+            'GET',
+            f'{self.server_url}/bar',
+            headers=self.mock_server.auth.signed_headers.return_value,
+            stream=False,
+        )], self.mock_server.session.request.call_args_list)
+
+    @ddt.data(
+        {},  # no keys
+        {'keys': [{'alg': 'RS384'}]},  # no key op
+        {'keys': [{'alg': 'RS384', 'key_ops': ['verify'], 'kid': 'a'}]},  # bad key op
+        {'keys': [{'alg': 'RS128', 'key_ops': ['sign']}], 'kid': 'a'},  # bad algo
+        {'keys': [{'alg': 'RS384', 'key_ops': ['sign']}]},  # no kid
+    )
+    def test_jwks_without_suitable_key(self, bad_jwks):
+        with self.assertRaisesRegex(FatalError, 'No private ES384 or RS384 key found'):
+            BackendServiceServer(self.server_url, self.client_id, bad_jwks, [])
+
+    @ddt.data(
+        {'token_endpoint_auth_methods_supported': None},
+        {'token_endpoint_auth_methods_supported': ['nope']},
+        {'token_endpoint_auth_signing_alg_values_supported': None},
+        {'token_endpoint_auth_signing_alg_values_supported': ['nope']},
+        {'token_endpoint': None},
+        {'token_endpoint': ''},
+    )
+    def test_bad_smart_config(self, bad_config_override):
+        """Verify that we require fully correct smart configurations."""
+        for entry, value in bad_config_override.items():
+            if value is None:
+                del self.smart_configuration[entry]
+            else:
+                self.smart_configuration[entry] = value
+
+        self.responses.reset()
+        self.responses.get(
+            f'{self.server_url}/.well-known/smart-configuration',
+            match=[matchers.header_matcher({'Accept': 'application/json'})],
+            json=self.smart_configuration,
+        )
+
+        with self.assertRaisesRegex(FatalError, 'does not support the client-confidential-asymmetric protocol'):
+            BackendServiceServer(self.server_url, self.client_id, self.jwks, [])
+
+    def test_authorize_error_with_response(self):
+        """Verify that we translate authorize http response errors into FatalErrors."""
+        error = Exception()
+        error.response = mock.MagicMock()
+        error.response.json.return_value = {'error_description': 'Ouch!'}
+        self.mock_client.authorize.side_effect = error
+        with self.assertRaisesRegex(FatalError, 'Could not authenticate with the FHIR server: Ouch!'):
+            BackendServiceServer(self.server_url, self.client_id, self.jwks, [])
+
+    def test_authorize_error_without_response(self):
+        """Verify that we translate authorize non-response errors into FatalErrors."""
+        self.mock_client.authorize.side_effect = Exception('no memory')
+        with self.assertRaisesRegex(FatalError, 'Could not authenticate with the FHIR server: no memory'):
+            BackendServiceServer(self.server_url, self.client_id, self.jwks, [])
+
+    def test_get_error_401(self):
+        """Verify that an expired token is refreshed."""
+        server = BackendServiceServer(self.server_url, self.client_id, self.jwks, [])
+
+        self.mock_server.session.request.side_effect = [make_response(status_code=401), make_response()]
+        self.mock_server.reauthorize.return_value = None  # fhirclient gives None if there is no refresh token
+
+        # Check that we correctly tried to re-authenticate
+        self.assertEqual(200, server.request('GET', 'foo').status_code)
+        self.assertEqual(1, self.mock_server.reauthorize.call_count)
+        self.assertEqual(2, self.mock_client_class.call_count)
+        self.assertEqual(2, self.mock_client.prepare.call_count)
+        self.assertEqual(2, self.mock_client.authorize.call_count)
+
+    def test_get_error_429(self):
+        """Verify that 429 errors are passed through and not treated as exceptions."""
+        server = BackendServiceServer(self.server_url, self.client_id, self.jwks, [])
+
+        # Confirm 429 passes
+        self.mock_server.session.request.return_value = make_response(status_code=429)
+        self.assertEqual(429, server.request('GET', 'foo').status_code)
+
+        # Sanity check that 430 does not
+        self.mock_server.session.request.return_value = make_response(status_code=430)
+        with self.assertRaises(FatalError):
+            server.request('GET', 'foo')
+
+    @ddt.data(
+        {'json': {'resourceType': 'OperationOutcome', 'issue': [{'diagnostics': 'testmsg'}]}},  # OperationOutcome
+        {'json': {'issue': [{'diagnostics': 'msg'}]}, 'reason': 'testmsg'},  # non-OperationOutcome json
+        {'text': 'testmsg'},  # just pure text content
+        {'reason': 'testmsg'},
+    )
+    def test_get_error_other(self, response_args):
+        """Verify that other http errors are FatalErrors."""
+        server = BackendServiceServer(self.server_url, self.client_id, self.jwks, [])
+
+        self.mock_server.session.request.return_value = make_response(status_code=500, **response_args)
+        with self.assertRaisesRegex(FatalError, 'testmsg'):
+            server.request('GET', 'foo')
+
+
+@ddt.ddt
+@freezegun.freeze_time('Sep 15th, 2021 1:23:45')
+class TestBulkExporter(unittest.TestCase):
+    """
+    Test case for bulk export logic.
+
+    i.e. tests for bulk_export.py
+    """
+
+    def setUp(self):
+        super().setUp()
+        self.tmpdir = tempfile.TemporaryDirectory()  # pylint: disable=consider-using-with
+        self.server = mock.MagicMock()
+        self.exporter = BulkExporter(self.server, ['Condition', 'Patient'], self.tmpdir.name)
+
+    def test_happy_path(self):
+        """Verify an end-to-end bulk export with no problems and no waiting works as expected"""
+        self.server.request.side_effect = [
+            make_response(status_code=202, headers={'Content-Location': 'https://example.com/poll'}),  # kickoff
+            make_response(json={'output': [
+                {'type': 'Condition', 'url': 'https://example.com/con1'},
+                {'type': 'Condition', 'url': 'https://example.com/con2'},
+                {'type': 'Patient', 'url': 'https://example.com/pat1'},
+            ]}),  # status
+            make_response(json={'type': 'Condition1'}),  # download
+            make_response(json={'type': 'Condition2'}),  # download
+            make_response(json={'type': 'Patient1'}),  # download
+            make_response(status_code=202),  # delete request
+        ]
+
+        self.exporter.export()
+
+        self.assertListEqual([
+            mock.call('GET', '$export?_type=Condition,Patient&_since=1800-01-01T00:00:00Z',
+                      headers={'Prefer': 'respond-async'}),
+            mock.call('GET', 'https://example.com/poll', headers={'Accept': 'application/json'}),
+            mock.call('GET', 'https://example.com/con1', headers={'Accept': 'application/fhir+ndjson'}, stream=True),
+            mock.call('GET', 'https://example.com/con2', headers={'Accept': 'application/fhir+ndjson'}, stream=True),
+            mock.call('GET', 'https://example.com/pat1', headers={'Accept': 'application/fhir+ndjson'}, stream=True),
+            mock.call('DELETE', 'https://example.com/poll', headers=None),
+        ], self.server.request.call_args_list)
+
+        self.assertEqual({'type': 'Condition1'}, common.read_json(f'{self.tmpdir.name}/Condition.000.ndjson'))
+        self.assertEqual({'type': 'Condition2'}, common.read_json(f'{self.tmpdir.name}/Condition.001.ndjson'))
+        self.assertEqual({'type': 'Patient1'}, common.read_json(f'{self.tmpdir.name}/Patient.000.ndjson'))
+
+    def test_export_error(self):
+        """Verify that we download and present any server-reported errors during the bulk export"""
+        self.server.request.side_effect = [
+            make_response(status_code=202, headers={'Content-Location': 'https://example.com/poll'}),  # kickoff
+            make_response(json={
+                'error': [
+                    {'type': 'OperationOutcome', 'url': 'https://example.com/err1'},
+                    {'type': 'OperationOutcome', 'url': 'https://example.com/err2'},
+                ],
+                'output': [  # include an output too, to confirm we don't bother trying to download it
+                    {'type': 'Condition', 'url': 'https://example.com/con1'},
+                ]
+            }),  # status
+            make_response(json={'type': 'OperationOutcome', 'issue': [{'diagnostics': 'errmsg1'}]}),  # error
+            make_response(json={'type': 'OperationOutcome', 'issue': [{'diagnostics': 'errmsg2'}]}),  # error
+            make_response(status_code=202),  # delete request
+        ]
+
+        with self.assertRaisesRegex(FatalError, 'Errors occurred during export:\n - errmsg1\n - errmsg2'):
+            self.exporter.export()
+
+        self.assertListEqual([
+            mock.call('GET', '$export?_type=Condition,Patient&_since=1800-01-01T00:00:00Z',
+                      headers={'Prefer': 'respond-async'}),
+            mock.call('GET', 'https://example.com/poll', headers={'Accept': 'application/json'}),
+            mock.call('GET', 'https://example.com/err1', headers=None),
+            mock.call('GET', 'https://example.com/err2', headers=None),
+            mock.call('DELETE', 'https://example.com/poll', headers=None),
+        ], self.server.request.call_args_list)
+
+    def test_unexpected_status_code(self):
+        """Verify that we bail if we see a successful code we don't understand"""
+        self.server.request.return_value = make_response(status_code=204)  # "no content"
+        with self.assertRaisesRegex(FatalError, 'Unexpected status code 204'):
+            self.exporter.export()
+
+    @mock.patch('cumulus.loaders.fhir.bulk_export.time.sleep')
+    def test_delay(self, mock_sleep):
+        """Verify that we wait the amount of time the server asks us to"""
+        self.server.request.side_effect = [
+            # Kicking off bulk export
+            make_response(status_code=429, headers={'Retry-After': '3600'}),  # one hour
+            make_response(status_code=202, headers={'Content-Location': 'https://example.com/poll'}),  # kickoff done
+            # Checking status of bulk export
+            make_response(status_code=429),  # default of one minute
+            make_response(status_code=202, headers={'Retry-After': '18000'}),  # five hours
+            make_response(status_code=429, headers={'Retry-After': '64800'}),  # 18 hours (putting us over a day)
+        ]
+
+        with self.assertRaisesRegex(FatalError, 'Timed out waiting'):
+            self.exporter.export()
+
+        # 86460 == 24 hours + one minute
+        self.assertEqual(86460, self.exporter._total_wait_time)  # pylint: disable=protected-access
+
+        self.assertListEqual([
+            mock.call(3600),
+            mock.call(60),
+            mock.call(18000),
+            mock.call(64800),
+        ], mock_sleep.call_args_list)
+
+    def test_delete_if_interrupted(self):
+        """Verify that we still delete the export on the server if we raise an exception during the middle of export"""
+        self.server.request.side_effect = [
+            make_response(status_code=202, headers={'Content-Location': 'https://example.com/poll'}),  # kickoff done
+            FatalError('Test Status Call Failed'),  # status error
+            make_response(status_code=501),  # also verify that an error during delete does not override the first
+        ]
+
+        with self.assertRaisesRegex(FatalError, 'Test Status Call Failed'):
+            self.exporter.export()
+
+        self.assertListEqual([
+            mock.call('GET', '$export?_type=Condition,Patient&_since=1800-01-01T00:00:00Z',
+                      headers={'Prefer': 'respond-async'}),
+            mock.call('GET', 'https://example.com/poll', headers={'Accept': 'application/json'}),
+            mock.call('DELETE', 'https://example.com/poll', headers=None),
+        ], self.server.request.call_args_list)
+
+
+class TestBulkExportEndToEnd(unittest.TestCase):
+    """
+    Test case for doing an entire bulk export loop, without mocking python code.
+
+    Server responses are mocked, but that's it. This is more of a functional test case than a unit test case.
+    """
+
+    def setUp(self) -> None:
+        super().setUp()
+
+        self.root = store.Root('http://localhost:9999/fhir')
+        self.client_id = 'test-client-id'
+
+        self.jwks_file = tempfile.NamedTemporaryFile()  # pylint: disable=consider-using-with
+        jwk_token = jwk.JWK.generate(kty='EC', alg='ES384', curve='P-384', kid='a',
+                                     key_ops=['sign', 'verify']).export(as_dict=True)
+        jwks = {'keys': [jwk_token]}
+        self.jwks_file.write(dumps(jwks).encode('utf8'))
+        self.jwks_file.flush()
+        self.jwks_path = self.jwks_file.name
+
+        # === Now set up requests ===
+
+        # /.well-known/smart-configuration
+        responses.get(
+            f'{self.root.path}/.well-known/smart-configuration',
+            match=[matchers.header_matcher({'Accept': 'application/json'})],
+            json={
+                'capabilities': ['client-confidential-asymmetric'],
+                'token_endpoint': f'{self.root.path}/token',
+                'token_endpoint_auth_methods_supported': ['private_key_jwt'],
+                'token_endpoint_auth_signing_alg_values_supported': ['ES384'],
+            },
+        )
+
+        # /metadata (most of this is just to pass validation -- this endpoint is just for fhirclient to get a token url)
+        responses.get(
+            f'{self.root.path}/metadata',
+            json={
+                'date': '1900-01-01',
+                'fhirVersion': '4.0.1',
+                'format': ['application/fhir+json'],
+                'kind': 'instance',
+                'resourceType': 'CapabilityStatement',
+                'rest': [{
+                    'mode': 'server',
+                    'security': {
+                        'extension': [{
+                            'url': 'http://fhir-registry.smarthealthit.org/StructureDefinition/oauth-uris',
+                            'extension': [
+                                # Notably only offer a token URL, just like the bulk-data-server has.
+                                # Some versions of fhirclient also expect an authorize URL, but we should still work
+                                # in cases where that isn't available.
+                                {'url': 'token', 'valueUri': f'{self.root.path}/token'}
+                            ],
+                        }],
+                    },
+                }],
+                'status': 'active',
+            },
+        )
+
+        # /token
+        responses.post(
+            f'{self.root.path}/token',
+            json={
+                'access_token': '1234567890',
+            },
+        )
+
+        # /$export
+        responses.get(
+            f'{self.root.path}/$export',
+            match=[
+                matchers.header_matcher({
+                    'Accept': 'application/fhir+json',
+                    'Authorization': 'Bearer 1234567890',
+                    'Prefer': 'respond-async',
+                }),
+                matchers.query_param_matcher({
+                    '_type': 'Condition,DocumentReference,Encounter,Observation,Patient',
+                    '_since': '1800-01-01T00:00:00Z',
+                })
+            ],
+            headers={'Content-Location': f'{self.root.path}/poll'},
+            status=202,
+        )
+
+        # /poll
+        responses.get(
+            f'{self.root.path}/poll',
+            match=[matchers.header_matcher({
+                'Accept': 'application/json',
+                'Authorization': 'Bearer 1234567890',
+            })],
+            json={
+                'output': [{'type': 'Patient', 'url': f'{self.root.path}/download/patient1'}],
+            },
+        )
+
+        # /download/patient1
+        responses.get(
+            f'{self.root.path}/download/patient1',
+            match=[matchers.header_matcher({
+                'Accept': 'application/fhir+ndjson',
+                'Authorization': 'Bearer 1234567890',
+            })],
+            json={  # content doesn't really matter
+                'id': 'testPatient1',
+                'resourceType': 'Patient',
+            },
+        )
+
+        # DELETE /poll
+        responses.delete(
+            f'{self.root.path}/poll',
+            match=[matchers.header_matcher({
+                'Accept': 'application/fhir+json',
+                'Authorization': 'Bearer 1234567890',
+            })],
+            status=202,
+        )
+
+    @responses.activate(assert_all_requests_are_fired=True)
+    def test_successful_bulk_export(self):
+        """Verify a happy path bulk export, from toe to tip"""
+        loader = loaders.FhirNdjsonLoader(self.root, client_id=self.client_id, jwks=self.jwks_path)
+        tmpdir = loader.load_all()
+
+        self.assertEqual(
+            {'id': 'testPatient1', 'resourceType': 'Patient'},
+            common.read_json(os.path.join(tmpdir.name, 'Patient.000.ndjson')),
+        )


### PR DESCRIPTION
This commit allows passing an http/https URL as the input path when using the ndjson input format.

Cumulus ETL will then query the given server for bulk exports of the resources it cares about.

Currently, we are very greedy and request everything the server will give us. We can refine that in the future.

You'll also need to pass two new arguments when using this feature:
`--smart-client-id`: the client ID you registered (or path to one)
`--smart-jwks`: path to a file with the JWKS you registered

Fixes #78 