### PR TITLE
fix: keep a couple more US core extensions for patient gender

### DIFF
--- a/cumulus/deid/ms-config.json
+++ b/cumulus/deid/ms-config.json
@@ -5,8 +5,10 @@
   "fhirPathRules": [
     {"path": "nodesByName('modifierExtension')", "method": "keep", "comment": "Cumulus: keep these so we can ignore resources with modifiers we don't understand"},
     {"path": "DocumentReference.nodesByType('Attachment').data", "method": "keep", "comment": "Cumulus: needed to run NLP on physician notes"},
-    {"path": "Patient.extension.where(url='http://hl7.org/fhir/us/core/StructureDefinition/us-core-race')", "method": "keep", "comment": "Cumulus: race is useful for studies"},
-    {"path": "Patient.extension.where(url='http://hl7.org/fhir/us/core/StructureDefinition/us-core-ethnicity')", "method": "keep", "comment": "Cumulus: ethnicity is useful for studies"},
+    {"path": "Patient.extension.where(url='http://hl7.org/fhir/us/core/StructureDefinition/us-core-birthsex')", "method": "keep", "comment": "Cumulus: useful for studies"},
+    {"path": "Patient.extension.where(url='http://hl7.org/fhir/us/core/StructureDefinition/us-core-ethnicity')", "method": "keep", "comment": "Cumulus: useful for studies"},
+    {"path": "Patient.extension.where(url='http://hl7.org/fhir/us/core/StructureDefinition/us-core-genderIdentity')", "method": "keep", "comment": "Cumulus: useful for studies"},
+    {"path": "Patient.extension.where(url='http://hl7.org/fhir/us/core/StructureDefinition/us-core-race')", "method": "keep", "comment": "Cumulus: useful for studies"},
     {"path": "Patient.birthDate", "method": "redact", "comment": "Cumulus: only keep year of birth (enablePartialDatesForRedact does that for us)"},
     {"path": "xxx", "method": "redact", "comment": "Cumulus: more changes below, search for the Cumulus: comment prefix"},
 


### PR DESCRIPTION
### Description
Specifically, add these two extensions to our allow-list:
- http://hl7.org/fhir/us/core/StructureDefinition/us-core-birthsex
- http://hl7.org/fhir/us/core/StructureDefinition/us-core-genderIdentity

<!--- Describe your changes in detail -->

### Checklist
- [x] Consider if documentation (like in `docs/`) needs to be updated
- [x] Consider if tests should be added
