### PR TITLE
refactor: some cleanups from concurrency research

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -432,6 +432,6 @@ valid-metaclass-classmethod-first-arg=mcs
 
 # Exceptions that will emit a warning when being caught. Defaults to
 # "Exception"
-overgeneral-exceptions=StandardError,
-                       Exception,
-                       BaseException
+overgeneral-exceptions=builtins.StandardError,
+                       builtins.Exception,
+                       builtins.BaseException

--- a/cumulus/ctakes.py
+++ b/cumulus/ctakes.py
@@ -38,7 +38,7 @@ def covid_symptoms_extract(cache: store.Root, docref: dict) -> List[dict]:
                 physician_note = base64.standard_b64decode(content["attachment"]["data"]).decode(charset)
                 break
     else:
-        logging.warning("No text/plain content for symptoms")  # ideally would print identifier, but it's PHI...
+        logging.warning("No text/plain content in docref %s", docref_id)
         return []
 
     # Strip this "line feed" character that often shows up in notes and is confusing for cNLP.
@@ -57,8 +57,8 @@ def covid_symptoms_extract(cache: store.Root, docref: dict) -> List[dict]:
 
     try:
         ctakes_json = extract(cache, ctakes_namespace, physician_note)
-    except Exception as exc:  # pylint: disable=broad-except
-        logging.error("Could not extract symptoms: %s", exc)
+    except Exception:  # pylint: disable=broad-except
+        logging.exception("Could not extract symptoms for docref: %s", docref_id)
         return []
 
     matches = ctakes_json.list_sign_symptom(ctakesclient.typesystem.Polarity.pos)
@@ -77,7 +77,7 @@ def covid_symptoms_extract(cache: store.Root, docref: dict) -> List[dict]:
         spans = ctakes_json.list_spans(matches)
         polarities_cnlp = list_polarity(cache, cnlp_namespace, physician_note, spans)
     except Exception:  # pylint: disable=broad-except
-        logging.exception("Could not check negation")
+        logging.exception("Could not check negation for docref %s", docref_id)
         polarities_cnlp = [ctakesclient.typesystem.Polarity.pos] * len(matches)  # fake all positives
 
     # Now filter out any non-positive matches

--- a/cumulus/formats/__init__.py
+++ b/cumulus/formats/__init__.py
@@ -1,6 +1,4 @@
 """Classes that know _how_ to write out results to the target folder"""
 
 from .base import Format
-from .deltalake import DeltaLakeFormat
-from .ndjson import NdjsonFormat
-from .parquet import ParquetFormat
+from .factory import get_format_class

--- a/cumulus/formats/batched_files.py
+++ b/cumulus/formats/batched_files.py
@@ -1,8 +1,6 @@
 """An implementation of Format designed to write in batches of files"""
 
 import abc
-import logging
-import os
 
 import pandas
 
@@ -37,29 +35,21 @@ class BatchedFileFormat(Format):
     #
     ##########################################################################################
 
-    def initialize(self, summary, dbname: str) -> None:
+    def __init__(self, *args, **kwargs) -> None:
         """Performs any preparation before any batches have been written."""
+        super().__init__(*args, **kwargs)
+
         # Let's clear out any existing files before writing any new ones.
         # Note: There is a real issue here where Athena will see invalid results until we've written all
         #       our files out. Use the deltalake format to get atomic updates.
-        parent_dir = self.root.joinpath(dbname)
+        parent_dir = self.root.joinpath(self.dbname)
         try:
             self.root.rm(parent_dir, recursive=True)
         except FileNotFoundError:
             pass
+        self.root.makedirs(parent_dir)
 
-    def write_records(
-        self, summary, dataframe: pandas.DataFrame, dbname: str, batch: int, group_field: str = None
-    ) -> None:
+    def _write_one_batch(self, dataframe: pandas.DataFrame, batch: int) -> None:
         """Writes the whole dataframe to a single file"""
-        summary.attempt += len(dataframe)
-
-        try:
-            full_path = self.root.joinpath(f"{dbname}/{dbname}.{batch:03}.{self.suffix}")
-            self.root.makedirs(os.path.dirname(full_path))
-            self.write_format(dataframe, full_path)
-
-            summary.success += len(dataframe)
-            summary.success_rate(1)
-        except Exception:  # pylint: disable=broad-except
-            logging.exception("Could not process data records")
+        full_path = self.root.joinpath(f"{self.dbname}/{self.dbname}.{batch:03}.{self.suffix}")
+        self.write_format(dataframe, full_path)

--- a/cumulus/formats/deltalake.py
+++ b/cumulus/formats/deltalake.py
@@ -50,8 +50,12 @@ class DeltaLakeFormat(Format):
     Stores data in a delta lake.
     """
 
-    def __init__(self, root: store.Root):
-        super().__init__(root)
+    spark = None
+
+    @classmethod
+    def initialize_class(cls, root: store.Root) -> None:
+        if cls.spark is not None:
+            return
 
         # This _suppress_output call is because pyspark is SO NOISY during session creation. Like 40 lines of trivial
         # output. Progress reports of downloading the jars. Comments about default logging level and the hostname.
@@ -68,74 +72,70 @@ class DeltaLakeFormat(Format):
             )
 
             # Now add delta's packages and actually build the session
-            self.spark = delta.configure_spark_with_delta_pip(
+            cls.spark = delta.configure_spark_with_delta_pip(
                 builder,
                 extra_packages=[
                     "org.apache.hadoop:hadoop-aws:3.3.4",
                 ],
             ).getOrCreate()
 
-        self.spark.sparkContext.setLogLevel("ERROR")
-        self._configure_fs()
+        cls.spark.sparkContext.setLogLevel("ERROR")
+        cls._configure_fs(root, cls.spark)
 
-    def write_records(
-        self, summary, dataframe: pandas.DataFrame, dbname: str, batch: int, group_field: str = None
-    ) -> None:
+    def _write_one_batch(self, dataframe: pandas.DataFrame, batch: int) -> None:
         """Writes the whole dataframe to a delta lake"""
-        summary.attempt += len(dataframe)
-        full_path = self._table_path(dbname)
+        # First, convert our pandas dataframe to a spark dataframe.
+        # You'd think that self.spark.createDataFrame(df) would be the right thing to do, but actually, it can't
+        # seem to correctly infer the nested schema (it doesn't give nested fields names, just the types).
+        # But parquet does this well, and spark can read parquet well. So we do this dance of pandas -> parquet ->
+        # sparks.
+        with tempfile.NamedTemporaryFile() as parquet_file:
+            dataframe.to_parquet(parquet_file.name, index=False)
+            del dataframe  # allow GC to clean this up
+            updates = self.spark.read.parquet(parquet_file.name)
+            table = self.update_delta_table(updates)
+
+        table.generate("symlink_format_manifest")
+
+    def update_delta_table(self, updates: pyspark.sql.DataFrame) -> delta.DeltaTable:
+        full_path = self._table_path(self.dbname)
 
         try:
-            # First, convert our pandas dataframe to a spark dataframe.
-            # You'd think that self.spark.createDataFrame(df) would be the right thing to do, but actually, it can't
-            # seem to correctly infer the nested schema (it doesn't give nested fields names, just the types).
-            # But parquet does this well, and spark can read parquet well. So we do this dance of pandas -> parquet ->
-            # sparks.
-            with tempfile.NamedTemporaryFile() as parquet_file:
-                dataframe.to_parquet(parquet_file.name, index=False)
-                updates = self.spark.read.parquet(parquet_file.name)
+            # Load table -- this will trigger an AnalysisException if the table doesn't exist yet
+            table = delta.DeltaTable.forPath(self.spark, full_path)
 
-                try:
-                    # Load table -- this will trigger an AnalysisException if the table doesn't exist yet
-                    table = delta.DeltaTable.forPath(self.spark, full_path)
+            if self.group_field:
+                # Delete any existing groups about to be overwritten. This leaves a small gap where if we
+                # crash before inserting new rows, we will have deleted data without a replacement.
+                # But a re-run of the ETL will correct that mistake. So it's not the worst gap to have.
+                #
+                # Ideally we'd be able to do both in the same MERGE statement for maximum atomicity.
+                # But delta lake won't let us, as it tries to detect possibly undefined behavior,
+                # and a line like the following will trip on it, worried about updating multiple rows at once:
+                #  whenMatchedUpdateAll("table.id = updates.id").whenMatchedDelete().whenNotMatchedInsertAll()
+                #
+                # TODO: Once delta-spark 2.3 releases, we can do everything in one MERGE:
+                #  - step 1: gather all group_field values in the source dataframe
+                #  - step 2: add whenNotMatchedBySourceDelete(f"{group_field} in {all_source_values}")
+                table.alias("table").merge(
+                    updates.alias("updates"), f"table.{self.group_field} = updates.{self.group_field}"
+                ).whenMatchedDelete().execute()
 
-                    if group_field:
-                        # Delete any existing groups about to be overwritten. This leaves a small gap where if we
-                        # crash before inserting new rows, we will have deleted data without a replacement.
-                        # But a re-run of the ETL will correct that mistake. So it's not the worst gap to have.
-                        #
-                        # Ideally we'd be able to do both in the same MERGE statement for maximum atomicity.
-                        # But delta lake won't let us, as it tries to detect possibly undefined behavior,
-                        # and a line like the following will trip on it, worried about updating multiple rows at once:
-                        #  whenMatchedUpdateAll("table.id = updates.id").whenMatchedDelete().whenNotMatchedInsertAll()
-                        #
-                        # TODO: Once delta-spark 2.3 releases, we can do everything in one MERGE:
-                        #  - step 1: gather all group_field values in the source dataframe
-                        #  - step 2: add whenNotMatchedBySourceDelete(f"{group_field} in {all_source_values}")
-                        table.alias("table").merge(
-                            updates.alias("updates"), f"table.{group_field} = updates.{group_field}"
-                        ).whenMatchedDelete().execute()
+            # Merge in new data
+            table.alias("table").merge(
+                source=updates.alias("updates"), condition="table.id = updates.id"
+            ).whenMatchedUpdateAll().whenNotMatchedInsertAll().execute()
 
-                    # Merge in new data
-                    table.alias("table").merge(
-                        source=updates.alias("updates"), condition="table.id = updates.id"
-                    ).whenMatchedUpdateAll().whenNotMatchedInsertAll().execute()
+        except AnalysisException:
+            # table does not exist yet, let's make an initial version
+            updates.write.save(path=full_path, format="delta")
+            table = delta.DeltaTable.forPath(self.spark, full_path)
 
-                except AnalysisException:
-                    # table does not exist yet, let's make an initial version
-                    updates.write.save(path=full_path, format="delta")
-                    table = delta.DeltaTable.forPath(self.spark, full_path)  # re-load the table to generate symlink
+        return table
 
-            table.generate("symlink_format_manifest")
-
-            summary.success += len(dataframe)
-            summary.success_rate(1)
-        except Exception:  # pylint: disable=broad-except
-            logging.exception("Could not process data records")
-
-    def finalize(self, summary, dbname: str) -> None:
+    def finalize(self) -> None:
         """Performs any necessary cleanup after all batches have been written"""
-        full_path = self._table_path(dbname)
+        full_path = self._table_path(self.dbname)
 
         try:
             table = delta.DeltaTable.forPath(self.spark, full_path)
@@ -143,23 +143,24 @@ class DeltaLakeFormat(Format):
             return  # if the table doesn't exist because we didn't write anything, that's fine - just bail
 
         try:
-            table.optimize().executeCompaction()  # gather small files into larger files for better query performance
+            table.optimize().executeCompaction()  # pool small files for better query performance
             table.generate("symlink_format_manifest")
             table.vacuum()  # Clean up unused data files older than retention policy (default 7 days)
         except AnalysisException:
-            logging.exception("Could not finalize Delta Lake table %s", dbname)
+            logging.exception("Could not finalize Delta Lake table %s", self.dbname)
 
     def _table_path(self, dbname: str) -> str:
         return self.root.joinpath(dbname).replace("s3://", "s3a://")  # hadoop uses the s3a: scheme instead of s3:
 
-    def _configure_fs(self):
+    @staticmethod
+    def _configure_fs(root: store.Root, spark: pyspark.sql.SparkSession):
         """Tell spark/hadoop how to talk to S3 for us"""
-        fsspec_options = self.root.fsspec_options()
-        self.spark.conf.set("fs.s3a.sse.enabled", "true")
-        self.spark.conf.set("fs.s3a.server-side-encryption-algorithm", "SSE-KMS")
+        fsspec_options = root.fsspec_options()
+        spark.conf.set("fs.s3a.sse.enabled", "true")
+        spark.conf.set("fs.s3a.server-side-encryption-algorithm", "SSE-KMS")
         kms_key = fsspec_options.get("s3_additional_kwargs", {}).get("SSEKMSKeyId")
         if kms_key:
-            self.spark.conf.set("fs.s3a.server-side-encryption.key", kms_key)
+            spark.conf.set("fs.s3a.server-side-encryption.key", kms_key)
         region_name = fsspec_options.get("client_kwargs", {}).get("region_name")
         if region_name:
-            self.spark.conf.set("fs.s3a.endpoint.region", region_name)
+            spark.conf.set("fs.s3a.endpoint.region", region_name)

--- a/cumulus/formats/factory.py
+++ b/cumulus/formats/factory.py
@@ -1,0 +1,23 @@
+"""Create a Format instance"""
+
+from typing import Type
+
+from .base import Format
+from .deltalake import DeltaLakeFormat
+from .ndjson import NdjsonFormat
+from .parquet import ParquetFormat
+
+
+def get_format_class(name: str) -> Type[Format]:
+    """
+    Returns a Format class of the named type for the target output path.
+    """
+    classes = {
+        "deltalake": DeltaLakeFormat,
+        "ndjson": NdjsonFormat,
+        "parquet": ParquetFormat,
+    }
+    try:
+        return classes[name]
+    except KeyError as exc:
+        raise ValueError(f"Unknown output format name {name}.") from exc

--- a/cumulus/labelstudio.py
+++ b/cumulus/labelstudio.py
@@ -15,7 +15,7 @@ from cumulus import store
 ###############################################################################
 def merge_cohort(filepath) -> list:
     if not os.path.exists(filepath):
-        raise Exception(f"not found! {filepath}")
+        raise FileNotFoundError(f"not found! {filepath}")
 
     cohort = store.read_json(filepath).get("cohort")
 

--- a/tests/test_codebook.py
+++ b/tests/test_codebook.py
@@ -14,6 +14,7 @@ from cumulus.deid.codebook import Codebook, CodebookDB
 def assert_empty_db(db: CodebookDB):
     assert {
         "version": 1,
+        "id_salt": "31323334",
     } == db.settings
 
 
@@ -47,6 +48,7 @@ class TestCodebook(unittest.TestCase):
 
 
 @ddt.ddt
+@mock.patch("cumulus.deid.codebook.secrets.token_hex", new=lambda x: "31323334")
 class TestCodebookDB(unittest.TestCase):
     """Test case for the CodebookDB class"""
 
@@ -130,9 +132,7 @@ class TestCodebookDB(unittest.TestCase):
             # But after a save, we are no longer modified
             self.assertFalse(db.save(tmpdir))
 
-            # Resource hashes cause modification once
-            db.resource_hash("1")
-            self.assertTrue(db.save(tmpdir))
+            # Resource hashes don't cause modification
             db.resource_hash("1")
             self.assertFalse(db.save(tmpdir))
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -16,8 +16,6 @@ class TestConfigSummary(unittest.TestCase):
         summary = config.JobSummary("empty")
         expected = {
             "attempt": 0,
-            "csv": [],
-            "failed": [],
             "hostname": gethostname(),
             "label": "empty",
             "success": 0,


### PR DESCRIPTION
### Description

After doing some research on concurrency approaches (mostly looking at task and batch threading), the performance wins were inconclusive (when capping ourselves at a given memory usage).

But some of the refactoring along the way is valuable. These changes will make it easier to do future concurrency testing, and in some places are just fixing issues.

PYLINT:

- Update to pylint 2.16 changes

FORMATS:

- Hide the specific format classes behind a factory method
- Make each format instance be table-specific and take all its arguments at creation time, which makes it easier in the future to have separate threads own their instances (simplify locking) and makes the code cleaner
- Add a class-initialize method, which can be used to do any work that will be shared across format instances (i.e. initialize pysparks which is slow, and not sharable across processes)
- Bring the error handling up to the shared base class

CTAKES:

- Print the de-identified docref ID when an error happens

CODEBOOK:

- Initialize salt at creation time. This makes the codebook easier to share between threads in the future, and makes code easier to reason about.

CONFIG:

- Light cleanup to accept more primitive types, and instead generate the interesting ones (like formatters)
- Don't print status update as side effect of recording successful batch, but rather in the task main loop for clarity

TASKS:

- Filter NLP by emergency room before scrubbing, as an optimization
- Print fancier output (including a final message with cute stars), which can more easily be threaded in the future and still be understandable

### Output Changes

Tired:
```
###############################################################
condition:
success = 200,000 rate % 1.0
success = 370,317 rate % 1.0
###############################################################
documentreference:
ERROR:root:Could not find any files for DocumentReference in the input folder, skipping that resource.
###############################################################
encounter:
success = 200,000 rate % 1.0
success = 400,000 rate % 1.0
...
```

Wired:
```
###############################################################
condition:
  200,000 processed for condition
  370,317 processed for condition
  ⭐ done with condition (370,317 processed) ⭐
###############################################################
documentreference:
  ⭐ done with documentreference (0 processed) ⭐
###############################################################
encounter:
  200,000 processed for encounter
  400,000 processed for encounter
...
```
### Checklist
- [x] Consider if documentation (like in `docs/`) needs to be updated
- [x] Consider if tests should be added
