### PR TITLE
fix: merge schemas by default when writing to Delta Lake

### DIFF
--- a/cumulus/formats/deltalake.py
+++ b/cumulus/formats/deltalake.py
@@ -61,6 +61,7 @@ class DeltaLakeFormat(AthenaFormat):
             # Prep the builder with various config options
             builder = pyspark.sql.SparkSession.builder \
                 .appName('cumulus-etl') \
+                .config('spark.databricks.delta.schema.autoMerge.enabled', 'true') \
                 .config('spark.driver.memory', '2g') \
                 .config('spark.sql.catalog.spark_catalog', 'org.apache.spark.sql.delta.catalog.DeltaCatalog') \
                 .config('spark.sql.extensions', 'io.delta.sql.DeltaSparkSessionExtension')


### PR DESCRIPTION
### Description
Delta Lakes are super strict about schema validation when writing to them. But FHIR is a bit unpredictable and a new batch of a table might have fields that previous batch didn't (maybe the hospital started adding metadata or stopped adding it)

So enable schema autoMerge when writing to a Delta Lake.

See https://delta.io/blog/2022-11-16-delta-lake-schema-enforcement/

<!--- Describe your changes in detail -->

### Checklist
- [x] Consider if documentation (like in `docs/`) needs to be updated
- [x] Consider if tests should be added
