### PR TITLE
fix: pass AWS environment variables through to docker

### DIFF
--- a/compose.yaml
+++ b/compose.yaml
@@ -5,6 +5,9 @@ services:
       context: .
       target: cumulus-etl
     environment:
+      - AWS_ACCESS_KEY_ID
+      - AWS_SECRET_ACCESS_KEY
+      - AWS_SESSION_TOKEN
       - URL_CTAKES_REST=http://ctakes-covid:8080/ctakes-web-rest/service/analyze
       - URL_CNLP_NEGATION=http://cnlp-transformers:8000/negation/process
     networks:


### PR DESCRIPTION
### Description
This should help when testing locally / in non-EC2 contexts

I tried but failed to get ~/.aws/credentials picked up. I used syntax like:
```
    volumes:
      - $HOME/.aws/credentials:/root/.aws/credentials:ro
```

And it looked like it was showing up in the container, but cumulus wasn't picking it up. Not sure why. But these variables get through anyway.

<!--- Describe your changes in detail -->

### Checklist
- [x] Consider if documentation (like in `docs/`) needs to be updated
- [x] Consider if tests should be added
