### PR TITLE
feat: disable philter by default, add --philter to enable

### DIFF
--- a/cumulus/deid/scrubber.py
+++ b/cumulus/deid/scrubber.py
@@ -30,10 +30,10 @@ class Scrubber:
        the resource is fully de-identified.
     """
 
-    def __init__(self, codebook_dir: str = None):
+    def __init__(self, codebook_dir: str = None, use_philter: bool = False):
         self.codebook = codebook.Codebook(codebook_dir)
         self.codebook_dir = codebook_dir
-        self.philter = philter.Philter()
+        self.philter = philter.Philter() if use_philter else None
 
     @staticmethod
     async def scrub_bulk_data(input_dir: str) -> tempfile.TemporaryDirectory:
@@ -77,7 +77,7 @@ class Scrubber:
         :param text: the text to scrub
         :returns: the scrubbed text, with PHI replaced by asterisks ("*")
         """
-        return self.philter.scrub_text(text)
+        return self.philter.scrub_text(text) if self.philter else text
 
     def save(self) -> None:
         """Saves any resources used to persist across runs (like the codebook)"""

--- a/docs/explanations/deid.md
+++ b/docs/explanations/deid.md
@@ -135,7 +135,7 @@ So Cumulus does not bother keeping a mapping for those.
 ### Freeform Text Fields
 
 There are some freeform text fields that Cumulus ETS asks the Microsoft Anonymizer tool to leave in.
-These fields may be useful for presenting or computing a phenotype:
+These fields are useful for presenting or computing a phenotype:
 - `CodeableConcept.text`
 - `Coding.display`
 - `Observation.valueString` and `Observation.component.valueString`
@@ -143,8 +143,11 @@ These fields may be useful for presenting or computing a phenotype:
 Although Cumulus wants to largely preserve these fields,
 they may contain PHI since they are freeform text fields after all.
 
-So to reduce that risk, the [philter program](https://github.com/SironaMedical/philter-lite) is run on the text,
-which replaces any detected PHI like names, phone numbers, MRNs, social security numbers, etc. with asterisks.
+If that is likely for your institution, you can have Cumulus ETL run
+[philter](https://github.com/SironaMedical/philter-lite) over these freeform fields, by passing `--philter`.
+This replaces any detected PHI like names, phone numbers, MRNs, social security numbers, etc. with asterisks.
+
+But be warned that it will significantly slow down the ETL process.
 
 ### NLP on Physician Notes
 

--- a/tests/test_etl.py
+++ b/tests/test_etl.py
@@ -61,6 +61,7 @@ class BaseI2b2EtlSimple(CtakesMixin, TreeCompareMixin, unittest.IsolatedAsyncioT
         comment=None,
         batch_size=None,
         tasks=None,
+        philter=True,
     ) -> None:
         args = [
             input_path or self.input_path,
@@ -78,6 +79,8 @@ class BaseI2b2EtlSimple(CtakesMixin, TreeCompareMixin, unittest.IsolatedAsyncioT
             args.append(f"--batch-size={batch_size}")
         if tasks:
             args.append(f'--task={",".join(tasks)}')
+        if philter:
+            args.append("--philter")
         await etl.main(args)
 
     def enforce_consistent_uuids(self):

--- a/tests/test_philter.py
+++ b/tests/test_philter.py
@@ -15,7 +15,7 @@ class TestPhilter(unittest.IsolatedAsyncioTestCase):
 
     def setUp(self):
         super().setUp()
-        self.scrubber = deid.Scrubber()
+        self.scrubber = deid.Scrubber(use_philter=True)
 
     @ddt.data(
         ({"CodeableConcept": {"text": "Fever at 123 Main St"}}, {"CodeableConcept": {"text": "Fever at *** **** **"}}),
@@ -38,3 +38,8 @@ class TestPhilter(unittest.IsolatedAsyncioTestCase):
     def test_scrub_text(self):
         """Verify that scrub_text() exists and works"""
         self.assertEqual("Hello Mr. *****", self.scrubber.scrub_text("Hello Mr. Jones"))
+
+    def test_can_disable_philter(self):
+        """Verify that disabling philter works"""
+        self.scrubber = deid.Scrubber()  # disabled by default
+        self.assertEqual("Hello Mr. Jones", self.scrubber.scrub_text("Hello Mr. Jones"))


### PR DESCRIPTION
### Description
In early testing, philter is extremely slow. Like 10x to 240x slower.

So while we investigate how we can improve that, let's make it optional for now. Most people hopefully don't *need* it, it was designed as an extra safeguard. But folks can enable for now, opting into the speed difference, while we look into this.

<!--- Describe your changes in detail -->

### Checklist
- [x] Consider if documentation (like in `docs/`) needs to be updated
- [x] Consider if tests should be added
