### PR TITLE
WIP: feat: add some concurrency to our ETL core loop

### DIFF
--- a/cumulus/config.py
+++ b/cumulus/config.py
@@ -5,55 +5,69 @@ import os
 from socket import gethostname
 from typing import List
 
-from cumulus import common, formats, loaders, store
+from cumulus import common, formats, store
 
 
 class JobConfig:
-    """Configuration for an ETL job"""
+    """
+    Configuration for an entire ETL run.
+
+    This only store simple data structures, but can act as a factory for more interesting ones.
+    For example, this config holds the output format slug string, but can spit out a Format class for you.
+    This architecture is designed to make it easier to pass a JobConfig to multiple processes.
+    """
 
     def __init__(
         self,
-        loader: loaders.Loader,
-        dir_input: str,
-        store_format: formats.Format,
-        dir_phi: store.Root,
+        dir_input: str,  # original user-input path
+        dir_input_deid: str,  # temporary dir where we are reading the de-identified data from
+        dir_output: str,
+        dir_phi: str,
+        input_format: str,
+        output_format: str,
         timestamp: datetime.datetime = None,
         comment: str = None,
         batch_size: int = 1,  # this default is never really used - overridden by command line args
         tasks: List[str] = None,
     ):
-        """
-        :param loader: describes how input files were loaded (e.g. i2b2 or ndjson)
-        :param dir_input: the actual folder to grab input files from, in ndjson format
-        :param store_format: where to place output files and how, like ndjson
-        :param dir_phi: where to place PHI build artifacts like the codebook
-        """
-        self._loader = loader  # only kept around for logging purposes, use dir_input to read data
-        self.dir_input = dir_input
-        self.format = store_format
+        self._dir_input_orig = dir_input
+        self.dir_input = dir_input_deid
+        self._dir_output = dir_output
         self.dir_phi = dir_phi
+        self._input_format = input_format
+        self._output_format = output_format
         self.timestamp = common.timestamp_filename(timestamp)
         self.hostname = gethostname()
         self.comment = comment or ""
         self.batch_size = batch_size
         self.tasks = tasks or []
 
+        # initialize format class
+        self._output_root = store.Root(self._dir_output, create=True)
+        self._format_class = formats.get_format_class(self._output_format)
+
+    def initialize_formatter(self):
+        self._format_class.initialize_class(self._output_root)
+
+    def create_formatter(self, summary, dbname: str, group_field: str = None) -> formats.Format:
+        return self._format_class(self._output_root, summary, dbname, group_field)
+
     def path_config(self) -> str:
         return os.path.join(self.dir_job_config(), "job_config.json")
 
     def dir_job_config(self) -> str:
-        path = self.format.root.joinpath(f"JobConfig/{self.timestamp}")
-        self.format.root.makedirs(path)
+        path = self._output_root.joinpath(f"JobConfig/{self.timestamp}")
+        self._output_root.makedirs(path)
         return path
 
     def as_json(self):
         return {
-            "dir_input": self._loader.root.path,  # the original folder, rather than the temp dir holding deid files
-            "dir_output": self.format.root.path,
-            "dir_phi": self.dir_phi.path,
+            "dir_input": self._dir_input_orig,  # the original folder, rather than the temp dir holding deid files
+            "dir_output": self._dir_output,
+            "dir_phi": self.dir_phi,
             "path": self.path_config(),
-            "input_format": type(self._loader).__name__,
-            "output_format": type(self.format).__name__,
+            "input_format": self._input_format,
+            "output_format": self._output_format,
             "comment": self.comment,
             "batch_size": self.batch_size,
             "tasks": ",".join(self.tasks),
@@ -65,35 +79,25 @@ class JobSummary:
 
     def __init__(self, label=None):
         self.label = label
-        self.csv = []
         self.attempt = 0
         self.success = 0
-        self.failed = []
         self.timestamp = common.timestamp_datetime()
         self.hostname = gethostname()
 
-    def success_rate(self, show_every=1000 * 10) -> float:
+    def success_rate(self) -> float:
         """
-        :param show_every: print success rate
-        :return: % success rate
+        :return: % success rate (0.0 to 1.0)
         """
         if not self.attempt:
             return 1.0
 
-        prct = float(self.success) / float(self.attempt)
-
-        if 0 == self.attempt % show_every:
-            print(f"success = {self.success:,} rate % {prct}")
-
-        return prct
+        return float(self.success) / float(self.attempt)
 
     def as_json(self):
         return {
-            "csv": self.csv,
             "label": self.label,
             "attempt": self.attempt,
             "success": self.success,
-            "failed": self.failed,
             "success_rate": self.success_rate(),
             "timestamp": self.timestamp,
             "hostname": self.hostname,

--- a/cumulus/formats/__init__.py
+++ b/cumulus/formats/__init__.py
@@ -1,6 +1,4 @@
 """Classes that know _how_ to write out results to the target folder"""
 
 from .base import Format
-from .deltalake import DeltaLakeFormat
-from .ndjson import NdjsonFormat
-from .parquet import ParquetFormat
+from .factory import get_format_class

--- a/cumulus/formats/base.py
+++ b/cumulus/formats/base.py
@@ -1,6 +1,7 @@
 """Abstraction for where to write and read data"""
 
 import abc
+import logging
 
 import pandas
 
@@ -14,44 +15,63 @@ class Format(abc.ABC):
     Subclass this to provide a different output format (like ndjson or parquet).
     """
 
-    def __init__(self, root: store.Root):
-        """
-        Initialize a new Format class
-        :param root: the base location to write data to
-        """
-        self.root = root
-
-    def initialize(self, summary, dbname: str) -> None:
+    @classmethod
+    def initialize_class(cls, root: store.Root) -> None:
         """
         Performs any preparation before any batches have been written.
 
-        :param summary: JobSummary to be filled as records are written
-        :param dbname: the database name (folder name)
+        (e.g. some cross-thread expensive setup)
         """
 
-    @abc.abstractmethod
-    def write_records(
-        self, summary, dataframe: pandas.DataFrame, dbname: str, batch: int, group_field: str = None
-    ) -> None:
+    def __init__(self, root: store.Root, summary, dbname: str, group_field: str):
         """
-        Writes a single dataframe to the output root.
-
+        Initialize a new Format class
+        :param root: the base location to write data to
         :param summary: JobSummary to be filled as records are written
-        :param dataframe: the data records to write
         :param dbname: the database name (folder name)
-        :param batch: the batch number, from zero up
         :param group_field: a field name that if specified, indicates all previous records with a same value should be
          deleted -- for example "docref_id" will mean that any existing rows matching docref_id will be deleted before
          inserting any from this dataframe. Make sure that all records for a given group are in one single dataframe.
          See the comments for the EtlTask.group_field class attribute for more context.
         """
+        self.root = root
+        self.summary = summary
+        self.dbname = dbname
+        self.group_field = group_field
 
-    def finalize(self, summary, dbname: str) -> None:
+    def initialize(self) -> None:
+        """
+        Performs any preparation before any batches have been written.
+        """
+
+    def write_records(self, dataframe: pandas.DataFrame, batch: int) -> None:
+        """
+        Writes a single dataframe to the output root.
+
+        :param dataframe: the data records to write
+        :param batch: the batch number, from zero up
+        """
+        count = len(dataframe)
+        self.summary.attempt += count
+
+        try:
+            self._write_one_batch(dataframe, batch)
+            self.summary.success += count
+        except Exception:  # pylint: disable=broad-except
+            logging.exception("Could not process data records")
+
+    @abc.abstractmethod
+    def _write_one_batch(self, dataframe: pandas.DataFrame, batch: int) -> None:
+        """
+        Writes a single dataframe to the output root.
+
+        :param dataframe: the data records to write
+        :param batch: the batch number, from zero up
+        """
+
+    def finalize(self) -> None:
         """
         Performs any necessary cleanup after all batches have been written.
 
         Note that this is not guaranteed to be called, if the ETL process gets interrupted.
-
-        :param summary: JobSummary to be filled as records are written
-        :param dbname: the database name (folder name)
         """

--- a/cumulus/formats/deltalake.py
+++ b/cumulus/formats/deltalake.py
@@ -8,6 +8,7 @@ import contextlib
 import logging
 import os
 import tempfile
+import threading
 
 import delta
 import pandas
@@ -50,9 +51,10 @@ class DeltaLakeFormat(Format):
     Stores data in a delta lake.
     """
 
-    def __init__(self, root: store.Root):
-        super().__init__(root)
+    spark = None
 
+    @classmethod
+    def initialize_class(cls, root: store.Root) -> None:
         # This _suppress_output call is because pyspark is SO NOISY during session creation. Like 40 lines of trivial
         # output. Progress reports of downloading the jars. Comments about default logging level and the hostname.
         # I could not find a way to set the log level before the session is created. So here we just suppress
@@ -68,74 +70,80 @@ class DeltaLakeFormat(Format):
             )
 
             # Now add delta's packages and actually build the session
-            self.spark = delta.configure_spark_with_delta_pip(
+            cls.spark = delta.configure_spark_with_delta_pip(
                 builder,
                 extra_packages=[
                     "org.apache.hadoop:hadoop-aws:3.3.4",
                 ],
             ).getOrCreate()
 
-        self.spark.sparkContext.setLogLevel("ERROR")
-        self._configure_fs()
+        cls.spark.sparkContext.setLogLevel("ERROR")
+        cls._configure_fs(root, cls.spark)
 
-    def write_records(
-        self, summary, dataframe: pandas.DataFrame, dbname: str, batch: int, group_field: str = None
-    ) -> None:
+    def __init__(self, root: store.Root, summary, dbname: str, group_field: str):
+        super().__init__(root, summary, dbname, group_field)
+
+        # Create a threading lock to avoid two threads writing to the same table.
+        # This is technically safe to do, but Delta Lake will likely throw ConcurrentAppendException and tell you to
+        # retry the write. So for practical reasons, we just lock each table's access.
+        self._lock = threading.Lock()
+
+    def _write_one_batch(self, dataframe: pandas.DataFrame, batch: int) -> None:
         """Writes the whole dataframe to a delta lake"""
-        summary.attempt += len(dataframe)
-        full_path = self._table_path(dbname)
+        # First, convert our pandas dataframe to a spark dataframe.
+        # You'd think that self.spark.createDataFrame(df) would be the right thing to do, but actually, it can't
+        # seem to correctly infer the nested schema (it doesn't give nested fields names, just the types).
+        # But parquet does this well, and spark can read parquet well. So we do this dance of pandas -> parquet ->
+        # sparks.
+        with tempfile.NamedTemporaryFile() as parquet_file:
+            dataframe.to_parquet(parquet_file.name, index=False)
+            del dataframe  # allow GC to clean this up
+            updates = self.spark.read.parquet(parquet_file.name)
+
+            with self._lock:
+                table = self.update_delta_table(updates)
+
+        table.generate("symlink_format_manifest")
+
+    def update_delta_table(self, updates: pyspark.sql.DataFrame) -> delta.DeltaTable:
+        full_path = self._table_path(self.dbname)
 
         try:
-            # First, convert our pandas dataframe to a spark dataframe.
-            # You'd think that self.spark.createDataFrame(df) would be the right thing to do, but actually, it can't
-            # seem to correctly infer the nested schema (it doesn't give nested fields names, just the types).
-            # But parquet does this well, and spark can read parquet well. So we do this dance of pandas -> parquet ->
-            # sparks.
-            with tempfile.NamedTemporaryFile() as parquet_file:
-                dataframe.to_parquet(parquet_file.name, index=False)
-                updates = self.spark.read.parquet(parquet_file.name)
+            # Load table -- this will trigger an AnalysisException if the table doesn't exist yet
+            table = delta.DeltaTable.forPath(self.spark, full_path)
 
-                try:
-                    # Load table -- this will trigger an AnalysisException if the table doesn't exist yet
-                    table = delta.DeltaTable.forPath(self.spark, full_path)
+            if self.group_field:
+                # Delete any existing groups about to be overwritten. This leaves a small gap where if we
+                # crash before inserting new rows, we will have deleted data without a replacement.
+                # But a re-run of the ETL will correct that mistake. So it's not the worst gap to have.
+                #
+                # Ideally we'd be able to do both in the same MERGE statement for maximum atomicity.
+                # But delta lake won't let us, as it tries to detect possibly undefined behavior,
+                # and a line like the following will trip on it, worried about updating multiple rows at once:
+                #  whenMatchedUpdateAll("table.id = updates.id").whenMatchedDelete().whenNotMatchedInsertAll()
+                #
+                # TODO: Once delta-spark 2.3 releases, we can do everything in one MERGE:
+                #  - step 1: gather all group_field values in the source dataframe
+                #  - step 2: add whenNotMatchedBySourceDelete(f"{group_field} in {all_source_values}")
+                table.alias("table").merge(
+                    updates.alias("updates"), f"table.{self.group_field} = updates.{self.group_field}"
+                ).whenMatchedDelete().execute()
 
-                    if group_field:
-                        # Delete any existing groups about to be overwritten. This leaves a small gap where if we
-                        # crash before inserting new rows, we will have deleted data without a replacement.
-                        # But a re-run of the ETL will correct that mistake. So it's not the worst gap to have.
-                        #
-                        # Ideally we'd be able to do both in the same MERGE statement for maximum atomicity.
-                        # But delta lake won't let us, as it tries to detect possibly undefined behavior,
-                        # and a line like the following will trip on it, worried about updating multiple rows at once:
-                        #  whenMatchedUpdateAll("table.id = updates.id").whenMatchedDelete().whenNotMatchedInsertAll()
-                        #
-                        # TODO: Once delta-spark 2.3 releases, we can do everything in one MERGE:
-                        #  - step 1: gather all group_field values in the source dataframe
-                        #  - step 2: add whenNotMatchedBySourceDelete(f"{group_field} in {all_source_values}")
-                        table.alias("table").merge(
-                            updates.alias("updates"), f"table.{group_field} = updates.{group_field}"
-                        ).whenMatchedDelete().execute()
+            # Merge in new data
+            table.alias("table").merge(
+                source=updates.alias("updates"), condition="table.id = updates.id"
+            ).whenMatchedUpdateAll().whenNotMatchedInsertAll().execute()
 
-                    # Merge in new data
-                    table.alias("table").merge(
-                        source=updates.alias("updates"), condition="table.id = updates.id"
-                    ).whenMatchedUpdateAll().whenNotMatchedInsertAll().execute()
+        except AnalysisException:
+            # table does not exist yet, let's make an initial version
+            updates.write.save(path=full_path, format="delta")
+            table = delta.DeltaTable.forPath(self.spark, full_path)
 
-                except AnalysisException:
-                    # table does not exist yet, let's make an initial version
-                    updates.write.save(path=full_path, format="delta")
-                    table = delta.DeltaTable.forPath(self.spark, full_path)  # re-load the table to generate symlink
+        return table
 
-            table.generate("symlink_format_manifest")
-
-            summary.success += len(dataframe)
-            summary.success_rate(1)
-        except Exception:  # pylint: disable=broad-except
-            logging.exception("Could not process data records")
-
-    def finalize(self, summary, dbname: str) -> None:
+    def finalize(self) -> None:
         """Performs any necessary cleanup after all batches have been written"""
-        full_path = self._table_path(dbname)
+        full_path = self._table_path(self.dbname)
 
         try:
             table = delta.DeltaTable.forPath(self.spark, full_path)
@@ -143,23 +151,25 @@ class DeltaLakeFormat(Format):
             return  # if the table doesn't exist because we didn't write anything, that's fine - just bail
 
         try:
-            table.optimize().executeCompaction()  # gather small files into larger files for better query performance
+            with self._lock:
+                table.optimize().executeCompaction()  # pool small files for better query performance
             table.generate("symlink_format_manifest")
             table.vacuum()  # Clean up unused data files older than retention policy (default 7 days)
         except AnalysisException:
-            logging.exception("Could not finalize Delta Lake table %s", dbname)
+            logging.warning("Could not finalize Delta Lake table %s", self.dbname)
 
     def _table_path(self, dbname: str) -> str:
         return self.root.joinpath(dbname).replace("s3://", "s3a://")  # hadoop uses the s3a: scheme instead of s3:
 
-    def _configure_fs(self):
+    @staticmethod
+    def _configure_fs(root: store.Root, spark: pyspark.sql.SparkSession):
         """Tell spark/hadoop how to talk to S3 for us"""
-        fsspec_options = self.root.fsspec_options()
-        self.spark.conf.set("fs.s3a.sse.enabled", "true")
-        self.spark.conf.set("fs.s3a.server-side-encryption-algorithm", "SSE-KMS")
+        fsspec_options = root.fsspec_options()
+        spark.conf.set("fs.s3a.sse.enabled", "true")
+        spark.conf.set("fs.s3a.server-side-encryption-algorithm", "SSE-KMS")
         kms_key = fsspec_options.get("s3_additional_kwargs", {}).get("SSEKMSKeyId")
         if kms_key:
-            self.spark.conf.set("fs.s3a.server-side-encryption.key", kms_key)
+            spark.conf.set("fs.s3a.server-side-encryption.key", kms_key)
         region_name = fsspec_options.get("client_kwargs", {}).get("region_name")
         if region_name:
-            self.spark.conf.set("fs.s3a.endpoint.region", region_name)
+            spark.conf.set("fs.s3a.endpoint.region", region_name)

--- a/cumulus/formats/factory.py
+++ b/cumulus/formats/factory.py
@@ -1,0 +1,23 @@
+"""Create a Format instance"""
+
+from typing import Type
+
+from .base import Format
+from .deltalake import DeltaLakeFormat
+from .ndjson import NdjsonFormat
+from .parquet import ParquetFormat
+
+
+def get_format_class(name: str) -> Type[Format]:
+    """
+    Returns a Format class of the named type for the target output path.
+    """
+    classes = {
+        "deltalake": DeltaLakeFormat,
+        "ndjson": NdjsonFormat,
+        "parquet": ParquetFormat,
+    }
+    try:
+        return classes[name]
+    except KeyError:
+        raise ValueError(f"Unknown output format name {name}.")

--- a/docs/CONCURRENCY.md
+++ b/docs/CONCURRENCY.md
@@ -1,0 +1,82 @@
+# Concurrency in Cumulus ETL
+
+Concurrency is a general term for running code in parallel.
+
+Python has [several specific strategies](https://realpython.com/python-concurrency/)
+for achieving concurrency, each with its own pros and cons.
+But in brief, you can use multiple CPUs, threads, or cooperative multitasking.
+
+Each makes more sense in different performance profiles.
+Cumulus ETL itself is broadly I/O bound, rather than CPU bound.
+But let's talk about the various pieces of the whole.
+
+## Performance Profile of Cumulus ETL Steps
+
+Obviously, this document might become out of date, so we won't get too in the weeds.
+
+### I2B2 Conversion
+
+This can't be done in parallel with other steps.
+It's almost entirely about reading, converting, and writing as fast as it can.
+
+It might benefit from some concurrency, but this step becomes less important with bulk FHIR.
+
+### MS Tool De-Identification
+
+We can't control concurrency of this, and we need its output before we do any other steps.
+
+Thankfully, the MS tool does use multiple CPUs already.
+
+### Tasks
+
+Each task is broadly independent, with just the codebook as shared writable data.
+Most tasks are just reading, de-identifying, and writing as fast as they can.
+Only the NLP tasks do something interesting with the input data.
+
+### NLP
+
+cTAKES uses multiple cores already.
+I'm not sure about cNLP transformers, but ideally you're using the GPU for that.
+
+### Delta Lake
+
+Delta Lake can handle multiple requests at once and sends them to another Java process,
+which does use multiple CPUS.
+
+Delta Lake technically allows multiple writers at once to the same table,
+but only in the sense that nothing will be corrupted.
+If you realistically try to do that, one of your writers will get an error.
+
+So writes to Delta Lake inside a task should be in serial.
+But multiple tasks can each send requests to Delta Lake for their own tables in parallel.
+
+## Memory
+
+One thing to be mindful of as you increase concurrency is that each active task needs data.
+If you have a bundle size of 200k, each task would (naively) want its own 200k to operate on.
+
+So you either need to document that interaction between bundle size and concurrency,
+or secretly share the bundle size between concurrent tasks.
+
+Smaller bundles are mostly tolerable, since our most important format writer (Delta Lake) can
+consolidate small files into larger ones.
+(If we didn't do that, we might be hurting performance on the query side of things.)
+
+## Approaches
+
+Since we're mostly just reading, writing, and sending off tasks to other processes (NLP & Delta),
+it's safe to say that using multiple cores is probably not our highest priority.
+Especially since that would add some complexity (each process would need its own copies of some
+data like the pyspark instance).
+
+Instead, threads are a bit easier to understand and get us the same benefit of waiting on some I/O.
+
+Asyncio is another similar approach that would work,
+but it needs the cooperation of your I/O libraries and pyspark is not compatible.
+
+Here's what we do now for concurrency:
+- Run each task on its own thread
+
+Future improvements might be:
+- Sending multiple NLP requests from the same task at the same time
+- Reading the next bundle while waiting for a Delta Lake write to finish

--- a/tests/test_codebook.py
+++ b/tests/test_codebook.py
@@ -47,6 +47,7 @@ class TestCodebook(unittest.TestCase):
 
 
 @ddt.ddt
+@mock.patch("cumulus.deid.codebook.secrets.token_hex", new=lambda x: "1234")
 class TestCodebookDB(unittest.TestCase):
     """Test case for the CodebookDB class"""
 


### PR DESCRIPTION
### Description
Specifically, send each task to its own thread.
Guard codebook access with thread locks.

### Output change:

Tired:
```
###############################################################
condition:
success = 200,000 rate % 1.0
success = 370,317 rate % 1.0
###############################################################
documentreference:
ERROR:root:Could not find any files for DocumentReference in the input folder, skipping that resource.
###############################################################
encounter:
success = 200,000 rate % 1.0
success = 400,000 rate % 1.0
...
```

Wired:
```
###############################################################
Tasks:
  ⭐ done with covid_symptom__nlp_results (0 processed) ⭐
  ⭐ done with documentreference (0 processed) ⭐
  11,417 processed for patient
  200,000 processed for condition
  ⭐ done with patient (11,417 processed) ⭐
  200,000 processed for encounter
  370,317 processed for condition
  ⭐ done with condition (370,317 processed) ⭐
  400,000 processed for encounter
  200,000 processed for observation
  600,000 processed for encounter
  ...
```

### Results

Looks like threading among the tasks is about 10% improvement, and threading inside a task is another 10% (for 20% total).
 
More testing needs to be done. And the above speed improvements did not take memory use into account.

TODO:
- Continue testing threading inside a task. With further locking & waiting with a single batch, do we lose performance gains?
- Divide batch size by number of threads, dynamically.
- Send NLP requests in parallel.

Or I can pause and slim this down to just the across-task threading, which seems like a reasonably easy win.

### Raw performance notes

Just parking this here in case my laptop dies.

```
rm -rf /tmp/synthea; time python3 -m cumulus.etl ~/Downloads/synthea/10000/fhir/ /tmp/synthea/output /tmp/synthea/phi

4 tables, no NLP, 5M records:

main:
real	8m47.788s
user	5m10.444s
sys	0m8.687s
real	8m58.487s
user	5m16.811s
sys	0m9.904s

with full batch threading:
real	6m58.081s
user	5m54.791s
sys	0m15.059s
real	7m14.039s
user	6m1.213s
sys	0m18.546s
real	7m12.233s
user	5m59.629s
sys	0m16.165s

with full batch threading (2 subthreads):
real	6m41.983s
user	5m40.866s
sys	0m14.705s
real	7m14.670s
user	5m49.834s
sys	0m20.662s

with full batch threading (one subthread and a future wait):
real	8m13.779s
user	5m56.886s
sys	0m15.574s

with task-only threading (but batch locks still there):
real	7m58.068s
user	5m16.086s
sys	0m12.560s
real	7m52.620s
user	5m9.342s
sys	0m11.238s
with task threading (no batch locks):
real	8m14.008s
user	5m17.869s
sys	0m13.514s
real	7m49.188s
user	5m14.312s
```
### Checklist
- [x] Consider if documentation (like in `docs/`) needs to be updated
- [x] Consider if tests should be added
