### PR TITLE
Reorder images in dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,20 +14,20 @@ RUN dotnet publish \
   --output=/bin \
   /app/FHIR/src/Microsoft.Health.Fhir.Anonymizer.R4.CommandLineTool
 
-FROM python:3.10 AS cumulus-etl
-COPY --from=ms-tool /bin/Microsoft.Health.Fhir.Anonymizer.R4.CommandLineTool /bin
-COPY . /app
-RUN --mount=type=cache,target=/root/.cache \
-  pip3 install /app
-RUN rm -r /app
-
-ENTRYPOINT ["cumulus-etl"]
-
 FROM python:3.10 AS cumulus-etl-test
 COPY --from=ms-tool /bin/Microsoft.Health.Fhir.Anonymizer.R4.CommandLineTool /bin
 COPY . /app
 RUN --mount=type=cache,target=/root/.cache \
   pip3 install /app/[tests]
+RUN rm -r /app
+
+ENTRYPOINT ["cumulus-etl"]
+
+FROM python:3.10 AS cumulus-etl
+COPY --from=ms-tool /bin/Microsoft.Health.Fhir.Anonymizer.R4.CommandLineTool /bin
+COPY . /app
+RUN --mount=type=cache,target=/root/.cache \
+  pip3 install /app
 RUN rm -r /app
 
 ENTRYPOINT ["cumulus-etl"]


### PR DESCRIPTION
### Description
This commit changes the order of the images in the dockerfile, so that you get the prod image if you elect to not use the compose file for building the project.

### Checklist
- [ ] Consider if documentation (like in `docs/`) needs to be updated
- [ ] Consider if tests should be added
