### PR TITLE
docker: use default python image, not the slim one

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,7 @@ RUN dotnet publish \
   --output=/bin \
   /app/FHIR/src/Microsoft.Health.Fhir.Anonymizer.R4.CommandLineTool
 
-FROM python:3.10-slim AS cumulus-etl
+FROM python:3.10 AS cumulus-etl
 COPY . /app
 RUN pip3 install /app
 RUN rm -r /app


### PR DESCRIPTION

### Description
This one has git installed, to fix building even when we use dependencies pointing at a git URL. (right now, the docker image is not buildable)

And it's also the recommended upstream image.

<!--- Describe your changes in detail -->

### Checklist
- [x] Consider if documentation (like in `docs/`) needs to be updated
- [x] Consider if tests should be added
