### PR TITLE
feat: add --export-to=PATH to save bulk exports

### DIFF
--- a/cumulus/errors.py
+++ b/cumulus/errors.py
@@ -1,5 +1,8 @@
 """Exception classes and error handling"""
 
+import sys
+
+
 # Error return codes, mostly just distinguished for the benefit of tests.
 # These start at 10 just to leave some room for future use.
 SQL_USER_MISSING = 10
@@ -18,3 +21,11 @@ ARGS_CONFLICT = 22
 ARGS_INVALID = 23
 FHIR_URL_MISSING = 24
 BASIC_CREDENTIALS_MISSING = 25
+BULK_EXPORT_FOLDER_NOT_EMPTY = 26
+BULK_EXPORT_FOLDER_NOT_LOCAL = 27
+
+
+def fatal(message: str, status: int):
+    """Convenience method to exit the program with a user-friendly error message a test-friendly status code"""
+    print(message, file=sys.stderr)
+    sys.exit(status)  # raises a SystemExit exception

--- a/cumulus/etl.py
+++ b/cumulus/etl.py
@@ -187,6 +187,9 @@ def make_parser() -> argparse.ArgumentParser:
     auth.add_argument("--fhir-url", metavar="URL", help="FHIR server base URL, only needed if you exported separately")
 
     export = parser.add_argument_group("bulk export")
+    export.add_argument(
+        "--export-to", metavar="PATH", help="Where to put exported files (default is to delete after use)"
+    )
     export.add_argument("--since", help="Start date for export from the FHIR server")
     export.add_argument("--until", help="End date for export from the FHIR server")
 
@@ -279,7 +282,9 @@ async def main(args: List[str]):
         if args.input_format == "i2b2":
             config_loader = loaders.I2b2Loader(root_input, args.batch_size)
         else:
-            config_loader = loaders.FhirNdjsonLoader(root_input, client, since=args.since, until=args.until)
+            config_loader = loaders.FhirNdjsonLoader(
+                root_input, client, export_to=args.export_to, since=args.since, until=args.until
+            )
 
         # Pull down resources and run the MS tool on them
         deid_dir = await load_and_deidentify(config_loader, required_resources)

--- a/cumulus/loaders/__init__.py
+++ b/cumulus/loaders/__init__.py
@@ -1,5 +1,5 @@
 """Public API for loaders"""
 
 from .base import Loader
-from .fhir.fhir_ndjson import FhirNdjsonLoader
+from .fhir.ndjson_loader import FhirNdjsonLoader
 from .i2b2.loader import I2b2Loader

--- a/cumulus/loaders/base.py
+++ b/cumulus/loaders/base.py
@@ -1,10 +1,22 @@
 """Base abstract loader"""
 
 import abc
-import tempfile
-from typing import List
+from typing import List, Protocol
 
 from cumulus.store import Root
+
+
+# Loaders often want the ability to provide callers with a TemporaryDirectory -- a folder that will be deleted as soon
+# as the caller is done using it. However, some code flows may instead require returning a folder that already exists.
+# So for that use case, we define a Directory protocol for typing purposes, which looks like a TemporaryDirectory.
+# And then a RealDirectory class that does not delete its folder.
+class Directory(Protocol):
+    name: str
+
+
+class RealDirectory:
+    def __init__(self, path: str):
+        self.name = path
 
 
 class Loader(abc.ABC):
@@ -24,7 +36,7 @@ class Loader(abc.ABC):
         self.root = root
 
     @abc.abstractmethod
-    async def load_all(self, resources: List[str]) -> tempfile.TemporaryDirectory:
+    async def load_all(self, resources: List[str]) -> Directory:
         """
         Loads the listed remote resources and places them into a local folder as FHIR ndjson
 

--- a/cumulus/loaders/i2b2/loader.py
+++ b/cumulus/loaders/i2b2/loader.py
@@ -7,7 +7,7 @@ from functools import partial
 from typing import Callable, Iterable, List, TypeVar
 
 from cumulus import store
-from cumulus.loaders.base import Loader
+from cumulus.loaders.base import Directory, Loader
 from cumulus.loaders.i2b2 import extract, schema, transform
 from cumulus.loaders.i2b2.oracle import extract as oracle_extract
 
@@ -39,7 +39,7 @@ class I2b2Loader(Loader):
         super().__init__(root)
         self.batch_size = batch_size
 
-    async def load_all(self, resources: List[str]) -> tempfile.TemporaryDirectory:
+    async def load_all(self, resources: List[str]) -> Directory:
         if self.root.protocol in ["tcp"]:
             return self._load_all_from_oracle(resources)
 

--- a/docs/howtos/run-cumulus-etl.md
+++ b/docs/howtos/run-cumulus-etl.md
@@ -319,6 +319,28 @@ Note that support for these parameters among EHRs is not super common.
 But if you are lucky enough to be working with an EHR that supports either one,
 you can pass in a time like `--since=2023-01-16T20:32:48Z`.
 
+#### Saving Bulk Export Files
+
+Bulk exports can be tricky to get right and can take a long time.
+Sometimes (and especially when first experimenting with Cumulus ETL),
+you will want to save the results of a bulk export for inspection or in case Cumulus ETL fails.
+
+By default, Cumulus ETL throws away the results of a bulk export once it's done with them.
+But you can pass `--export-to=/path/to/folder` to instead save the exported `.ndjson` files in the given folder.
+
+Note that you'll want to expose the local path to docker so that the files reach your actual disk, like so:
+
+```sh
+docker compose \
+  run --rm \
+  --volume /my/exported/files:/folder \
+  cumulus-etl \
+  --export-to=/folder \
+  https://my-fhir-server/ \
+  s3://output/ \
+  s3://phi/
+```
+
 #### External Bulk Export
 
 Instead of using Cumulus ETL to drive your bulk export itself, you can instead do the bulk export externally,

--- a/tests/test_bulk_export.py
+++ b/tests/test_bulk_export.py
@@ -3,560 +3,20 @@
 import contextlib
 import io
 import tempfile
-import time
 import unittest
 from json import dumps
 from unittest import mock
 
 import ddt
 import freezegun
-import httpx
 import responses
 import respx
-from jwcrypto import jwk, jwt
+from jwcrypto import jwk
 
-from cumulus import common, errors, etl, loaders, store
-from cumulus.fhir_client import FatalError, FhirClient
+from cumulus import common, etl, store
+from cumulus.fhir_client import FatalError
 from cumulus.loaders.fhir.bulk_export import BulkExporter
-
-
-def make_response(status_code=200, json=None, text=None, reason=None, headers=None, stream=False):
-    """Makes a fake response for ease of testing"""
-    headers = dict(headers or {})
-    headers.setdefault("Content-Type", "application/json" if json else "text/plain; charset=utf-8")
-    json = dumps(json) if json else None
-    body = (json or text or "").encode("utf8")
-    stream_contents = None
-    if stream:
-        stream_contents = httpx.ByteStream(body)
-        body = None
-    return respx.MockResponse(
-        status_code=status_code,
-        content=body,
-        stream=stream_contents,
-        extensions=reason and {"reason_phrase": reason.encode("utf8")},
-        headers=headers or {},
-        request=httpx.Request("GET", "fake_request_url"),
-    )
-
-
-class TestBulkEtl(unittest.IsolatedAsyncioTestCase):
-    """
-    Test case for bulk export support in the etl pipeline and ndjson loader.
-
-    i.e. tests for etl.py & fhir_ndjson.py
-
-    This does no actual bulk loading.
-    """
-
-    def setUp(self):
-        super().setUp()
-        self.jwks_file = tempfile.NamedTemporaryFile()  # pylint: disable=consider-using-with
-        self.jwks_path = self.jwks_file.name
-        self.jwks_file.write(b'{"fake":"jwks"}')
-        self.jwks_file.flush()
-
-        # Mock out the bulk export code by default. We don't care about actually doing any
-        # bulk work in this test case, just confirming the flow.
-        exporter_patcher = mock.patch("cumulus.loaders.fhir.fhir_ndjson.BulkExporter", spec=BulkExporter)
-        self.addCleanup(exporter_patcher.stop)
-        self.mock_exporter_class = exporter_patcher.start()
-        self.mock_exporter = mock.AsyncMock()
-        self.mock_exporter_class.return_value = self.mock_exporter
-
-    @mock.patch("cumulus.etl.fhir_client.FhirClient")
-    @mock.patch("cumulus.etl.loaders.FhirNdjsonLoader")
-    async def test_etl_passes_args(self, mock_loader, mock_client):
-        """Verify that we are passed the client ID and JWKS from the command line"""
-        mock_loader.side_effect = ValueError  # just to stop the etl pipeline once we get this far
-
-        with self.assertRaises(ValueError):
-            await etl.main(
-                [
-                    "http://localhost:9999",
-                    "/tmp/output",
-                    "/tmp/phi",
-                    "--skip-init-checks",
-                    "--input-format=ndjson",
-                    "--smart-client-id=x",
-                    f"--smart-jwks={self.jwks_path}",
-                    "--since=2018",
-                    "--until=2020",
-                ]
-            )
-
-        self.assertEqual(1, mock_client.call_count)
-        self.assertEqual("x", mock_client.call_args[1]["smart_client_id"])
-        self.assertEqual({"fake": "jwks"}, mock_client.call_args[1]["smart_jwks"])
-        self.assertEqual(1, mock_loader.call_count)
-        self.assertEqual("2018", mock_loader.call_args[1]["since"])
-        self.assertEqual("2020", mock_loader.call_args[1]["until"])
-
-    @mock.patch("cumulus.etl.fhir_client.FhirClient")
-    async def test_reads_client_id_from_file(self, mock_client):
-        """Verify that we try to read a client ID from a file."""
-        mock_client.side_effect = ValueError  # just to stop the etl pipeline once we get this far
-
-        # First, confirm string is used directly if file doesn't exist
-        with self.assertRaises(ValueError):
-            await etl.main(
-                [
-                    "http://localhost:9999",
-                    "/tmp/output",
-                    "/tmp/phi",
-                    "--skip-init-checks",
-                    "--smart-client-id=/direct-string",
-                ]
-            )
-        self.assertEqual("/direct-string", mock_client.call_args[1]["smart_client_id"])
-
-        # Now read from a file that exists
-        with tempfile.NamedTemporaryFile(buffering=0) as file:
-            file.write(b"\ninside-file\n")
-            with self.assertRaises(ValueError):
-                await etl.main(
-                    [
-                        "http://localhost:9999",
-                        "/tmp/output",
-                        "/tmp/phi",
-                        "--skip-init-checks",
-                        f"--smart-client-id={file.name}",
-                    ]
-                )
-            self.assertEqual("inside-file", mock_client.call_args[1]["smart_client_id"])
-
-    @mock.patch("cumulus.etl.fhir_client.FhirClient")
-    async def test_reads_bearer_token(self, mock_client):
-        """Verify that we read the bearer token file"""
-        mock_client.side_effect = ValueError  # just to stop the etl pipeline once we get this far
-
-        with tempfile.NamedTemporaryFile(buffering=0) as file:
-            file.write(b"\ninside-file\n")
-            with self.assertRaises(ValueError):
-                await etl.main(
-                    [
-                        "http://localhost:9999",
-                        "/tmp/output",
-                        "/tmp/phi",
-                        "--skip-init-checks",
-                        f"--bearer-token={file.name}",
-                    ]
-                )
-            self.assertEqual("inside-file", mock_client.call_args[1]["bearer_token"])
-
-    @mock.patch("cumulus.etl.fhir_client.FhirClient")
-    async def test_reads_basic_auth(self, mock_client):
-        """Verify that we read the basic password file and pass it along"""
-        mock_client.side_effect = ValueError  # just to stop the etl pipeline once we get this far
-
-        with tempfile.NamedTemporaryFile(buffering=0) as file:
-            file.write(b"\ninside-file\n")
-            with self.assertRaises(ValueError):
-                await etl.main(
-                    [
-                        "http://localhost:9999",
-                        "/tmp/output",
-                        "/tmp/phi",
-                        "--skip-init-checks",
-                        "--basic-user=UserName",
-                        f"--basic-passwd={file.name}",
-                    ]
-                )
-
-        self.assertEqual("UserName", mock_client.call_args[1]["basic_user"])
-        self.assertEqual("inside-file", mock_client.call_args[1]["basic_password"])
-
-    @mock.patch("cumulus.etl.fhir_client.FhirClient")
-    async def test_fhir_url(self, mock_client):
-        """Verify that we handle the user provided --fhir-client correctly"""
-        mock_client.side_effect = ValueError  # just to stop the etl pipeline once we get this far
-
-        # Confirm that we don't allow conflicting URLs
-        with self.assertRaises(SystemExit):
-            await etl.main(
-                [
-                    "http://localhost:9999",
-                    "/tmp/output",
-                    "/tmp/phi",
-                    "--skip-init-checks",
-                    "--fhir-url=https://example.com/hello",
-                ]
-            )
-
-        # But a subset --fhir-url is fine
-        with self.assertRaises(ValueError):
-            await etl.main(
-                [
-                    "https://example.com/hello/Group/1234",
-                    "/tmp/output",
-                    "/tmp/phi",
-                    "--skip-init-checks",
-                    "--fhir-url=https://example.com/hello",
-                ]
-            )
-        self.assertEqual("https://example.com/hello/Group/1234", mock_client.call_args[0][0])
-
-        # Now do a normal use of --fhir-url
-        mock_client.side_effect = ValueError  # just to stop the etl pipeline once we get this far
-        with self.assertRaises(ValueError):
-            await etl.main(
-                [
-                    "/tmp/input",
-                    "/tmp/output",
-                    "/tmp/phi",
-                    "--skip-init-checks",
-                    "--fhir-url=https://example.com/hello",
-                ]
-            )
-        self.assertEqual("https://example.com/hello", mock_client.call_args[0][0])
-
-    @mock.patch("cumulus.etl.fhir_client.FhirClient")
-    async def test_export_flow(self, mock_client):
-        """
-        Verify that we make the right calls down as far as the bulk export helper classes, with the right resources.
-        """
-        self.mock_exporter.export.side_effect = ValueError  # stop us when we get this far, but also confirm we call it
-
-        with self.assertRaises(ValueError):
-            await etl.main(
-                [
-                    "http://localhost:9999",
-                    "/tmp/output",
-                    "/tmp/phi",
-                    "--skip-init-checks",
-                    "--task=condition,encounter",
-                ]
-            )
-
-        expected_resources = {"Condition", "Encounter"}
-        self.assertEqual(1, mock_client.call_count)
-        self.assertEqual(expected_resources, mock_client.call_args[0][1])
-        self.assertEqual(1, self.mock_exporter_class.call_count)
-        self.assertEqual(expected_resources, set(self.mock_exporter_class.call_args[0][1]))
-
-    async def test_fatal_errors_are_fatal(self):
-        """Verify that when a FatalError is raised, we do really quit"""
-        self.mock_exporter.export.side_effect = FatalError
-
-        with self.assertRaises(SystemExit) as cm:
-            await loaders.FhirNdjsonLoader(store.Root("http://localhost:9999"), mock.AsyncMock()).load_all(["Patient"])
-
-        self.assertEqual(1, self.mock_exporter.export.call_count)
-        self.assertEqual(errors.BULK_EXPORT_FAILED, cm.exception.code)
-
-
-@ddt.ddt
-@freezegun.freeze_time("Sep 15th, 2021 1:23:45")
-@mock.patch("cumulus.fhir_client.uuid.uuid4", new=lambda: "1234")
-class TestBulkServer(unittest.IsolatedAsyncioTestCase):
-    """
-    Test case for bulk export server oauth2 / request support.
-
-    i.e. tests for backend_service.py
-    """
-
-    def setUp(self):
-        super().setUp()
-
-        # By default, set up a working server and auth. Tests can break things as needed.
-
-        self.client_id = "my-client-id"
-        self.jwk = jwk.JWK.generate(kty="RSA", alg="RS384", kid="a", key_ops=["sign", "verify"]).export(as_dict=True)
-        self.jwks = {"keys": [self.jwk]}
-        self.server_url = "https://example.com/fhir"
-        self.token_url = "https://auth.example.com/token"
-
-        # Generate expected JWT
-        token = jwt.JWT(
-            header={
-                "alg": "RS384",
-                "kid": "a",
-                "typ": "JWT",
-            },
-            claims={
-                "iss": self.client_id,
-                "sub": self.client_id,
-                "aud": self.token_url,
-                "exp": int(time.time()) + 299,  # aided by freezegun not changing time under us
-                "jti": "1234",
-            },
-        )
-        token.make_signed_token(key=jwk.JWK(**self.jwk))
-        self.expected_jwt = token.serialize()
-
-        # Initialize responses mock
-        self.respx_mock = respx.mock(assert_all_called=False)
-        self.addCleanup(self.respx_mock.stop)
-        self.respx_mock.start()
-
-        # We ask for smart-configuration to discover the token endpoint
-        self.smart_configuration = {
-            "capabilities": ["client-confidential-asymmetric"],
-            "token_endpoint": self.token_url,
-            "token_endpoint_auth_methods_supported": ["private_key_jwt"],
-            "token_endpoint_auth_signing_alg_values_supported": ["RS384"],
-        }
-        self.respx_mock.get(
-            f"{self.server_url}/.well-known/smart-configuration",
-            headers={"Accept": "application/json"},
-        ).respond(
-            json=self.smart_configuration,
-        )
-
-        # Set up mocks for fhirclient (we don't need to test its oauth code by mocking server responses there)
-        self.mock_client = mock.MagicMock()  # FHIRClient instance
-        self.mock_server = self.mock_client.server  # FHIRServer instance
-        client_patcher = mock.patch("cumulus.fhir_client.fhirclient.client.FHIRClient")
-        self.addCleanup(client_patcher.stop)
-        self.mock_client_class = client_patcher.start()  # FHIRClient class
-        self.mock_client_class.return_value = self.mock_client
-
-    @staticmethod
-    def mock_session(server, *args, **kwargs):
-        session = mock.AsyncMock(spec=httpx.AsyncClient)
-        session.send.return_value = make_response(*args, **kwargs)
-        return mock.patch.object(server, "_session", session)
-
-    async def test_required_arguments(self):
-        """Verify that we require both a client ID and a JWK Set"""
-        # Deny any actual requests during this test
-        self.respx_mock.get(f"{self.server_url}/test").respond(status_code=401)
-
-        # Simple helper to open and make a call on client.
-        async def use_client(request=False, code=None, url=self.server_url, **kwargs):
-            try:
-                async with FhirClient(url, [], **kwargs) as client:
-                    if request:
-                        await client.request("GET", "test")
-            except SystemExit as exc:
-                if code is None:
-                    raise
-                self.assertEqual(code, exc.code)
-
-        # No SMART args at all doesn't cause any problem, if we don't make calls
-        await use_client()
-
-        # No SMART args at all will raise though if we do make a call
-        await use_client(code=errors.SMART_CREDENTIALS_MISSING, request=True)
-
-        # No client ID
-        await use_client(code=errors.FHIR_URL_MISSING, request=True, url=None)
-
-        # No JWKS
-        await use_client(code=errors.SMART_CREDENTIALS_MISSING, smart_client_id="foo")
-
-        # No client ID
-        await use_client(code=errors.SMART_CREDENTIALS_MISSING, smart_jwks=self.jwks)
-
-        # Works fine if both given
-        await use_client(smart_client_id="foo", smart_jwks=self.jwks)
-
-    async def test_auth_initial_authorize(self):
-        """Verify that we authorize correctly upon class initialization"""
-        async with FhirClient(
-            self.server_url, ["Condition", "Patient"], smart_client_id=self.client_id, smart_jwks=self.jwks
-        ):
-            pass
-
-        # Check initialization of FHIRClient
-        self.assertListEqual(
-            [
-                mock.call(
-                    settings={
-                        "api_base": f"{self.server_url}/",
-                        "app_id": self.client_id,
-                        "jwt_token": self.expected_jwt,
-                        "scope": "system/Condition.read system/Patient.read",
-                    }
-                )
-            ],
-            self.mock_client_class.call_args_list,
-        )
-
-        # Check authorization calls to FHIRClient
-        self.assertFalse(self.mock_client.wants_patient)  # otherwise fhirclient adds scopes
-        self.assertListEqual([mock.call()], self.mock_client.prepare.call_args_list)
-        self.assertListEqual([mock.call()], self.mock_client.authorize.call_args_list)
-
-    async def test_auth_with_bearer_token(self):
-        """Verify that we pass along the bearer token to the server"""
-        self.respx_mock.get(
-            f"{self.server_url}/foo",
-            headers={"Authorization": "Bearer fob"},
-        )
-
-        async with FhirClient(self.server_url, ["Condition", "Patient"], bearer_token="fob") as server:
-            await server.request("GET", "foo")
-
-    async def test_auth_with_basic_auth(self):
-        """Verify that we pass along the basic user/password to the server"""
-        self.respx_mock.get(
-            f"{self.server_url}/foo",
-            headers={"Authorization": "Basic VXNlcjpwNHNzdzByZA=="},
-        )
-
-        async with FhirClient(self.server_url, [], basic_user="User", basic_password="p4ssw0rd") as server:
-            await server.request("GET", "foo")
-
-    async def test_get_with_new_header(self):
-        """Verify that we issue a GET correctly for the happy path"""
-        # This is mostly confirming that we call mocks correctly, but that's important since we're mocking out all
-        # of fhirclient. Since we do that, we need to confirm we're driving it well.
-
-        async with FhirClient(self.server_url, [], smart_client_id=self.client_id, smart_jwks=self.jwks) as server:
-            with self.mock_session(server) as mock_session:
-                # With new header and stream
-                await server.request("GET", "foo", headers={"Test": "Value"}, stream=True)
-
-        self.assertEqual(
-            [
-                mock.call(
-                    {
-                        "Accept": "application/fhir+json",
-                        "Accept-Charset": "UTF-8",
-                        "Test": "Value",
-                    }
-                )
-            ],
-            self.mock_server.auth.signed_headers.call_args_list,
-        )
-        self.assertEqual(
-            [
-                mock.call(
-                    "GET",
-                    f"{self.server_url}/foo",
-                    headers=self.mock_server.auth.signed_headers.return_value,
-                )
-            ],
-            mock_session.build_request.call_args_list,
-        )
-
-    async def test_get_with_overriden_header(self):
-        """Verify that we issue a GET correctly for the happy path"""
-        async with FhirClient(self.server_url, [], smart_client_id=self.client_id, smart_jwks=self.jwks) as server:
-            with self.mock_session(server) as mock_session:
-                # With overriding a header and default stream (False)
-                await server.request("GET", "bar", headers={"Accept": "text/plain"})
-
-        self.assertEqual(
-            [
-                mock.call(
-                    {
-                        "Accept": "text/plain",
-                        "Accept-Charset": "UTF-8",
-                    }
-                )
-            ],
-            self.mock_server.auth.signed_headers.call_args_list,
-        )
-        self.assertEqual(
-            [
-                mock.call(
-                    "GET",
-                    f"{self.server_url}/bar",
-                    headers=self.mock_server.auth.signed_headers.return_value,
-                )
-            ],
-            mock_session.build_request.call_args_list,
-        )
-
-    @ddt.data(
-        {},  # no keys
-        {"keys": [{"alg": "RS384"}]},  # no key op
-        {"keys": [{"alg": "RS384", "key_ops": ["verify"], "kid": "a"}]},  # bad key op
-        {"keys": [{"alg": "RS128", "key_ops": ["sign"]}], "kid": "a"},  # bad algo
-        {"keys": [{"alg": "RS384", "key_ops": ["sign"]}]},  # no kid
-    )
-    async def test_jwks_without_suitable_key(self, bad_jwks):
-        with self.assertRaisesRegex(FatalError, "No private ES384 or RS384 key found"):
-            async with FhirClient(self.server_url, [], smart_client_id=self.client_id, smart_jwks=bad_jwks):
-                pass
-
-    @ddt.data(
-        {"token_endpoint_auth_methods_supported": None},
-        {"token_endpoint_auth_methods_supported": ["nope"]},
-        {"token_endpoint_auth_signing_alg_values_supported": None},
-        {"token_endpoint_auth_signing_alg_values_supported": ["nope"]},
-        {"token_endpoint": None},
-        {"token_endpoint": ""},
-    )
-    async def test_bad_smart_config(self, bad_config_override):
-        """Verify that we require fully correct smart configurations."""
-        for entry, value in bad_config_override.items():
-            if value is None:
-                del self.smart_configuration[entry]
-            else:
-                self.smart_configuration[entry] = value
-
-        self.respx_mock.reset()
-        self.respx_mock.get(
-            f"{self.server_url}/.well-known/smart-configuration",
-            headers={"Accept": "application/json"},
-        ).respond(
-            json=self.smart_configuration,
-        )
-
-        with self.assertRaisesRegex(FatalError, "does not support the client-confidential-asymmetric protocol"):
-            async with FhirClient(self.server_url, [], smart_client_id=self.client_id, smart_jwks=self.jwks):
-                pass
-
-    async def test_authorize_error_with_response(self):
-        """Verify that we translate authorize http response errors into FatalErrors."""
-        error = Exception()
-        error.response = mock.MagicMock()
-        error.response.json.return_value = {"error_description": "Ouch!"}
-        self.mock_client.authorize.side_effect = error
-        with self.assertRaisesRegex(FatalError, "Could not authenticate with the FHIR server: Ouch!"):
-            async with FhirClient(self.server_url, [], smart_client_id=self.client_id, smart_jwks=self.jwks):
-                pass
-
-    async def test_authorize_error_without_response(self):
-        """Verify that we translate authorize non-response errors into FatalErrors."""
-        self.mock_client.authorize.side_effect = Exception("no memory")
-        with self.assertRaisesRegex(FatalError, "Could not authenticate with the FHIR server: no memory"):
-            async with FhirClient(self.server_url, [], smart_client_id=self.client_id, smart_jwks=self.jwks):
-                pass
-
-    async def test_get_error_401(self):
-        """Verify that an expired token is refreshed."""
-        async with FhirClient(self.server_url, [], smart_client_id=self.client_id, smart_jwks=self.jwks) as server:
-            # Check that we correctly tried to re-authenticate
-            with self.mock_session(server) as mock_session:
-                mock_session.send.side_effect = [make_response(status_code=401), make_response()]
-                self.mock_server.reauthorize.return_value = None  # fhirclient gives None if there is no refresh token
-                response = await server.request("GET", "foo")
-                self.assertEqual(200, response.status_code)
-
-        self.assertEqual(1, self.mock_server.reauthorize.call_count)
-        self.assertEqual(2, self.mock_client_class.call_count)
-        self.assertEqual(2, self.mock_client.prepare.call_count)
-        self.assertEqual(2, self.mock_client.authorize.call_count)
-
-    async def test_get_error_429(self):
-        """Verify that 429 errors are passed through and not treated as exceptions."""
-        async with FhirClient(self.server_url, [], smart_client_id=self.client_id, smart_jwks=self.jwks) as server:
-            # Confirm 429 passes
-            with self.mock_session(server, status_code=429):
-                response = await server.request("GET", "foo")
-                self.assertEqual(429, response.status_code)
-
-            # Sanity check that 430 does not
-            with self.mock_session(server, status_code=430):
-                with self.assertRaises(FatalError):
-                    await server.request("GET", "foo")
-
-    @ddt.data(
-        {"json": {"resourceType": "OperationOutcome", "issue": [{"diagnostics": "testmsg"}]}},  # OperationOutcome
-        {"json": {"issue": [{"diagnostics": "msg"}]}, "reason": "testmsg"},  # non-OperationOutcome json
-        {"text": "testmsg"},  # just pure text content
-        {"reason": "testmsg"},
-    )
-    async def test_get_error_other(self, response_args):
-        """Verify that other http errors are FatalErrors."""
-        async with FhirClient(self.server_url, [], smart_client_id=self.client_id, smart_jwks=self.jwks) as server:
-            with self.mock_session(server, status_code=500, **response_args):
-                with self.assertRaisesRegex(FatalError, "testmsg"):
-                    await server.request("GET", "foo")
+from tests.utils import make_response
 
 
 @ddt.ddt
@@ -586,7 +46,7 @@ class TestBulkExporter(unittest.IsolatedAsyncioTestCase):
         self.server.request.side_effect = [
             make_response(status_code=202, headers={"Content-Location": "https://example.com/poll"}),  # kickoff
             make_response(
-                json={
+                json_payload={
                     "output": [
                         {"type": "Condition", "url": "https://example.com/con1"},
                         {"type": "Condition", "url": "https://example.com/con2"},
@@ -594,9 +54,9 @@ class TestBulkExporter(unittest.IsolatedAsyncioTestCase):
                     ]
                 }
             ),  # status
-            make_response(json={"type": "Condition1"}, stream=True),  # download
-            make_response(json={"type": "Condition2"}, stream=True),  # download
-            make_response(json={"type": "Patient1"}, stream=True),  # download
+            make_response(json_payload={"type": "Condition1"}, stream=True),  # download
+            make_response(json_payload={"type": "Condition2"}, stream=True),  # download
+            make_response(json_payload={"type": "Patient1"}, stream=True),  # download
             make_response(status_code=202),  # delete request
         ]
 
@@ -651,7 +111,7 @@ class TestBulkExporter(unittest.IsolatedAsyncioTestCase):
         self.server.request.side_effect = [
             make_response(status_code=202, headers={"Content-Location": "https://example.com/poll"}),  # kickoff
             make_response(
-                json={
+                json_payload={
                     "error": [
                         {"type": "OperationOutcome", "url": "https://example.com/err1"},
                         {"type": "OperationOutcome", "url": "https://example.com/err2"},
@@ -662,7 +122,9 @@ class TestBulkExporter(unittest.IsolatedAsyncioTestCase):
                 }
             ),  # status
             # errors
-            make_response(json={"type": "OperationOutcome", "issue": [{"severity": "error", "diagnostics": "err1"}]}),
+            make_response(
+                json_payload={"type": "OperationOutcome", "issue": [{"severity": "error", "diagnostics": "err1"}]}
+            ),
             make_response(
                 text='{"type": "OperationOutcome", "issue": [{"severity": "fatal", "details": {"text": "err2"}}]}\n'
                 '{"type": "OperationOutcome", "issue": [{"severity": "warning", "diagnostics": "warning1"}]}\n'
@@ -695,7 +157,7 @@ class TestBulkExporter(unittest.IsolatedAsyncioTestCase):
         self.server.request.side_effect = [
             make_response(status_code=202, headers={"Content-Location": "https://example.com/poll"}),  # kickoff
             make_response(
-                json={
+                json_payload={
                     "error": [
                         {"type": "OperationOutcome", "url": "https://example.com/warning1"},
                     ],
@@ -703,7 +165,7 @@ class TestBulkExporter(unittest.IsolatedAsyncioTestCase):
             ),  # status
             # warning
             make_response(
-                json={"type": "OperationOutcome", "issue": [{"severity": "warning", "diagnostics": "warning1"}]}
+                json_payload={"type": "OperationOutcome", "issue": [{"severity": "warning", "diagnostics": "warning1"}]}
             ),
             make_response(status_code=202),  # delete request
         ]

--- a/tests/test_fhir_client.py
+++ b/tests/test_fhir_client.py
@@ -1,0 +1,331 @@
+"""Tests for FhirClient and similar"""
+
+import time
+import unittest
+from unittest import mock
+
+import ddt
+import freezegun
+import httpx
+import respx
+from jwcrypto import jwk, jwt
+
+from cumulus import errors
+from cumulus.fhir_client import FatalError, FhirClient
+from tests.utils import make_response
+
+
+@ddt.ddt
+@freezegun.freeze_time("Sep 15th, 2021 1:23:45")
+@mock.patch("cumulus.fhir_client.uuid.uuid4", new=lambda: "1234")
+class TestBulkServer(unittest.IsolatedAsyncioTestCase):
+    """
+    Test case for bulk export server oauth2 / request support.
+
+    i.e. tests for backend_service.py
+    """
+
+    def setUp(self):
+        super().setUp()
+
+        # By default, set up a working server and auth. Tests can break things as needed.
+
+        self.client_id = "my-client-id"
+        self.jwk = jwk.JWK.generate(kty="RSA", alg="RS384", kid="a", key_ops=["sign", "verify"]).export(as_dict=True)
+        self.jwks = {"keys": [self.jwk]}
+        self.server_url = "https://example.com/fhir"
+        self.token_url = "https://auth.example.com/token"
+
+        # Generate expected JWT
+        token = jwt.JWT(
+            header={
+                "alg": "RS384",
+                "kid": "a",
+                "typ": "JWT",
+            },
+            claims={
+                "iss": self.client_id,
+                "sub": self.client_id,
+                "aud": self.token_url,
+                "exp": int(time.time()) + 299,  # aided by freezegun not changing time under us
+                "jti": "1234",
+            },
+        )
+        token.make_signed_token(key=jwk.JWK(**self.jwk))
+        self.expected_jwt = token.serialize()
+
+        # Initialize responses mock
+        self.respx_mock = respx.mock(assert_all_called=False)
+        self.addCleanup(self.respx_mock.stop)
+        self.respx_mock.start()
+
+        # We ask for smart-configuration to discover the token endpoint
+        self.smart_configuration = {
+            "capabilities": ["client-confidential-asymmetric"],
+            "token_endpoint": self.token_url,
+            "token_endpoint_auth_methods_supported": ["private_key_jwt"],
+            "token_endpoint_auth_signing_alg_values_supported": ["RS384"],
+        }
+        self.respx_mock.get(
+            f"{self.server_url}/.well-known/smart-configuration",
+            headers={"Accept": "application/json"},
+        ).respond(
+            json=self.smart_configuration,
+        )
+
+        # Set up mocks for fhirclient (we don't need to test its oauth code by mocking server responses there)
+        self.mock_client = mock.MagicMock()  # FHIRClient instance
+        self.mock_server = self.mock_client.server  # FHIRServer instance
+        client_patcher = mock.patch("cumulus.fhir_client.fhirclient.client.FHIRClient")
+        self.addCleanup(client_patcher.stop)
+        self.mock_client_class = client_patcher.start()  # FHIRClient class
+        self.mock_client_class.return_value = self.mock_client
+
+    @staticmethod
+    def mock_session(server, *args, **kwargs):
+        session = mock.AsyncMock(spec=httpx.AsyncClient)
+        session.send.return_value = make_response(*args, **kwargs)
+        return mock.patch.object(server, "_session", session)
+
+    async def test_required_arguments(self):
+        """Verify that we require both a client ID and a JWK Set"""
+        # Deny any actual requests during this test
+        self.respx_mock.get(f"{self.server_url}/test").respond(status_code=401)
+
+        # Simple helper to open and make a call on client.
+        async def use_client(request=False, code=None, url=self.server_url, **kwargs):
+            try:
+                async with FhirClient(url, [], **kwargs) as client:
+                    if request:
+                        await client.request("GET", "test")
+            except SystemExit as exc:
+                if code is None:
+                    raise
+                self.assertEqual(code, exc.code)
+
+        # No SMART args at all doesn't cause any problem, if we don't make calls
+        await use_client()
+
+        # No SMART args at all will raise though if we do make a call
+        await use_client(code=errors.SMART_CREDENTIALS_MISSING, request=True)
+
+        # No client ID
+        await use_client(code=errors.FHIR_URL_MISSING, request=True, url=None)
+
+        # No JWKS
+        await use_client(code=errors.SMART_CREDENTIALS_MISSING, smart_client_id="foo")
+
+        # No client ID
+        await use_client(code=errors.SMART_CREDENTIALS_MISSING, smart_jwks=self.jwks)
+
+        # Works fine if both given
+        await use_client(smart_client_id="foo", smart_jwks=self.jwks)
+
+    async def test_auth_initial_authorize(self):
+        """Verify that we authorize correctly upon class initialization"""
+        async with FhirClient(
+            self.server_url, ["Condition", "Patient"], smart_client_id=self.client_id, smart_jwks=self.jwks
+        ):
+            pass
+
+        # Check initialization of FHIRClient
+        self.assertListEqual(
+            [
+                mock.call(
+                    settings={
+                        "api_base": f"{self.server_url}/",
+                        "app_id": self.client_id,
+                        "jwt_token": self.expected_jwt,
+                        "scope": "system/Condition.read system/Patient.read",
+                    }
+                )
+            ],
+            self.mock_client_class.call_args_list,
+        )
+
+        # Check authorization calls to FHIRClient
+        self.assertFalse(self.mock_client.wants_patient)  # otherwise fhirclient adds scopes
+        self.assertListEqual([mock.call()], self.mock_client.prepare.call_args_list)
+        self.assertListEqual([mock.call()], self.mock_client.authorize.call_args_list)
+
+    async def test_auth_with_bearer_token(self):
+        """Verify that we pass along the bearer token to the server"""
+        self.respx_mock.get(
+            f"{self.server_url}/foo",
+            headers={"Authorization": "Bearer fob"},
+        )
+
+        async with FhirClient(self.server_url, ["Condition", "Patient"], bearer_token="fob") as server:
+            await server.request("GET", "foo")
+
+    async def test_auth_with_basic_auth(self):
+        """Verify that we pass along the basic user/password to the server"""
+        self.respx_mock.get(
+            f"{self.server_url}/foo",
+            headers={"Authorization": "Basic VXNlcjpwNHNzdzByZA=="},
+        )
+
+        async with FhirClient(self.server_url, [], basic_user="User", basic_password="p4ssw0rd") as server:
+            await server.request("GET", "foo")
+
+    async def test_get_with_new_header(self):
+        """Verify that we issue a GET correctly for the happy path"""
+        # This is mostly confirming that we call mocks correctly, but that's important since we're mocking out all
+        # of fhirclient. Since we do that, we need to confirm we're driving it well.
+
+        async with FhirClient(self.server_url, [], smart_client_id=self.client_id, smart_jwks=self.jwks) as server:
+            with self.mock_session(server) as mock_session:
+                # With new header and stream
+                await server.request("GET", "foo", headers={"Test": "Value"}, stream=True)
+
+        self.assertEqual(
+            [
+                mock.call(
+                    {
+                        "Accept": "application/fhir+json",
+                        "Accept-Charset": "UTF-8",
+                        "Test": "Value",
+                    }
+                )
+            ],
+            self.mock_server.auth.signed_headers.call_args_list,
+        )
+        self.assertEqual(
+            [
+                mock.call(
+                    "GET",
+                    f"{self.server_url}/foo",
+                    headers=self.mock_server.auth.signed_headers.return_value,
+                )
+            ],
+            mock_session.build_request.call_args_list,
+        )
+
+    async def test_get_with_overriden_header(self):
+        """Verify that we issue a GET correctly for the happy path"""
+        async with FhirClient(self.server_url, [], smart_client_id=self.client_id, smart_jwks=self.jwks) as server:
+            with self.mock_session(server) as mock_session:
+                # With overriding a header and default stream (False)
+                await server.request("GET", "bar", headers={"Accept": "text/plain"})
+
+        self.assertEqual(
+            [
+                mock.call(
+                    {
+                        "Accept": "text/plain",
+                        "Accept-Charset": "UTF-8",
+                    }
+                )
+            ],
+            self.mock_server.auth.signed_headers.call_args_list,
+        )
+        self.assertEqual(
+            [
+                mock.call(
+                    "GET",
+                    f"{self.server_url}/bar",
+                    headers=self.mock_server.auth.signed_headers.return_value,
+                )
+            ],
+            mock_session.build_request.call_args_list,
+        )
+
+    @ddt.data(
+        {},  # no keys
+        {"keys": [{"alg": "RS384"}]},  # no key op
+        {"keys": [{"alg": "RS384", "key_ops": ["verify"], "kid": "a"}]},  # bad key op
+        {"keys": [{"alg": "RS128", "key_ops": ["sign"]}], "kid": "a"},  # bad algo
+        {"keys": [{"alg": "RS384", "key_ops": ["sign"]}]},  # no kid
+    )
+    async def test_jwks_without_suitable_key(self, bad_jwks):
+        with self.assertRaisesRegex(FatalError, "No private ES384 or RS384 key found"):
+            async with FhirClient(self.server_url, [], smart_client_id=self.client_id, smart_jwks=bad_jwks):
+                pass
+
+    @ddt.data(
+        {"token_endpoint_auth_methods_supported": None},
+        {"token_endpoint_auth_methods_supported": ["nope"]},
+        {"token_endpoint_auth_signing_alg_values_supported": None},
+        {"token_endpoint_auth_signing_alg_values_supported": ["nope"]},
+        {"token_endpoint": None},
+        {"token_endpoint": ""},
+    )
+    async def test_bad_smart_config(self, bad_config_override):
+        """Verify that we require fully correct smart configurations."""
+        for entry, value in bad_config_override.items():
+            if value is None:
+                del self.smart_configuration[entry]
+            else:
+                self.smart_configuration[entry] = value
+
+        self.respx_mock.reset()
+        self.respx_mock.get(
+            f"{self.server_url}/.well-known/smart-configuration",
+            headers={"Accept": "application/json"},
+        ).respond(
+            json=self.smart_configuration,
+        )
+
+        with self.assertRaisesRegex(FatalError, "does not support the client-confidential-asymmetric protocol"):
+            async with FhirClient(self.server_url, [], smart_client_id=self.client_id, smart_jwks=self.jwks):
+                pass
+
+    async def test_authorize_error_with_response(self):
+        """Verify that we translate authorize http response errors into FatalErrors."""
+        error = Exception()
+        error.response = mock.MagicMock()
+        error.response.json.return_value = {"error_description": "Ouch!"}
+        self.mock_client.authorize.side_effect = error
+        with self.assertRaisesRegex(FatalError, "Could not authenticate with the FHIR server: Ouch!"):
+            async with FhirClient(self.server_url, [], smart_client_id=self.client_id, smart_jwks=self.jwks):
+                pass
+
+    async def test_authorize_error_without_response(self):
+        """Verify that we translate authorize non-response errors into FatalErrors."""
+        self.mock_client.authorize.side_effect = Exception("no memory")
+        with self.assertRaisesRegex(FatalError, "Could not authenticate with the FHIR server: no memory"):
+            async with FhirClient(self.server_url, [], smart_client_id=self.client_id, smart_jwks=self.jwks):
+                pass
+
+    async def test_get_error_401(self):
+        """Verify that an expired token is refreshed."""
+        async with FhirClient(self.server_url, [], smart_client_id=self.client_id, smart_jwks=self.jwks) as server:
+            # Check that we correctly tried to re-authenticate
+            with self.mock_session(server) as mock_session:
+                mock_session.send.side_effect = [make_response(status_code=401), make_response()]
+                self.mock_server.reauthorize.return_value = None  # fhirclient gives None if there is no refresh token
+                response = await server.request("GET", "foo")
+                self.assertEqual(200, response.status_code)
+
+        self.assertEqual(1, self.mock_server.reauthorize.call_count)
+        self.assertEqual(2, self.mock_client_class.call_count)
+        self.assertEqual(2, self.mock_client.prepare.call_count)
+        self.assertEqual(2, self.mock_client.authorize.call_count)
+
+    async def test_get_error_429(self):
+        """Verify that 429 errors are passed through and not treated as exceptions."""
+        async with FhirClient(self.server_url, [], smart_client_id=self.client_id, smart_jwks=self.jwks) as server:
+            # Confirm 429 passes
+            with self.mock_session(server, status_code=429):
+                response = await server.request("GET", "foo")
+                self.assertEqual(429, response.status_code)
+
+            # Sanity check that 430 does not
+            with self.mock_session(server, status_code=430):
+                with self.assertRaises(FatalError):
+                    await server.request("GET", "foo")
+
+    @ddt.data(
+        {
+            "json_payload": {"resourceType": "OperationOutcome", "issue": [{"diagnostics": "testmsg"}]}
+        },  # OperationOutcome
+        {"json_payload": {"issue": [{"diagnostics": "msg"}]}, "reason": "testmsg"},  # non-OperationOutcome json
+        {"text": "testmsg"},  # just pure text content
+        {"reason": "testmsg"},
+    )
+    async def test_get_error_other(self, response_args):
+        """Verify that other http errors are FatalErrors."""
+        async with FhirClient(self.server_url, [], smart_client_id=self.client_id, smart_jwks=self.jwks) as server:
+            with self.mock_session(server, status_code=500, **response_args):
+                with self.assertRaisesRegex(FatalError, "testmsg"):
+                    await server.request("GET", "foo")

--- a/tests/test_ndjson_loader.py
+++ b/tests/test_ndjson_loader.py
@@ -1,0 +1,241 @@
+"""Tests for ndjson loading (both bulk export and local)"""
+
+import os
+import tempfile
+import unittest
+from unittest import mock
+
+from cumulus import errors, etl, loaders, store
+from cumulus.fhir_client import FatalError
+from cumulus.loaders.fhir.bulk_export import BulkExporter
+
+
+class TestNdjsonLoader(unittest.IsolatedAsyncioTestCase):
+    """
+    Test case for the etl pipeline and ndjson loader.
+
+    i.e. tests for etl.py & ndjson_loader.py
+
+    This does no actual bulk loading.
+    """
+
+    def setUp(self):
+        super().setUp()
+        self.jwks_file = tempfile.NamedTemporaryFile()  # pylint: disable=consider-using-with
+        self.jwks_path = self.jwks_file.name
+        self.jwks_file.write(b'{"fake":"jwks"}')
+        self.jwks_file.flush()
+
+        # Mock out the bulk export code by default. We don't care about actually doing any
+        # bulk work in this test case, just confirming the flow.
+        exporter_patcher = mock.patch("cumulus.loaders.fhir.ndjson_loader.BulkExporter", spec=BulkExporter)
+        self.addCleanup(exporter_patcher.stop)
+        self.mock_exporter_class = exporter_patcher.start()
+        self.mock_exporter = mock.AsyncMock()
+        self.mock_exporter_class.return_value = self.mock_exporter
+
+    @mock.patch("cumulus.etl.fhir_client.FhirClient")
+    @mock.patch("cumulus.etl.loaders.FhirNdjsonLoader")
+    async def test_etl_passes_args(self, mock_loader, mock_client):
+        """Verify that we are passed the client ID and JWKS from the command line"""
+        mock_loader.side_effect = ValueError  # just to stop the etl pipeline once we get this far
+
+        with self.assertRaises(ValueError):
+            await etl.main(
+                [
+                    "http://localhost:9999",
+                    "/tmp/output",
+                    "/tmp/phi",
+                    "--skip-init-checks",
+                    "--input-format=ndjson",
+                    "--smart-client-id=x",
+                    f"--smart-jwks={self.jwks_path}",
+                    "--export-to=/tmp/exported",
+                    "--since=2018",
+                    "--until=2020",
+                ]
+            )
+
+        self.assertEqual(1, mock_client.call_count)
+        self.assertEqual("x", mock_client.call_args[1]["smart_client_id"])
+        self.assertEqual({"fake": "jwks"}, mock_client.call_args[1]["smart_jwks"])
+        self.assertEqual(1, mock_loader.call_count)
+        self.assertEqual("/tmp/exported", mock_loader.call_args[1]["export_to"])
+        self.assertEqual("2018", mock_loader.call_args[1]["since"])
+        self.assertEqual("2020", mock_loader.call_args[1]["until"])
+
+    @mock.patch("cumulus.etl.fhir_client.FhirClient")
+    async def test_reads_client_id_from_file(self, mock_client):
+        """Verify that we try to read a client ID from a file."""
+        mock_client.side_effect = ValueError  # just to stop the etl pipeline once we get this far
+
+        # First, confirm string is used directly if file doesn't exist
+        with self.assertRaises(ValueError):
+            await etl.main(
+                [
+                    "http://localhost:9999",
+                    "/tmp/output",
+                    "/tmp/phi",
+                    "--skip-init-checks",
+                    "--smart-client-id=/direct-string",
+                ]
+            )
+        self.assertEqual("/direct-string", mock_client.call_args[1]["smart_client_id"])
+
+        # Now read from a file that exists
+        with tempfile.NamedTemporaryFile(buffering=0) as file:
+            file.write(b"\ninside-file\n")
+            with self.assertRaises(ValueError):
+                await etl.main(
+                    [
+                        "http://localhost:9999",
+                        "/tmp/output",
+                        "/tmp/phi",
+                        "--skip-init-checks",
+                        f"--smart-client-id={file.name}",
+                    ]
+                )
+            self.assertEqual("inside-file", mock_client.call_args[1]["smart_client_id"])
+
+    @mock.patch("cumulus.etl.fhir_client.FhirClient")
+    async def test_reads_bearer_token(self, mock_client):
+        """Verify that we read the bearer token file"""
+        mock_client.side_effect = ValueError  # just to stop the etl pipeline once we get this far
+
+        with tempfile.NamedTemporaryFile(buffering=0) as file:
+            file.write(b"\ninside-file\n")
+            with self.assertRaises(ValueError):
+                await etl.main(
+                    [
+                        "http://localhost:9999",
+                        "/tmp/output",
+                        "/tmp/phi",
+                        "--skip-init-checks",
+                        f"--bearer-token={file.name}",
+                    ]
+                )
+            self.assertEqual("inside-file", mock_client.call_args[1]["bearer_token"])
+
+    @mock.patch("cumulus.etl.fhir_client.FhirClient")
+    async def test_reads_basic_auth(self, mock_client):
+        """Verify that we read the basic password file and pass it along"""
+        mock_client.side_effect = ValueError  # just to stop the etl pipeline once we get this far
+
+        with tempfile.NamedTemporaryFile(buffering=0) as file:
+            file.write(b"\ninside-file\n")
+            with self.assertRaises(ValueError):
+                await etl.main(
+                    [
+                        "http://localhost:9999",
+                        "/tmp/output",
+                        "/tmp/phi",
+                        "--skip-init-checks",
+                        "--basic-user=UserName",
+                        f"--basic-passwd={file.name}",
+                    ]
+                )
+
+        self.assertEqual("UserName", mock_client.call_args[1]["basic_user"])
+        self.assertEqual("inside-file", mock_client.call_args[1]["basic_password"])
+
+    @mock.patch("cumulus.etl.fhir_client.FhirClient")
+    async def test_fhir_url(self, mock_client):
+        """Verify that we handle the user provided --fhir-client correctly"""
+        mock_client.side_effect = ValueError  # just to stop the etl pipeline once we get this far
+
+        # Confirm that we don't allow conflicting URLs
+        with self.assertRaises(SystemExit):
+            await etl.main(
+                [
+                    "http://localhost:9999",
+                    "/tmp/output",
+                    "/tmp/phi",
+                    "--skip-init-checks",
+                    "--fhir-url=https://example.com/hello",
+                ]
+            )
+
+        # But a subset --fhir-url is fine
+        with self.assertRaises(ValueError):
+            await etl.main(
+                [
+                    "https://example.com/hello/Group/1234",
+                    "/tmp/output",
+                    "/tmp/phi",
+                    "--skip-init-checks",
+                    "--fhir-url=https://example.com/hello",
+                ]
+            )
+        self.assertEqual("https://example.com/hello/Group/1234", mock_client.call_args[0][0])
+
+        # Now do a normal use of --fhir-url
+        mock_client.side_effect = ValueError  # just to stop the etl pipeline once we get this far
+        with self.assertRaises(ValueError):
+            await etl.main(
+                [
+                    "/tmp/input",
+                    "/tmp/output",
+                    "/tmp/phi",
+                    "--skip-init-checks",
+                    "--fhir-url=https://example.com/hello",
+                ]
+            )
+        self.assertEqual("https://example.com/hello", mock_client.call_args[0][0])
+
+    @mock.patch("cumulus.etl.fhir_client.FhirClient")
+    async def test_export_flow(self, mock_client):
+        """
+        Verify that we make the right calls down as far as the bulk export helper classes, with the right resources.
+        """
+        self.mock_exporter.export.side_effect = ValueError  # stop us when we get this far, but also confirm we call it
+
+        with self.assertRaises(ValueError):
+            await etl.main(
+                [
+                    "http://localhost:9999",
+                    "/tmp/output",
+                    "/tmp/phi",
+                    "--skip-init-checks",
+                    "--task=condition,encounter",
+                ]
+            )
+
+        expected_resources = {"Condition", "Encounter"}
+        self.assertEqual(1, mock_client.call_count)
+        self.assertEqual(expected_resources, mock_client.call_args[0][1])
+        self.assertEqual(1, self.mock_exporter_class.call_count)
+        self.assertEqual(expected_resources, set(self.mock_exporter_class.call_args[0][1]))
+
+    async def test_fatal_errors_are_fatal(self):
+        """Verify that when a FatalError is raised, we do really quit"""
+        self.mock_exporter.export.side_effect = FatalError
+
+        with self.assertRaises(SystemExit) as cm:
+            await loaders.FhirNdjsonLoader(store.Root("http://localhost:9999"), mock.AsyncMock()).load_all(["Patient"])
+
+        self.assertEqual(1, self.mock_exporter.export.call_count)
+        self.assertEqual(errors.BULK_EXPORT_FAILED, cm.exception.code)
+
+    async def test_export_to_folder_happy_path(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            target = f"{tmpdir}/target"
+            loader = loaders.FhirNdjsonLoader(store.Root("http://localhost:9999"), mock.AsyncMock(), export_to=target)
+            folder = await loader.load_all([])
+
+            self.assertTrue(os.path.isdir(target))  # confirm it got created
+            self.assertEqual(target, self.mock_exporter_class.call_args[0][2])
+            self.assertEqual(target, folder.name)
+
+    def test_export_to_folder_has_contents(self):
+        """Verify we fail if an export folder already has contents"""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            os.mkdir(f"{tmpdir}/stuff")
+            with self.assertRaises(SystemExit) as cm:
+                loaders.FhirNdjsonLoader(store.Root("http://localhost:9999"), mock.AsyncMock(), export_to=tmpdir)
+        self.assertEqual(cm.exception.code, errors.BULK_EXPORT_FOLDER_NOT_EMPTY)
+
+    def test_export_to_folder_not_local(self):
+        """Verify we fail if an export folder is not local"""
+        with self.assertRaises(SystemExit) as cm:
+            loaders.FhirNdjsonLoader(store.Root("http://localhost:9999"), mock.AsyncMock(), export_to="http://foo/")
+        self.assertEqual(cm.exception.code, errors.BULK_EXPORT_FOLDER_NOT_LOCAL)


### PR DESCRIPTION
### Description
This offers a way to save the results of a bulk export locally, rather that deleting them when done with them.

Useful for debugging or archiving.

<!--- Describe your changes in detail -->

### Checklist
- [x] Consider if documentation (like in `docs/`) needs to be updated
- [x] Consider if tests should be added
