### PR TITLE
docs: use Athena v3 in example CloudFormation

### DIFF
--- a/docs/howtos/set-up-aws.md
+++ b/docs/howtos/set-up-aws.md
@@ -276,7 +276,7 @@ Resources:
         EnforceWorkGroupConfiguration: True
         PublishCloudWatchMetricsEnabled: True
         EngineVersion:
-          SelectedEngineVersion: "Athena engine version 2"
+          SelectedEngineVersion: "Athena engine version 3"
         ResultConfiguration:
           EncryptionConfiguration:
             EncryptionOption: SSE_KMS


### PR DESCRIPTION
It just released and it will be much easier to do a switch now than later. No crazy changes, but it has a few new features.
