### PR TITLE
Updated CNLP image name

### DIFF
--- a/compose.yaml
+++ b/compose.yaml
@@ -36,7 +36,7 @@ services:
       - etl-support    
 
   cnlp-transformers:
-    image: smartonfhir/cnlp-transformers:0.4-cpu
+    image: smartonfhir/cnlp-transformers:negation-0.4-cpu
     profiles:
       - etl-support
     networks:


### PR DESCRIPTION
### Description
The CNLPT team wanted to namespace the different flavors of models served by the CNLPT image.

This new target image also has a cache of the external models, so it should spin up much faster.

### Checklist
- [x] Consider if documentation (like in `docs/`) needs to be updated
- [x] Consider if tests should be added
