### PR TITLE
etl: add new context.json file in the PHI/build dir

### DIFF
--- a/cumulus/common.py
+++ b/cumulus/common.py
@@ -241,15 +241,23 @@ def print_header(name: str) -> None:
 #
 ###############################################################################
 
-def timestamp_datetime() -> str:
+def datetime_now() -> datetime.datetime:
+    """
+    UTC date and time, suitable for use as a FHIR 'instant' data type
+    """
+    return datetime.datetime.now(datetime.timezone.utc)
+
+
+def timestamp_datetime(time: datetime.datetime = None) -> str:
     """
     Human-readable UTC date and time
     :return: MMMM-DD-YYY hh:mm:ss
     """
-    return datetime.datetime.now(datetime.timezone.utc).strftime('%Y-%m-%d %H:%M:%S')
+    time = time or datetime_now()
+    return time.strftime('%Y-%m-%d %H:%M:%S')
 
 
-def timestamp_filename() -> str:
+def timestamp_filename(time: datetime.datetime = None) -> str:
     """
     Human-readable UTC date and time suitable for a filesystem path
 
@@ -257,4 +265,5 @@ def timestamp_filename() -> str:
 
     :return: MMMM-DD-YYY__hh.mm.ss
     """
-    return datetime.datetime.now(datetime.timezone.utc).strftime('%Y-%m-%d__%H.%M.%S')
+    time = time or datetime_now()
+    return time.strftime('%Y-%m-%d__%H.%M.%S')

--- a/cumulus/config.py
+++ b/cumulus/config.py
@@ -1,5 +1,6 @@
 """ETL job config with summary"""
 
+import datetime
 import os
 from socket import gethostname
 
@@ -15,6 +16,7 @@ class JobConfig:
             dir_input: str,
             store_format: store.Format,
             dir_phi: store.Root,
+            timestamp: datetime.datetime = None,
             comment: str = None,
             batch_size: int = 1,  # this default is never really used - overridden by command line args
     ):
@@ -28,7 +30,7 @@ class JobConfig:
         self.dir_input = dir_input
         self.format = store_format
         self.dir_phi = dir_phi
-        self.timestamp = common.timestamp_filename()
+        self.timestamp = common.timestamp_filename(timestamp)
         self.hostname = gethostname()
         self.comment = comment or ''
         self.batch_size = batch_size

--- a/cumulus/context.py
+++ b/cumulus/context.py
@@ -1,0 +1,71 @@
+"""
+ETL job context, holding some persistent state between runs.
+"""
+
+import datetime
+from typing import Optional
+
+from cumulus import common
+
+
+class JobContext:
+    """
+    Context for an ETL job.
+
+    This is not really settings or config in the sense of user-derived values.
+    A prime example is "last successful run time" which the next run might want to use as part of its work
+    (like to only extract the changed data since the last run) but is otherwise ephemeral information.
+
+    Another possible (but not yet implemented) use might be to store some past config values,
+    like the last used output format. To either give the user a chance to correct a mistake or to know
+    how to change from one format to another.
+
+    This is stored in the phi/build directory and is thus safe to store possible PHI.
+    """
+
+    _LAST_SUCCESSFUL_DATETIME = 'last_successful_datetime'
+    _LAST_SUCCESSFUL_INPUT_DIR = 'last_successful_input_dir'
+    _LAST_SUCCESSFUL_OUTPUT_DIR = 'last_successful_output_dir'
+
+    def __init__(self, path: str):
+        """
+        :param path: path to context file
+        """
+        self._path: str = path
+        try:
+            self._data = common.read_json(path)
+        except (FileNotFoundError, PermissionError):
+            self._data = {}
+
+    @property
+    def last_successful_datetime(self) -> Optional[datetime.datetime]:
+        value = self._data.get(self._LAST_SUCCESSFUL_DATETIME)
+        if value is not None:
+            return datetime.datetime.fromisoformat(value)
+        return None
+
+    @last_successful_datetime.setter
+    def last_successful_datetime(self, value: datetime.datetime) -> None:
+        self._data[self._LAST_SUCCESSFUL_DATETIME] = value.isoformat()
+
+    @property
+    def last_successful_input_dir(self) -> Optional[str]:
+        return self._data.get(self._LAST_SUCCESSFUL_INPUT_DIR)
+
+    @last_successful_input_dir.setter
+    def last_successful_input_dir(self, value: str) -> None:
+        self._data[self._LAST_SUCCESSFUL_INPUT_DIR] = value
+
+    @property
+    def last_successful_output_dir(self) -> Optional[str]:
+        return self._data.get(self._LAST_SUCCESSFUL_OUTPUT_DIR)
+
+    @last_successful_output_dir.setter
+    def last_successful_output_dir(self, value: str) -> None:
+        self._data[self._LAST_SUCCESSFUL_OUTPUT_DIR] = value
+
+    def save(self) -> None:
+        common.write_json(self._path, self.as_json(), indent=4)  # pretty-print this since it isn't large
+
+    def as_json(self) -> dict:
+        return dict(self._data)

--- a/tests/test_context.py
+++ b/tests/test_context.py
@@ -1,0 +1,49 @@
+"""Tests for context.py"""
+
+import datetime
+import json
+import tempfile
+import unittest
+
+from cumulus.context import JobContext
+
+
+class TestJobContext(unittest.TestCase):
+    """Test case for JobContext"""
+
+    def test_missing_file_context(self):
+        context = JobContext('nope')
+        self.assertEqual({}, context.as_json())
+
+    def test_save_and_load(self):
+        with tempfile.NamedTemporaryFile(mode='w+') as f:
+            json.dump({
+                'last_successful_input_dir': '/input/dir',
+            }, f)
+            f.flush()
+
+            context = JobContext(f.name)
+            self.assertEqual({
+                'last_successful_input_dir': '/input/dir',
+            }, context.as_json())
+
+            context.last_successful_datetime = datetime.datetime(2008, 5, 1, 14, 30, 30, tzinfo=datetime.timezone.utc)
+            self.assertEqual({
+                'last_successful_datetime': '2008-05-01T14:30:30+00:00',
+                'last_successful_input_dir': '/input/dir',
+            }, context.as_json())
+
+            context.save()
+            context2 = JobContext(f.name)
+            self.assertEqual(context.as_json(), context2.as_json())
+
+    def test_last_successful_props(self):
+        context = JobContext('nope')
+        context.last_successful_datetime = datetime.datetime(2008, 5, 1, 14, 30, 30, tzinfo=datetime.timezone.utc)
+        context.last_successful_input_dir = '/input'
+        context.last_successful_output_dir = '/output'
+        self.assertEqual({
+            'last_successful_datetime': '2008-05-01T14:30:30+00:00',
+            'last_successful_input_dir': '/input',
+            'last_successful_output_dir': '/output',
+        }, context.as_json())


### PR DESCRIPTION
### Description
This file holds some run-to-run key/value pairs. It's starting with some info from the last successful run (intended to be used for incremental bulk exports) but might grow other status information over time, like what the current output format is, etc.

### Checklist
- [x] Consider if documentation (like in `docs/`) needs to be updated
- [x] Consider if tests should be added
