### PR TITLE
fix: don't skip resources with contained references

### DIFF
--- a/cumulus/deid/codebook.py
+++ b/cumulus/deid/codebook.py
@@ -5,6 +5,7 @@ import hmac
 import logging
 import os
 import secrets
+from typing import Optional
 
 from cumulus import common
 
@@ -27,7 +28,7 @@ class Codebook:
         except (FileNotFoundError, PermissionError):
             self.db = CodebookDB()
 
-    def fake_id(self, resource_type: str, real_id: str) -> str:
+    def fake_id(self, resource_type: Optional[str], real_id: str) -> str:
         """
         Returns a new fake ID in place of the provided real ID
 

--- a/cumulus/deid/scrubber.py
+++ b/cumulus/deid/scrubber.py
@@ -134,7 +134,14 @@ class Scrubber:
         # "reference" can sometimes be a URL or non-FHIRReference element -- at some point we'll need to be smarter.
         elif key == "reference":
             resource_type, real_id = fhir_common.unref_resource(node)
-            fake_id = self.codebook.fake_id(resource_type, real_id)
+
+            # Handle contained references (see comments in unref_resource for more detail)
+            prefix = ""
+            if real_id.startswith("#"):
+                prefix = "#"
+                real_id = real_id[1:]
+
+            fake_id = f"{prefix}{self.codebook.fake_id(resource_type, real_id)}"
             node["reference"] = fhir_common.ref_resource(resource_type, fake_id)["reference"]
 
     @staticmethod

--- a/cumulus/etl.py
+++ b/cumulus/etl.py
@@ -97,7 +97,7 @@ def check_ctakes() -> None:
     if not is_url_available(ctakes_url):
         print(
             f"A running cTAKES server was not found at:\n    {ctakes_url}\n\n"
-            "Please set the URL_CTAKES_REST environment variable to your server.",
+            "Please set the URL_CTAKES_REST environment variable or start the docker support services.",
             file=sys.stderr,
         )
         raise SystemExit(errors.CTAKES_MISSING)
@@ -112,7 +112,7 @@ def check_cnlpt() -> None:
     if not is_url_available(cnlpt_url):
         print(
             f"A running cNLP transformers server was not found at:\n    {cnlpt_url}\n\n"
-            "Please set the URL_CNLP_NEGATION environment variable to your server.",
+            "Please set the URL_CNLP_NEGATION environment variable or start the docker support services.",
             file=sys.stderr,
         )
         raise SystemExit(errors.CNLPT_MISSING)

--- a/cumulus/fhir_common.py
+++ b/cumulus/fhir_common.py
@@ -1,6 +1,7 @@
 """FHIR utility methods"""
 
 import re
+from typing import Optional
 
 # A relative reference is something like Patient/123 or Patient?identifier=http://hl7.org/fhir/sid/us-npi|9999999299
 # (vs a contained reference that starts with # or an absolute URL reference like http://example.org/Patient/123)
@@ -13,7 +14,7 @@ RELATIVE_SEPARATOR_REGEX = re.compile("[/?]")
 ###############################################################################
 
 
-def ref_resource(resource_type: str, resource_id: str) -> dict:
+def ref_resource(resource_type: Optional[str], resource_id: str) -> dict:
     """
     Reference the FHIR proper way
     :param resource_type: Name of resource, like "Patient"
@@ -22,10 +23,10 @@ def ref_resource(resource_type: str, resource_id: str) -> dict:
     """
     if not resource_id:
         raise ValueError("Missing resource ID")
-    return {"reference": f"{resource_type}/{resource_id}"}
+    return {"reference": f"{resource_type}/{resource_id}" if resource_type else resource_id}
 
 
-def unref_resource(ref: dict) -> (str, str):
+def unref_resource(ref: dict) -> (Optional[str], str):
     """
     Returns the type & ID for the target of the reference
 
@@ -35,11 +36,23 @@ def unref_resource(ref: dict) -> (str, str):
 
     Raises ValueError if the reference could not be understood
     """
-    # FIXME: Support contained resources like '#p1' and absolute resources like
-    #        http://fhir.hl7.org/svc/StructureDefinition/c8973a22-2b5b-4e76-9c66-00639c99e61b
-    if not ref or not ref.get("reference") or ref["reference"].startswith("#"):
+    if not ref or not ref.get("reference"):
         raise ValueError(f'Reference type not handled: "{ref}"')
 
+    if ref["reference"].startswith("#"):
+        # This is a contained reference (internal reference to or from the toplevel resource / contained resources).
+        # See https://www.hl7.org/fhir/references.html#contained for more info.
+        #
+        # We don't need to support these super well, since they aren't used for cross-reference joining.
+        # In particular, we don't need to care about the resource type, since we don't need to record any of these
+        # in the codebook for debugging, which is the primary purpose of grabbing the resource type.
+        # In fact, we don't even want to try to grab the "type" field, since we shouldn't record these in the codebook
+        # or attempt to merge the type and id like "Patient/#123".
+        #
+        # We include the pound sign in the returned ID string, to allow others to detect this case.
+        return None, ref["reference"]
+
+    # FIXME: Support absolute resources like http://fhir.hl7.org/svc/StructureDefinition/c8973a22
     if not RELATIVE_REFERENCE_REGEX.match(ref["reference"]) and not ref.get("type"):
         raise ValueError(f'Unrecognized reference: "{ref["reference"]}"')
 

--- a/tests/test_fhir_common.py
+++ b/tests/test_fhir_common.py
@@ -14,6 +14,7 @@ class TestReferenceHandlers(unittest.TestCase):
     @ddt.data(
         ({"reference": "Patient/123"}, "Patient", "123"),
         ({"reference": "123", "type": "Patient"}, "Patient", "123"),
+        ({"reference": "#123"}, None, "#123"),
         # Synthea style reference
         ({"reference": "Patient?identifier=http://example.com|123"}, "Patient", "identifier=http://example.com|123"),
     )
@@ -25,7 +26,6 @@ class TestReferenceHandlers(unittest.TestCase):
     @ddt.data(
         None,
         "",
-        "#Contained/123",
         "123",  # with no type field
         "?/123",
         "http://example.com/Patient/123",
@@ -34,5 +34,10 @@ class TestReferenceHandlers(unittest.TestCase):
         with self.assertRaises(ValueError):
             fhir_common.unref_resource({"reference": reference})
 
-    def test_ref_resource(self):
-        self.assertEqual({"reference": "Patient/123"}, fhir_common.ref_resource("Patient", "123"))
+    @ddt.data(
+        ("Patient", "123", "Patient/123"),
+        (None, "#123", "#123"),
+    )
+    @ddt.unpack
+    def test_ref_resource(self, resource_type, resource_id, expected):
+        self.assertEqual({"reference": expected}, fhir_common.ref_resource(resource_type, resource_id))

--- a/tests/test_scrubber.py
+++ b/tests/test_scrubber.py
@@ -70,6 +70,17 @@ class TestScrubber(unittest.TestCase):
         )
         self.assertNotIn("data", docref["content"][0]["attachment"])
 
+    def test_contained_reference(self):
+        """Verify that we leave contained references contained"""
+        scrubber = Scrubber()
+        condition = i2b2_mock_data.condition()
+        condition["subject"]["reference"] = "#p12"
+
+        self.assertTrue(scrubber.scrub_resource(condition))
+        self.assertEqual(
+            "#221044b59936243b79da55c551b0c60ec7278733dde4acf65f83468cbd64bd0f", condition["subject"]["reference"]
+        )
+
     def test_unknown_modifier_extension(self):
         """Confirm we skip resources with unknown modifier extensions"""
         patient = i2b2_mock_data.patient()


### PR DESCRIPTION
### Description
Instead, we hash the reference in place and keep going. Contained references are not likely to be well-supported downstream, but that's fine for now. This at least keeps us from ignoring valid resources.

(We were seeing some of these in Encounter.location references -- which we don't care about, but the error from the unhandled reference was causing the whole encounter resource to be skipped -- which I think is good behavior in general, but we can fix that specific instance here.)

<!--- Describe your changes in detail -->

### Checklist
- [x] Consider if documentation (like in `docs/`) needs to be updated
- [x] Consider if tests should be added
