### PR TITLE
fix: ask for Binary permission along with DocumentReference

### DIFF
--- a/cumulus/errors.py
+++ b/cumulus/errors.py
@@ -1,6 +1,7 @@
 """Exception classes and error handling"""
 
 import sys
+from typing import NoReturn
 
 
 # Error return codes, mostly just distinguished for the benefit of tests.
@@ -25,7 +26,7 @@ BULK_EXPORT_FOLDER_NOT_EMPTY = 26
 BULK_EXPORT_FOLDER_NOT_LOCAL = 27
 
 
-def fatal(message: str, status: int):
+def fatal(message: str, status: int) -> NoReturn:
     """Convenience method to exit the program with a user-friendly error message a test-friendly status code"""
     print(message, file=sys.stderr)
     sys.exit(status)  # raises a SystemExit exception

--- a/cumulus/fhir_client.py
+++ b/cumulus/fhir_client.py
@@ -434,9 +434,14 @@ def create_fhir_client_for_cli(
         print(exc, file=sys.stderr)
         raise SystemExit(errors.ARGS_INVALID) from exc
 
+    client_resources = set(resources)
+    if "DocumentReference" in client_resources:
+        # A DocumentReference scope implies a Binary scope as well, since we'll usually need to download attachments
+        client_resources.add("Binary")
+
     return FhirClient(
         client_base_url,
-        resources,
+        client_resources,
         basic_user=args.basic_user,
         basic_password=basic_password,
         bearer_token=bearer_token,


### PR DESCRIPTION
### Description
If we are bulk-exporting DocumentReferences, we'll likely need Binary scope permission too. So we now always add it in that case. (this is different than the server-side record of which resources we can ask for -- this is a jwt-specific, session-specific list of which resources we claim we're going to ask the server for)

I hit this against the Cerner sandbox and and am surprised I haven't hit it before.

<!--- Describe your changes in detail -->

### Checklist
- [x] Consider if documentation (like in `docs/`) needs to be updated
- [x] Consider if tests should be added
