### PR TITLE
fix: add OBSENC to i2b2 encounter transform

### DIFF
--- a/cumulus/loaders/i2b2/external_mappings.py
+++ b/cumulus/loaders/i2b2/external_mappings.py
@@ -69,6 +69,7 @@ SNOMED_ADMISSION = {
     'Day Surgery': 'AMB',
     'Emergency': 'EMER',
     'Inpatient': 'IMP',
+    'Observation': 'OBSENC',
     'Outpatient': 'AMB',
     'Recurring Outpatient Series': 'AMB',
 }

--- a/cumulus/loaders/i2b2/transform.py
+++ b/cumulus/loaders/i2b2/transform.py
@@ -122,13 +122,15 @@ def to_fhir_encounter(visit: VisitDimension) -> Encounter:
             'value': parse_fhir_duration(visit.length_of_stay)
         })
 
-    if visit.inout_cd in external_mappings.SNOMED_ADMISSION:
-        encounter.class_fhir = Coding({
-            'system': 'http://terminology.hl7.org/CodeSystem/v3-ActCode',
-            'code': external_mappings.SNOMED_ADMISSION.get(visit.inout_cd)
-        })
-    else:
-        logging.warning('skipping encounter.class_fhir.code for i2b2 INOUT_CD : %s', visit.inout_cd)
+    class_fhir = external_mappings.SNOMED_ADMISSION.get(visit.inout_cd)
+    if not class_fhir:
+        logging.debug('unknown encounter.class_fhir.code for i2b2 INOUT_CD : %s', visit.inout_cd)
+        class_fhir = '?'  # bogus value, but FHIR demands *some* class value
+
+    encounter.class_fhir = Coding({
+        'system': 'http://terminology.hl7.org/CodeSystem/v3-ActCode',
+        'code': class_fhir,
+    })
 
     return encounter
 


### PR DESCRIPTION

### Description
And also always define an Encounter.class_fhir value. FHIR marks it as required. There's no good UNKNOWN value, so I'm using the '?' value for now, even though that's also not a registered value...

<!--- Describe your changes in detail -->

### Checklist
- [x] Consider if documentation (like in `docs/`) needs to be updated
- [x] Consider if tests should be added
