### PR TITLE
refactor: add asyncio support (mostly via httpx)

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-22.04
     strategy:
       matrix:
-        python-version: ["3.7", "3.8", "3.9", "3.10"]
+        python-version: ["3.8", "3.9", "3.10"]
 
     steps:
       - uses: actions/checkout@v3

--- a/cumulus/deid/mstool.py
+++ b/cumulus/deid/mstool.py
@@ -4,8 +4,8 @@ Code to support running Microsoft's Anonymizer tool
 See https://github.com/microsoft/Tools-for-Health-Data-Anonymization for more details.
 """
 
+import asyncio
 import os
-import subprocess  # nosec: B404
 import sys
 
 from cumulus import common, errors
@@ -17,28 +17,27 @@ def config_path() -> str:
     return os.path.join(os.path.dirname(__file__), "ms-config.json")
 
 
-def run_mstool(input_dir: str, output_dir: str) -> None:
+async def run_mstool(input_dir: str, output_dir: str) -> None:
     """
     Runs Microsoft's Anonymizer tool on the input directory and puts the results in the output directory
 
     The input must be in ndjson format. And the output will be as well.
     """
     common.print_header("De-identifying data...")
-    try:
-        # The following call only points at some temporary directory names (which we generate),
-        # so it should be safe, and we thus disable the security linter warning about validating inputs.
-        subprocess.run(  # nosec: subprocess_without_shell_equals_true
-            [
-                MSTOOL_CMD,
-                "--bulkData",
-                f"--configFile={config_path()}",
-                f"--inputFolder={input_dir}",
-                f"--outputFolder={output_dir}",
-            ],
-            capture_output=True,
-            check=True,
-            text=True,
+
+    process = await asyncio.create_subprocess_exec(
+        MSTOOL_CMD,
+        "--bulkData",
+        f"--configFile={config_path()}",
+        f"--inputFolder={input_dir}",
+        f"--outputFolder={output_dir}",
+        stdout=asyncio.subprocess.DEVNULL,
+        stderr=asyncio.subprocess.PIPE,
+    )
+    _, stderr = await process.communicate()
+
+    if process.returncode != 0:
+        print(
+            f"An error occurred while de-identifying the input resources:\n\n{stderr.decode('utf8')}", file=sys.stderr
         )
-    except subprocess.CalledProcessError as exc:
-        print(f"An error occurred while de-identifying the input resources:\n\n{exc.stderr}", file=sys.stderr)
-        raise SystemExit(errors.MSTOOL_FAILED) from exc
+        raise SystemExit(errors.MSTOOL_FAILED)

--- a/cumulus/deid/scrubber.py
+++ b/cumulus/deid/scrubber.py
@@ -35,7 +35,7 @@ class Scrubber:
         self.codebook_dir = codebook_dir
 
     @staticmethod
-    def scrub_bulk_data(input_dir: str) -> tempfile.TemporaryDirectory:
+    async def scrub_bulk_data(input_dir: str) -> tempfile.TemporaryDirectory:
         """
         Bulk de-identification of all input data
 
@@ -44,7 +44,7 @@ class Scrubber:
         :returns: a temporary directory holding the de-identified results, in FHIR ndjson format
         """
         tmpdir = tempfile.TemporaryDirectory()  # pylint: disable=consider-using-with
-        mstool.run_mstool(input_dir, tmpdir.name)
+        await mstool.run_mstool(input_dir, tmpdir.name)
         return tmpdir
 
     def scrub_resource(self, node: dict, scrub_attachments: bool = True) -> bool:

--- a/cumulus/loaders/base.py
+++ b/cumulus/loaders/base.py
@@ -24,7 +24,7 @@ class Loader(abc.ABC):
         self.root = root
 
     @abc.abstractmethod
-    def load_all(self, resources: List[str]) -> tempfile.TemporaryDirectory:
+    async def load_all(self, resources: List[str]) -> tempfile.TemporaryDirectory:
         """
         Loads the listed remote resources and places them into a local folder as FHIR ndjson
 

--- a/cumulus/loaders/i2b2/loader.py
+++ b/cumulus/loaders/i2b2/loader.py
@@ -39,7 +39,7 @@ class I2b2Loader(Loader):
         super().__init__(root)
         self.batch_size = batch_size
 
-    def load_all(self, resources: List[str]) -> tempfile.TemporaryDirectory:
+    async def load_all(self, resources: List[str]) -> tempfile.TemporaryDirectory:
         if self.root.protocol in ["tcp"]:
             return self._load_all_from_oracle(resources)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,11 +1,12 @@
 [project]
 name = "cumulus"
-requires-python = ">= 3.7"
+requires-python = ">= 3.8"
 dependencies = [
     "ctakesclient >= 1.3",
     "delta-spark >= 2.1",
     # This branch includes some jwt fixes we need (and will hopefully be in mainline in future)
     "fhirclient @ git+https://github.com/mikix/client-py.git@mikix/oauth2-jwt",
+    "httpx",
     "jwcrypto",
     "oracledb",
     "pandas",
@@ -58,6 +59,7 @@ tests = [
     "moto[s3]",
     "pytest",
     "responses",
+    "respx",
     "urllib3",
 ]
 dev = [

--- a/tests/test_i2b2_oracle_extract.py
+++ b/tests/test_i2b2_oracle_extract.py
@@ -9,7 +9,7 @@ from cumulus.loaders.i2b2.oracle import extract, query
 from tests import i2b2_mock_data
 
 
-class TestOracleExtraction(unittest.TestCase):
+class TestOracleExtraction(unittest.IsolatedAsyncioTestCase):
     """Test case for sql queries"""
 
     def setUp(self) -> None:
@@ -82,7 +82,7 @@ class TestOracleExtraction(unittest.TestCase):
         self.assertEqual([mock.call(query.sql_provider())], self.mock_execute.call_args_list)
 
     @mock.patch("cumulus.loaders.i2b2.loader.oracle_extract")
-    def test_loader(self, mock_extract):
+    async def test_loader(self, mock_extract):
         """Verify that when our i2b2 loader is given an Oracle URL, it runs SQL against it and drops it to ndjson"""
         mock_extract.list_observation_fact.return_value = [i2b2_mock_data.condition_dim()]
         mock_extract.list_patient.return_value = [i2b2_mock_data.patient_dim()]
@@ -90,7 +90,7 @@ class TestOracleExtraction(unittest.TestCase):
 
         root = store.Root("tcp://localhost/foo")
         oracle_loader = loader.I2b2Loader(root, 5)
-        tmpdir = oracle_loader.load_all(["Condition", "Encounter", "Patient"])
+        tmpdir = await oracle_loader.load_all(["Condition", "Encounter", "Patient"])
 
         # Check results
         self.assertEqual(

--- a/tests/test_mstool.py
+++ b/tests/test_mstool.py
@@ -14,35 +14,35 @@ from tests.utils import TreeCompareMixin
 
 
 @pytest.mark.skipif(not shutil.which(MSTOOL_CMD), reason="MS tool not installed")
-class TestMicrosoftTool(TreeCompareMixin, unittest.TestCase):
+class TestMicrosoftTool(TreeCompareMixin, unittest.IsolatedAsyncioTestCase):
     """Test case for the MS tool code (mostly testing our config file, really)"""
 
     def setUp(self):
         super().setUp()
         self.data_path = os.path.join(os.path.dirname(__file__), "data", "mstool")
 
-    def test_expected_transform(self):
+    async def test_expected_transform(self):
         """Confirms that our sample input data results in the correct output"""
         input_path = os.path.join(self.data_path, "input")
 
         with tempfile.TemporaryDirectory() as tmpdir:
-            run_mstool(input_path, tmpdir)
+            await run_mstool(input_path, tmpdir)
             expected_path = os.path.join(self.data_path, "output")
             dircmp = filecmp.dircmp(expected_path, tmpdir, ignore=[])
             self.assert_file_tree_equal(dircmp)
 
-    def test_invalid_syntax(self):
+    async def test_invalid_syntax(self):
         """Confirms that unparsable files throw an error"""
         with tempfile.TemporaryDirectory() as input_dir:
             with tempfile.TemporaryDirectory() as output_dir:
                 common.write_text(os.path.join(input_dir, "Condition.ndjson"), "foobar")
                 with self.assertRaises(SystemExit):
-                    run_mstool(input_dir, output_dir)
+                    await run_mstool(input_dir, output_dir)
 
-    def test_bad_fhir(self):
+    async def test_bad_fhir(self):
         """Confirms that parsable files with bad FHIR throw an error"""
         with tempfile.TemporaryDirectory() as input_dir:
             with tempfile.TemporaryDirectory() as output_dir:
                 common.write_json(os.path.join(input_dir, "Condition.ndjson"), {})
                 with self.assertRaises(SystemExit):
-                    run_mstool(input_dir, output_dir)
+                    await run_mstool(input_dir, output_dir)


### PR DESCRIPTION
### Description
This is not really used to much advantage yet, but will be once we parallelize some network calls.

A future PR will add concurrent http requests. So this PR is really just refactoring and adding async/await keywords all up and down the stack. No performance or functionality changes are expected from this.

Additionally:
- Bump minimum Python to 3.8 (for AsyncMock)
- Use httpx for async http support (and respx for mocks)

### Why `httpx`?

There are two major async http python libraries: `aiohttp` and `httpx`. This is not scientific, but they have 13k and 10k stars on github respectively. So both are huge, but `aiohttp` has a popularity edge.

And that's what I started with. But its test/mocking support was not as impressive as I wanted. It has two competing versions of the `responses` library, but neither allow you to match requests based on headers, only the URL path.

So I switched to `httpx`. It (a) is closer in API to `requests` and (b) has a really robust mocking library via `respx`.

### Python dep bump

As the commit message notes, I've bumped us to python3.8. I suspect Matt would say "why not just stick to one supported python version, 3.10". But the open source maintainer in me wants to keep supporting as much as possible. But I'm fine with dropping versions if it becomes even a little hard to support em (and here, I didn't want to have to work around the lack of `AsyncMock`).

### Checklist
- [x] Consider if documentation (like in `docs/`) needs to be updated
- [x] Consider if tests should be added
