### PR TITLE
ci: run the security static analysis tool bandit

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -51,13 +51,18 @@ jobs:
       - name: Install linters
         run: |
           python -m pip install --upgrade pip
-          pip install pycodestyle pylint
+          pip install bandit[toml] pycodestyle pylint
 
       - name: Run pycodestyle
         run: |
           pycodestyle --max-line-length=120 .
 
       - name: Run pylint
-        if: success() || failure() # still run pylint if pycodestyle fails
+        if: success() || failure() # still run pylint if above checks fail
         run: |
           pylint cumulus tests
+
+      - name: Run bandit
+        if: success() || failure() # still run bandit if above checks fail
+        run: |
+          bandit -c pyproject.toml -r .

--- a/cumulus/deid/mstool.py
+++ b/cumulus/deid/mstool.py
@@ -5,7 +5,7 @@ See https://github.com/microsoft/Tools-for-Health-Data-Anonymization for more de
 """
 
 import os
-import subprocess
+import subprocess  # nosec: B404
 import sys
 
 MSTOOL_CMD = 'Microsoft.Health.Fhir.Anonymizer.R4.CommandLineTool'
@@ -22,7 +22,9 @@ def run_mstool(input_dir: str, output_dir: str) -> None:
     The input must be in ndjson format. And the output will be as well.
     """
     try:
-        subprocess.run(
+        # The following call only points at some temporary directory names (which we generate),
+        # so it should be safe, and we thus disable the security linter warning about validating inputs.
+        subprocess.run(  # nosec: subprocess_without_shell_equals_true
             [
                 MSTOOL_CMD,
                 '--bulkData',

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,6 +42,9 @@ include = [
     "LICENSE",
 ]
 
+[tool.bandit]
+exclude_dirs = ["tests"]
+
 [project.optional-dependencies]
 tests = [
     "ddt",


### PR DESCRIPTION
### Description

Whether we run any security tooling came up during an IT review, and it sounds like a good idea.

Its only complaint so far was about using the subprocess module at all (low priority warning, just telling us "hey, please consider whether you are checking validity of input"). I think we are OK there, so I silenced those warnings on a line-by-line basis.

<!--- Describe your changes in detail -->

### Checklist
- [x] Consider if documentation (like in `docs/`) needs to be updated
- [x] Consider if tests should be added
