### PR TITLE
feat: download multiple bulk export files at once

### DIFF
--- a/cumulus/common.py
+++ b/cumulus/common.py
@@ -160,6 +160,20 @@ def write_json(path: str, data: Any, indent: Optional[int] = None) -> None:
 ###############################################################################
 
 
+def human_file_size(count: int) -> str:
+    """
+    Returns a human-readable version of a count of bytes.
+
+    I couldn't find a version of this that's sitting in a library we use. Very annoying.
+    Pandas has one, but it's private.
+    """
+    for suffix in ("KB", "MB"):
+        count /= 1024
+        if count < 1024:
+            return f"{count:.1f}{suffix}"
+    return f"{count / 1024:.1f}GB"
+
+
 def info_mode():
     logging.basicConfig()
     logging.getLogger().setLevel(logging.INFO)

--- a/cumulus/etl.py
+++ b/cumulus/etl.py
@@ -246,7 +246,7 @@ async def main(args: List[str]):
         )
 
     # Check which tasks are being run, allowing comma-separated values
-    task_names = args.task and list(itertools.chain.from_iterable(t.split(",") for t in args.task))
+    task_names = args.task and set(itertools.chain.from_iterable(t.split(",") for t in args.task))
     task_filters = args.task_filter and list(itertools.chain.from_iterable(t.split(",") for t in args.task_filter))
     selected_tasks = tasks.EtlTask.get_selected_tasks(task_names, task_filters)
 

--- a/cumulus/loaders/fhir/backend_service.py
+++ b/cumulus/loaders/fhir/backend_service.py
@@ -202,7 +202,9 @@ class BackendServiceServer:
         self._session: Optional[httpx.AsyncClient] = None
 
     async def __aenter__(self):
-        self._session = httpx.AsyncClient()
+        # Limit the number of connections open at once, because EHRs tend to be very busy.
+        limits = httpx.Limits(max_connections=5)
+        self._session = httpx.AsyncClient(limits=limits)
         await self._auth.authorize(self._session)
         return self
 


### PR DESCRIPTION
### Description
Limited to five requests at once, to avoid annoying EHR operators. Plus a variety of fixes, listed below.

Bulk Export Errors/Messages:
- Use the right mimetype when downloading messages, which previously would just error out because of the wrong mimetype
- If there are multiple issues listed in a single OperationOutcome, print all of them
- Try more fallback messages, if the issue doesn't have a "diagnostic" field (namely, try the detail.text field then the code field)
- Don't treat warning or information messages as fatal, but still print them out

UX improvements:
- Print how long we are about to wait between status checks
- Print the server filename and size for downloaded files, in addition to our renamed local filename

Other:
- If the user accidentally names the same task multiple times on the CLI, don't run the task twice

<!--- Describe your changes in detail -->

### Checklist
- [x] Consider if documentation (like in `docs/`) needs to be updated
- [x] Consider if tests should be added
