### PR TITLE
oracle: switch from cx_Oracle to oracledb

### DIFF
--- a/cumulus/loaders/i2b2/oracle/connect.py
+++ b/cumulus/loaders/i2b2/oracle/connect.py
@@ -3,7 +3,8 @@
 import getpass
 import logging
 import os
-import cx_Oracle
+
+import oracledb
 
 
 def get_data_source_name() -> str:
@@ -27,25 +28,9 @@ def get_password() -> str:
         return getpass.getpass(f'Enter password for I2B2_SQL_USER {user}: ')
 
 
-def get_library_path() -> str:
-    """
-    :return: SQL connection requires Linked Library
-    """
-    ldpath = os.getenv('LD_LIBRARY_PATH', None)
-
-    if ldpath is None or 'instantclient' not in ldpath:
-        raise Exception(
-            'LD_LIBRARY_PATH does not exist OR does not contain a path to '
-            'instantclient. '
-            'This environment variable must be set before calling scripts.')
-    else:
-        return ldpath
-
-
-def connect() -> cx_Oracle.Connection:
+def connect() -> oracledb.Connection:
     """
     :return: connection to oracle database
     """
     logging.info('Attempting to connect to %s', get_data_source_name())
-    cx_Oracle.init_oracle_client(lib_dir=get_library_path())
-    return cx_Oracle.connect(get_user(), get_password(), get_data_source_name())
+    return oracledb.connect(user=get_user(), password=get_password(), dsn=get_data_source_name())

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,6 @@ name = "cumulus"
 requires-python = ">= 3.7"
 dependencies = [
     "ctakesclient >= 1.3",
-    "cx-oracle",
     # This branch includes some jwt fixes we need (and will hopefully be in mainline in future)
     "fhirclient @ git+https://github.com/mikix/client-py.git@mikix/oauth2-jwt",
     "jwcrypto",
@@ -49,6 +48,7 @@ tests = [
     "ddt",
     "freezegun",
     "moto[s3]",
+    "oracledb",  # oracle support is not enabled by default, and is only used in tests right now
     "pytest",
     "responses",
     "urllib3",

--- a/test/test_i2b2_sql_connect.py
+++ b/test/test_i2b2_sql_connect.py
@@ -4,16 +4,12 @@ import unittest
 from cumulus.loaders.i2b2.oracle import connect
 
 
-@unittest.skip('oracle client drivers fail to load on new OSX')
+@unittest.skip('needs a running oracle server currently')
 class TestSQLDump(unittest.TestCase):
     """Test case for connecting to oracle"""
 
     def test_connect(self):
         connect.connect()
-
-    def test_LD_LIBRARY_PATH(self):
-        # Fails on new MACs due to no available Oracle Python Driver :(
-        connect.get_library_path()
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
### Description
This uses the new python library in thin-client mode, which means the Oracle support could work on modern Macs again.

This also moves the dependency to the optional test dependency list, because Oracle support is not currently enabled.

See the following links for more info on this switch:
- https://levelup.gitconnected.com/open-source-python-thin-driver-for-oracle-database-e82aac7ecf5a
- https://python-oracledb.readthedocs.io/en/latest/user_guide/appendix_c.html#upgrading-from-cx-oracle-8-3-to-python-oracledb

<!--- Describe your changes in detail -->

### Checklist
- [x] Consider if documentation (like in `docs/`) needs to be updated
- [x] Consider if tests should be added

Fixes #17