### PR TITLE
docs: add CONTRIBUTING doc

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,60 @@
+# How to contribute to Cumulus
+
+## Did you find a bug?
+
+Excellent!
+
+Please first look at the
+[existing GitHub issues](https://github.com/smart-on-fhir/cumulus-etl/issues)
+to see if it has already been reported.
+But if you don't see your bug, please
+[file a new GitHub issue](https://github.com/smart-on-fhir/cumulus-etl/issues/new),
+and we will look at it as soon as we can.  
+
+The more detail you can add, the quicker we will be able to fix the bug.
+
+## Do you want to write a patch that fixes a bug?
+
+Even better! Thank you!
+
+### Set up your dev environment
+
+To use the same dev environment as us, you'll want to run these commands:
+```sh
+pip install .[dev]
+pre-commit install
+```
+
+This will install the pre-commit hooks for the repo (which automatically enforce styling for you).
+
+### How to show us the patch
+
+Open a new GitHub PR and one of the maintainers will notice it and comment.
+
+Please add as much detail as you can about the problem you are solving and ideally even link to
+the related existing GitHub issue.
+
+### What to expect
+
+All code changes (even changes made by the main project developers)
+go through several automated CI steps and a manual code review.
+
+#### Automatic CI
+
+Here's what GitHub will automatically run:
+- unit tests (run `pytest` locally to confirm your tests pass)
+- lint tests (run `pylint cumulus tests` to confirm your code passes)
+- security static analysis (via `bandit`)
+
+#### Manual review
+
+A project developer will also review your code manually.
+Every PR needs one review approval to land.
+
+A reviewer will be looking for things like:
+- suitability (not every change makes sense for the project scope or direction)
+- maintainability
+- general quality
+
+Once approved, you can merge your PR yourself as long as the other GitHub tests pass.
+Congratulations, and thank you!


### PR DESCRIPTION
### Description
Designed to be a friendly introduction to helping, it also lays out the QA process we use for incoming fixes (and internal fixes)

<!--- Describe your changes in detail -->

### Checklist
- [x] Consider if documentation (like in `docs/`) needs to be updated
- [x] Consider if tests should be added
