### PR TITLE
fix: use the correct base FHIR URL when downloading attachments

### DIFF
--- a/cumulus/etl.py
+++ b/cumulus/etl.py
@@ -6,6 +6,7 @@ import itertools
 import json
 import logging
 import os
+import re
 import shutil
 import socket
 import sys
@@ -217,7 +218,12 @@ def create_fhir_client(args, root_input, resources):
                 file=sys.stderr,
             )
             raise SystemExit(errors.ARGS_CONFLICT)
-        client_base_url = root_input.path
+        elif not client_base_url:
+            # Use the input URL as the base URL. But note that it may not be the server root.
+            # For example, it may be a Group export URL. Let's try to find the actual root.
+            client_base_url = root_input.path
+            client_base_url = re.sub(r"/Patient/?$", "/", client_base_url)
+            client_base_url = re.sub(r"/Group/[^/]+/?$", "/", client_base_url)
 
     try:
         try:

--- a/cumulus/loaders/fhir/ndjson_loader.py
+++ b/cumulus/loaders/fhir/ndjson_loader.py
@@ -96,7 +96,9 @@ class FhirNdjsonLoader(base.Loader):
             target_dir = tempfile.TemporaryDirectory()  # pylint: disable=consider-using-with
 
         try:
-            bulk_exporter = BulkExporter(self.client, resources, target_dir.name, self.since, self.until)
+            bulk_exporter = BulkExporter(
+                self.client, resources, self.root.path, target_dir.name, self.since, self.until
+            )
             await bulk_exporter.export()
         except FatalError as exc:
             errors.fatal(str(exc), errors.BULK_EXPORT_FAILED)

--- a/tests/test_bulk_export.py
+++ b/tests/test_bulk_export.py
@@ -34,7 +34,7 @@ class TestBulkExporter(unittest.IsolatedAsyncioTestCase):
         self.server = mock.AsyncMock()
 
     def make_exporter(self, **kwargs) -> BulkExporter:
-        return BulkExporter(self.server, ["Condition", "Patient"], self.tmpdir.name, **kwargs)
+        return BulkExporter(self.server, ["Condition", "Patient"], "https://localhost/", self.tmpdir.name, **kwargs)
 
     async def export(self, **kwargs) -> BulkExporter:
         exporter = self.make_exporter(**kwargs)
@@ -66,7 +66,7 @@ class TestBulkExporter(unittest.IsolatedAsyncioTestCase):
             [
                 mock.call(
                     "GET",
-                    "$export?_type=Condition%2CPatient",
+                    "https://localhost/$export?_type=Condition%2CPatient",
                     headers={"Prefer": "respond-async"},
                 ),
                 mock.call("GET", "https://example.com/poll", headers={"Accept": "application/json"}),
@@ -99,7 +99,8 @@ class TestBulkExporter(unittest.IsolatedAsyncioTestCase):
             [
                 mock.call(
                     "GET",
-                    "$export?_type=Condition%2CPatient&_since=2000-01-01T00%3A00%3A00%2B00.00&_until=2010",
+                    "https://localhost/$export?"
+                    "_type=Condition%2CPatient&_since=2000-01-01T00%3A00%3A00%2B00.00&_until=2010",
                     headers={"Prefer": "respond-async"},
                 ),
             ],
@@ -141,7 +142,7 @@ class TestBulkExporter(unittest.IsolatedAsyncioTestCase):
             [
                 mock.call(
                     "GET",
-                    "$export?_type=Condition%2CPatient",
+                    "https://localhost/$export?_type=Condition%2CPatient",
                     headers={"Prefer": "respond-async"},
                 ),
                 mock.call("GET", "https://example.com/poll", headers={"Accept": "application/json"}),
@@ -227,7 +228,7 @@ class TestBulkExporter(unittest.IsolatedAsyncioTestCase):
             [
                 mock.call(
                     "GET",
-                    "$export?_type=Condition%2CPatient",
+                    "https://localhost/$export?_type=Condition%2CPatient",
                     headers={"Prefer": "respond-async"},
                 ),
                 mock.call("GET", "https://example.com/poll", headers={"Accept": "application/json"}),


### PR DESCRIPTION
### Description
If you are doing a bulk export, the wrong base URL was being used for attachments. It worked correctly for already-downloaded ndjson, but not for a live export.

The fix is basically to preserve the input URL for `BulkExporter`, but everywhere else use the root server URL.

In addition, this PR now always respects `--fhir-url`, as long as it doesn't actively conflict with the input URL. This is more of a defensive programming thing than a real fix. The above bug would have had a workaround of passing `--fhir-url` if this behavior had already been in place.

<!--- Describe your changes in detail -->

### Checklist
- [x] Consider if documentation (like in `docs/`) needs to be updated
- [x] Consider if tests should be added
