### PR TITLE
fix: save the codebook periodically as we run the ETL

### DIFF
--- a/tests/test_codebook.py
+++ b/tests/test_codebook.py
@@ -81,6 +81,33 @@ class TestCodebookDB(unittest.TestCase):
         self.assertEqual(e1, db2.encounter('1'))
         self.assertEqual(e2, db2.encounter('2'))
 
+    def test_does_not_save_if_not_modified(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            path = os.path.join(tmpdir, 'cb.json')
+
+            # Confirm that an empty book starts modified
+            db = CodebookDB()
+            self.assertTrue(db.save(path))
+
+            # But after a save, we are no longer modified
+            self.assertFalse(db.save(path))
+
+            # Change it again, and we can save
+            db.patient('1')
+            self.assertTrue(db.save(path))
+
+            # But if we make a call that doesn't modify the db, don't save
+            db.patient('1')
+            self.assertFalse(db.save(path))
+
+            # Resource hashes also cause modification
+            db.resource_hash('1')
+            self.assertTrue(db.save(path))
+
+            # And encounters
+            db.encounter('1')
+            self.assertTrue(db.save(path))
+
     def test_version0(self):
         script_dir = os.path.dirname(__file__)
         db_path = os.path.join(script_dir, 'data', 'codebook0.json')

--- a/tests/test_scrubber.py
+++ b/tests/test_scrubber.py
@@ -125,6 +125,7 @@ class TestScrubber(unittest.TestCase):
 
             # make sure that we raise an error on an unexpected cookbook version
             db.mapping['version'] = '.99'
+            db.modified = True
             db.save(path)
             with self.assertRaises(Exception) as context:
                 Scrubber(path)


### PR DESCRIPTION
### Description
Previously, we'd save the codebook after every job. But jobs write data out in batches as they go. So if the job is interrupted, that means it has written out data that didn't make it to the codebook.

For patients and encounters, whose de-identified IDs are randomized the first time they are encountered, this could cause a problem on the next run, where the same patient is given a new ID because the codebook was never saved from the previous run.

So this commit adds two changes:
- Save the codebook *before* writing out any batch of data.
- As an optimization, when the codebook wants to be saved, only write it out if anything has actually been modified inside of it. (Since we now want to save it more often, it made sense not to be saving a giant 1GB file all the time.)

<!--- Describe your changes in detail -->

### Checklist
- [x] Consider if documentation (like in `docs/`) needs to be updated
- [x] Consider if tests should be added
