### PR TITLE
feat: add chart-review subcommand

### DIFF
--- a/cumulus/chart_review/__init__.py
+++ b/cumulus/chart_review/__init__.py
@@ -1,0 +1,3 @@
+"""Chart review"""
+
+from .cli import chart_review_main, define_chart_review_parser

--- a/cumulus/chart_review/cli.py
+++ b/cumulus/chart_review/cli.py
@@ -1,0 +1,91 @@
+"""Aid manual chart review by sending docs to Label Studio"""
+
+import argparse
+
+from cumulus import cli_utils, common, errors, fhir_client, loaders, store
+from cumulus.chart_review import downloader
+
+
+#####################################################################################################################
+#
+# DocumentReference gathering
+#
+#####################################################################################################################
+
+
+async def gather_docrefs(
+    client: fhir_client.FhirClient, root_input: store.Root, args: argparse.Namespace
+) -> loaders.Directory:
+    """Selects and downloads just the docrefs we need to a folder."""
+    root_phi = store.Root(args.dir_phi, create=True)
+    is_fhir_server = root_input.protocol == "https"
+
+    if args.docrefs and args.anon_docrefs:
+        errors.fatal("You cannot use both --docrefs and --anon-docrefs at the same time.", errors.ARGS_CONFLICT)
+
+    ndjson_loader = loaders.FhirNdjsonLoader(root_input, client, export_to=args.export_to)
+
+    # There are three possibilities: we have real IDs, we have fake IDs, or neither.
+    if is_fhir_server:
+        if args.docrefs:
+            return await downloader.download_docrefs_from_real_ids(client, args.docrefs, export_to=args.export_to)
+        elif args.anon_docrefs:
+            return await downloader.download_docrefs_from_fake_ids(
+                client, root_phi.path, args.anon_docrefs, export_to=args.export_to
+            )
+        else:
+            # else we'll download the entire target path as a bulk export (presumably the user has scoped a Group)
+            return await ndjson_loader.load_all(["DocumentReference"])
+    else:
+        # TODO: filter out to just the docrefs given by --docrefs etc
+        return await ndjson_loader.load_all(["DocumentReference"])
+
+
+#####################################################################################################################
+#
+# Main
+#
+#####################################################################################################################
+
+
+def define_chart_review_parser(parser: argparse.ArgumentParser) -> None:
+    parser.usage = "%(prog)s [OPTION]... INPUT PHI"
+
+    parser.add_argument("dir_input", metavar="/path/to/input")
+    parser.add_argument("dir_phi", metavar="/path/to/phi")
+
+    parser.add_argument(
+        "--export-to", metavar="PATH", help="Where to put exported documents (default is to delete after use)"
+    )
+
+    cli_utils.add_aws(parser)
+    cli_utils.add_auth(parser)
+
+    docs = parser.add_argument_group("document selection")
+    docs.add_argument("--anon-docrefs", metavar="PATH", help="CSV file with anonymized patient_id,docref_id columns")
+    docs.add_argument("--docrefs", metavar="PATH", help="CSV file with a docref_id column of original IDs")
+
+
+async def chart_review_main(args: argparse.Namespace) -> None:
+    """
+    Prepare for chart review by uploading some documents to Label Studio.
+
+    There are three major steps:
+    1. Gather requested DocumentReference resources, reverse-engineering the original docref IDs if necessary
+    2. Run NLP
+    3. Run Philter
+    4. Upload to Label Studio
+    """
+    common.set_user_fs_options(vars(args))  # record filesystem options like --s3-region before creating Roots
+
+    root_input = store.Root(args.dir_input)
+    client = fhir_client.create_fhir_client_for_cli(args, root_input, ["DocumentReference"])
+
+    common.print_header("Chart review support is in development.\nPlease do not attempt to use for anything real.")
+
+    async with client:
+        common.print_header("Gathering documents:")
+        await gather_docrefs(client, root_input, args)
+        # TODO: run NLP
+        # TODO: run philter
+        # TODO: upload to Label Studio

--- a/cumulus/chart_review/downloader.py
+++ b/cumulus/chart_review/downloader.py
@@ -1,0 +1,108 @@
+"""Download just the docrefs we need for a chart review."""
+
+import asyncio
+import itertools
+import logging
+import os
+import urllib.parse
+from typing import Container, Iterable, List, Optional
+
+from cumulus import cli_utils, common, deid, fhir_client, loaders
+
+
+async def download_docrefs_from_fake_ids(
+    client: fhir_client.FhirClient,
+    dir_phi: str,
+    docref_csv: str,
+    export_to: str = None,
+) -> loaders.Directory:
+    """Download DocumentReference resources for the given patient and docref identifiers"""
+    output_folder = cli_utils.make_export_dir(export_to)
+
+    # Grab identifiers for which specific docrefs & patients we need
+    with common.read_csv(docref_csv) as reader:
+        rows = list(reader)
+        fake_docref_ids = {row["docref_id"] for row in rows}
+        fake_patient_ids = {row["patient_id"] for row in rows}
+
+    # We know how to reverse-map the patient identifiers, so do that up front
+    codebook = deid.Codebook(dir_phi)
+    patient_ids = codebook.real_ids("Patient", fake_patient_ids)
+
+    # Kick off a bunch of requests to the FHIR server for any documents for these patients
+    # (filtered to only the given fake IDs)
+    coroutines = [
+        _request_docrefs_for_patient(client, patient_id, codebook, fake_docref_ids) for patient_id in patient_ids
+    ]
+    docrefs_per_patient = await asyncio.gather(*coroutines)
+
+    # And write them all out
+    _write_docrefs_to_output_folder(itertools.chain.from_iterable(docrefs_per_patient), output_folder.name)
+    return output_folder
+
+
+async def download_docrefs_from_real_ids(
+    client: fhir_client.FhirClient,
+    docref_csv: str,
+    export_to: str = None,
+) -> loaders.Directory:
+    """Download DocumentReference resources for the given patient and docref identifiers"""
+    output_folder = cli_utils.make_export_dir(export_to)
+
+    # Grab identifiers for which specific docrefs we need
+    with common.read_csv(docref_csv) as reader:
+        docref_ids = {row["docref_id"] for row in reader}
+
+    # Kick off a bunch of requests to the FHIR server for these documents
+    coroutines = [_request_docref(client, docref_id) for docref_id in docref_ids]
+    docrefs = await asyncio.gather(*coroutines)
+    docrefs = filter(None, docrefs)  # filter out the failing requests
+
+    # And write them all out
+    _write_docrefs_to_output_folder(docrefs, output_folder.name)
+    return output_folder
+
+
+def _write_docrefs_to_output_folder(docrefs: Iterable[dict], output_folder: str) -> None:
+    # Figure out where to put these docrefs
+    output_file_path = os.path.join(output_folder, "DocumentReference.ndjson")
+
+    # Stitch the resulting documents together and return as one big iterator
+    with common.NdjsonWriter(output_file_path) as output_file:
+        for docref in docrefs:
+            output_file.write(docref)
+
+
+async def _request_docrefs_for_patient(
+    client: fhir_client.FhirClient, patient_id: str, codebook: deid.Codebook, fake_docref_ids: Container[str]
+) -> List[dict]:
+    """Returns all DocumentReferences for a given patient"""
+    params = {
+        "patient": patient_id,
+        "_elements": "content",  # doesn't seem widely supported? But harmless to *try* to restrict size of response
+    }
+    print(f"  Searching for all docrefs for patient {patient_id}.")
+    response = await client.request("GET", f"DocumentReference?{urllib.parse.urlencode(params)}")
+    bundle = response.json()
+
+    docrefs = []
+    for entry in bundle.get("entry", []):
+        resource = entry["resource"]
+        fake_id = codebook.fake_id("DocumentReference", resource["id"], caching_allowed=False)
+        if fake_id in fake_docref_ids:
+            print(f"  ⭐ Including docref {resource['id']} ⭐")
+            docrefs.append(resource)
+        else:
+            print(f"  Ignoring docref {resource['id']}")
+    return docrefs
+
+
+async def _request_docref(client: fhir_client.FhirClient, docref_id: str) -> Optional[dict]:
+    """Returns one DocumentReference for a given ID"""
+    print(f"  Downloading docref {docref_id}.")
+    try:
+        response = await client.request("GET", f"DocumentReference/{docref_id}")
+        return response.json()
+    except fhir_client.FatalError:
+        logging.warning("Error getting docref %s", docref_id)
+        return None

--- a/cumulus/cli.py
+++ b/cumulus/cli.py
@@ -3,40 +3,57 @@
 import argparse
 import asyncio
 import sys
-from typing import List
+from typing import List, Optional
 
-from cumulus import etl
+from cumulus import chart_review, etl
 
-
-def add_auth(parser: argparse.ArgumentParser) -> None:
-    group = parser.add_argument_group("authentication")
-    group.add_argument("--smart-client-id", metavar="ID", help="Client ID for SMART authentication")
-    group.add_argument("--smart-jwks", metavar="PATH", help="JWKS file for SMART authentication")
-    group.add_argument("--basic-user", metavar="USER", help="Username for Basic authentication")
-    group.add_argument("--basic-passwd", metavar="PATH", help="Password file for Basic authentication")
-    group.add_argument("--bearer-token", metavar="PATH", help="Token file for Bearer authentication")
-    group.add_argument("--fhir-url", metavar="URL", help="FHIR server base URL, only needed if you exported separately")
+CHART_REVIEW = "chart-review"
+ETL = "etl"
+KNOWN_COMMANDS = {CHART_REVIEW, ETL}
 
 
-def add_aws(parser: argparse.ArgumentParser) -> None:
-    group = parser.add_argument_group("AWS")
-    group.add_argument("--s3-region", metavar="REGION", help="If using S3 paths (s3://...), this is their region")
-    group.add_argument(
-        "--s3-kms-key", metavar="KEY", help="If using S3 paths (s3://...), this is the KMS key ID to use"
-    )
+async def run_chart_review(parser: argparse.ArgumentParser, argv: List[str]) -> None:
+    """Parses a chart review CLI"""
+    chart_review.define_chart_review_parser(parser)
+    args = parser.parse_args(argv)
+    await chart_review.chart_review_main(args)
 
 
-def make_parser() -> argparse.ArgumentParser:
-    """Creates an ArgumentParser for Cumulus ETL"""
-    parser = argparse.ArgumentParser(prog="cumulus-etl", usage="%(prog)s [OPTION]... INPUT OUTPUT PHI")
-    etl.define_etl_parser(parser, add_auth=add_auth, add_aws=add_aws)
-    return parser
+async def run_etl(parser: argparse.ArgumentParser, argv: List[str]) -> None:
+    """Parses an etl CLI"""
+    etl.define_etl_parser(parser)
+    args = parser.parse_args(argv)
+    await etl.etl_main(args)
+
+
+def get_subcommand(argv: List[str]) -> Optional[str]:
+    """
+    Determines which subcommand was requested by the given command line.
+
+    Python's argparse has no good way of setting a default sub-parser.
+    (i.e. one that parses the command line if no sub parser subcommand is specified)
+    So instead, this method inspects the first positional argument.
+    If it's a recognized command, we return it. Else None.
+    """
+    for i, arg in enumerate(argv):
+        if arg in KNOWN_COMMANDS:
+            return argv.pop(i)  # remove it to make later parsers' jobs easier
+        elif not arg.startswith("-"):
+            return None  # first positional arg did not match a known command, assume default command
 
 
 async def main(argv: List[str]) -> None:
-    parser = make_parser()
-    args = parser.parse_args(argv)
-    await etl.etl_main(args)
+    subcommand = get_subcommand(argv)
+
+    prog = "cumulus-etl"
+    if subcommand:
+        prog += f" {subcommand}"  # to make --help look nicer
+    parser = argparse.ArgumentParser(prog=prog)
+
+    if subcommand == CHART_REVIEW:
+        await run_chart_review(parser, argv)
+    else:
+        await run_etl(parser, argv)
 
 
 def main_cli():

--- a/cumulus/cli_utils.py
+++ b/cumulus/cli_utils.py
@@ -1,0 +1,52 @@
+"""Helper methods for CLI parsing."""
+
+import argparse
+import os
+import tempfile
+import urllib.parse
+
+from cumulus import errors, loaders
+
+
+def add_auth(parser: argparse.ArgumentParser) -> None:
+    group = parser.add_argument_group("authentication")
+    group.add_argument("--smart-client-id", metavar="ID", help="Client ID for SMART authentication")
+    group.add_argument("--smart-jwks", metavar="PATH", help="JWKS file for SMART authentication")
+    group.add_argument("--basic-user", metavar="USER", help="Username for Basic authentication")
+    group.add_argument("--basic-passwd", metavar="PATH", help="Password file for Basic authentication")
+    group.add_argument("--bearer-token", metavar="PATH", help="Token file for Bearer authentication")
+    group.add_argument("--fhir-url", metavar="URL", help="FHIR server base URL, only needed if you exported separately")
+
+
+def add_aws(parser: argparse.ArgumentParser) -> None:
+    group = parser.add_argument_group("AWS")
+    group.add_argument("--s3-region", metavar="REGION", help="If using S3 paths (s3://...), this is their region")
+    group.add_argument(
+        "--s3-kms-key", metavar="KEY", help="If using S3 paths (s3://...), this is the KMS key ID to use"
+    )
+
+
+def make_export_dir(export_to: str = None) -> loaders.Directory:
+    """Makes a temporary directory to drop exported ndjson files into"""
+    # Handle the easy case -- just a random temp dir
+    if not export_to:
+        return tempfile.TemporaryDirectory()  # pylint: disable=consider-using-with
+
+    # OK the user has a specific spot in mind. Let's do some quality checks. It must be local and empty.
+
+    if urllib.parse.urlparse(export_to).netloc:
+        # We require a local folder because that's all that the MS deid tool can operate on.
+        # If we were to relax this requirement, we'd want to copy the exported files over to a local dir.
+        errors.fatal(f"The target export folder '{export_to}' must be local. ", errors.BULK_EXPORT_FOLDER_NOT_LOCAL)
+
+    try:
+        if os.listdir(export_to):
+            errors.fatal(
+                f"The target export folder '{export_to}' already has contents. Please provide an empty folder.",
+                errors.BULK_EXPORT_FOLDER_NOT_EMPTY,
+            )
+    except FileNotFoundError:
+        # Target folder doesn't exist, so let's make it
+        os.makedirs(export_to, mode=0o700)
+
+    return loaders.RealDirectory(export_to)

--- a/cumulus/common.py
+++ b/cumulus/common.py
@@ -1,5 +1,7 @@
 """Utility methods"""
 
+import contextlib
+import csv
 import datetime
 import json
 import os
@@ -151,6 +153,32 @@ def write_json(path: str, data: Any, indent: Optional[int] = None) -> None:
 
     with open_file(path, "w") as f:
         json.dump(data, f, indent=indent)
+
+
+@contextlib.contextmanager
+def read_csv(path: str) -> csv.DictReader:
+    with open(path, newline="", encoding="utf8") as csvfile:
+        yield csv.DictReader(csvfile)
+
+
+class NdjsonWriter:
+    """Convenience context manager to write multiple objects to an ndjson file."""
+
+    def __init__(self, path: str):
+        self._path = path
+
+    def __enter__(self):
+        self._file = open(self._path, "w", encoding="utf8")
+        return self
+
+    def __exit__(self, exc_type, exc_value, traceback):
+        if self._file:
+            self._file.close()
+            self._file = None
+
+    def write(self, obj: dict) -> None:
+        json.dump(obj, self._file)
+        self._file.write("\n")
 
 
 ###############################################################################

--- a/cumulus/deid/__init__.py
+++ b/cumulus/deid/__init__.py
@@ -1,4 +1,5 @@
 """De-identification support"""
 
+from .codebook import Codebook
 from .mstool import MSTOOL_CMD
 from .scrubber import Scrubber

--- a/cumulus/etl/cli.py
+++ b/cumulus/etl/cli.py
@@ -10,12 +10,12 @@ import socket
 import sys
 import tempfile
 import time
-from typing import Callable, Iterable, List, Type
+from typing import Iterable, List, Type
 from urllib.parse import urlparse
 
 import ctakesclient
 
-from cumulus import common, deid, errors, fhir_client, loaders, store
+from cumulus import cli_utils, common, deid, errors, fhir_client, loaders, store
 from cumulus.etl import context, tasks
 from cumulus.etl.config import JobConfig, JobSummary
 
@@ -153,8 +153,10 @@ def check_requirements() -> None:
 ###############################################################################
 
 
-def define_etl_parser(parser: argparse.ArgumentParser, *, add_auth: Callable, add_aws: Callable) -> None:
+def define_etl_parser(parser: argparse.ArgumentParser) -> None:
     """Fills out an argument parser with all the ETL options."""
+    parser.usage = "%(prog)s [OPTION]... INPUT OUTPUT PHI"
+
     parser.add_argument("dir_input", metavar="/path/to/input")
     parser.add_argument("dir_output", metavar="/path/to/output")
     parser.add_argument("dir_phi", metavar="/path/to/phi")
@@ -177,8 +179,8 @@ def define_etl_parser(parser: argparse.ArgumentParser, *, add_auth: Callable, ad
     parser.add_argument("--comment", help="add the comment to the log file")
     parser.add_argument("--philter", action="store_true", help="run philter on all freeform text fields")
 
-    add_aws(parser)
-    add_auth(parser)
+    cli_utils.add_aws(parser)
+    cli_utils.add_auth(parser)
 
     export = parser.add_argument_group("bulk export")
     export.add_argument(

--- a/cumulus/loaders/__init__.py
+++ b/cumulus/loaders/__init__.py
@@ -1,5 +1,5 @@
 """Public API for loaders"""
 
-from .base import Loader
+from .base import Directory, Loader, RealDirectory
 from .fhir.ndjson_loader import FhirNdjsonLoader
 from .i2b2.loader import I2b2Loader

--- a/cumulus/loaders/i2b2/loader.py
+++ b/cumulus/loaders/i2b2/loader.py
@@ -1,12 +1,11 @@
 """I2B2 loader"""
 
-import json
 import os
 import tempfile
 from functools import partial
 from typing import Callable, Iterable, List, TypeVar
 
-from cumulus import store
+from cumulus import common, store
 from cumulus.loaders.base import Directory, Loader
 from cumulus.loaders.i2b2 import extract, schema, transform
 from cumulus.loaders.i2b2.oracle import extract as oracle_extract
@@ -104,15 +103,14 @@ class I2b2Loader(Loader):
 
         ids = set()  # keep track of every ID we've seen so far, because sometimes i2b2 can have duplicates
 
-        with open(output_path, "w", encoding="utf8") as output_file:
+        with common.NdjsonWriter(output_path) as output_file:
             # Now write each FHIR resource line by line to the output
             # (we do this all line by line via generators to avoid loading everything in memory at once)
             for resource in fhir_resources:
                 if resource["id"] in ids:
                     continue
                 ids.add(resource["id"])
-                json.dump(resource, output_file)
-                output_file.write("\n")
+                output_file.write(resource)
 
     ###################################################################################################################
     #

--- a/docs/howtos/cerner-tips.md
+++ b/docs/howtos/cerner-tips.md
@@ -1,0 +1,10 @@
+<!-- Target audience: engineer familiar with the project, helpful direct tone -->
+
+# Cerner Tips & Tricks
+
+## Chart Review
+
+Note that for chart review activities, you will need a second client application registered with Cerner.
+
+Your first will likely have been registered as a Millennium Bulk Data client.
+But you'll need just a basic Millennium R4 client for doing chart review, as it makes non-bulk-data requests.

--- a/docs/howtos/run-cumulus-etl.md
+++ b/docs/howtos/run-cumulus-etl.md
@@ -357,4 +357,5 @@ And you may need to specify `--fhir-url=` so that external document notes can be
 Different EHRs have different features and performance.
 Here is some EHR-specific documentation:
 
+- [Cerner](cerner-tips.md)
 - [Epic](epic-tips.md)

--- a/tests/test_chart_cli.py
+++ b/tests/test_chart_cli.py
@@ -1,0 +1,158 @@
+"""Tests for chart_review/cli.py"""
+
+import filecmp
+import json
+import os
+import shutil
+import tempfile
+import unittest
+from typing import Iterable, List, Set, Tuple
+
+import respx
+
+from cumulus import cli, common, errors
+
+# These are pre-computed fake IDs using the salt "1234"
+ANON_P1 = "70339b189b5646dab20b2e2e46f8cef66da257e992e04862d2e88e1e1f1b1bd4"
+ANON_P2 = "7a3a3360942dbbf6f0f119797db6a5d38cc57dfe8e727fabd5912a3c478b6cc0"
+ANON_D1 = "d2f6df5b3d1bde3d6a8c3fde68ef45fb46991b315ac3f5065e4a7aae42f17819"
+ANON_D2 = "4b5351bd9334232e8bf6d5dd0bfe65ba519cf68a54da85d289c2009b9b6dc668"
+ANON_D3 = "bf1f931f34052b61e3c0ddd290e483b980672db9d6d7705544c0bb130fa7e577"
+
+
+class TestChartReview(unittest.IsolatedAsyncioTestCase):
+    """Tests for high-level chart review support."""
+
+    def setUp(self):
+        super().setUp()
+
+        tmpdir = tempfile.mkdtemp()
+        # Comment out this next line when debugging, to persist directory
+        self.addCleanup(shutil.rmtree, tmpdir)
+
+        script_dir = os.path.dirname(__file__)
+        self.data_dir = os.path.join(script_dir, "data/simple")
+        self.input_path = os.path.join(self.data_dir, "ndjson-input")
+        self.phi_path = os.path.join(tmpdir, "phi")
+        self.export_path = os.path.join(tmpdir, "export")
+
+        # Write some initial cached patient mappings, so we can reverse-engineer them
+        os.makedirs(self.phi_path)
+        common.write_json(
+            f"{self.phi_path}/codebook.json",
+            {
+                "version": 1,
+                "id_salt": "1234",
+            },
+        )
+        common.write_json(
+            f"{self.phi_path}/codebook-cached-mappings.json",
+            {
+                "Patient": {
+                    "P1": ANON_P1,
+                    "P2": ANON_P2,
+                }
+            },
+        )
+
+        filecmp.clear_cache()
+
+    async def run_chart_review(
+        self,
+        input_path=None,
+        phi_path=None,
+        anon_docrefs=None,
+        docrefs=None,
+    ) -> None:
+        args = [
+            "chart-review",
+            input_path or self.input_path,
+            phi_path or self.phi_path,
+            f"--export-to={self.export_path}",
+        ]
+        if anon_docrefs:
+            args += ["--anon-docrefs", anon_docrefs]
+        if docrefs:
+            args += ["--docrefs", docrefs]
+        await cli.main(args)
+
+    @staticmethod
+    def mock_search_url(patient: str, doc_ids: Iterable[str]) -> None:
+        bundle = {
+            "resourceType": "Bundle",
+            "entry": [
+                {
+                    "resource": {
+                        "resourceType": "DocumentReference",
+                        "id": doc_id,
+                    }
+                }
+                for doc_id in doc_ids
+            ],
+        }
+
+        respx.get(f"https://localhost/DocumentReference?patient={patient}&_elements=content").respond(json=bundle)
+
+    @staticmethod
+    def mock_read_url(doc_id: str, code: int = 200) -> None:
+        docref = {
+            "resourceType": "DocumentReference",
+            "id": doc_id,
+        }
+        respx.get(f"https://localhost/DocumentReference/{doc_id}").respond(status_code=code, json=docref)
+
+    @staticmethod
+    def write_anon_docrefs(path: str, ids: List[Tuple[str, str]]) -> None:
+        """Fills a file with the provided docref ids of (docref_id, patient_id) tuples"""
+        lines = ["docref_id,patient_id"] + [f"{x[0]},{x[1]}" for x in ids]
+        with open(path, "w", encoding="utf8") as f:
+            f.write("\n".join(lines))
+
+    @staticmethod
+    def write_real_docrefs(path: str, ids: List[str]) -> None:
+        """Fills a file with the provided docref ids"""
+        lines = ["docref_id"] + ids
+        with open(path, "w", encoding="utf8") as f:
+            f.write("\n".join(lines))
+
+    def get_exported_ids(self) -> Set[str]:
+        with common.open_file(os.path.join(self.export_path, "DocumentReference.ndjson"), "r") as f:
+            return {json.loads(line)["id"] for line in f}
+
+    async def test_real_and_fake_docrefs_conflict(self):
+        """Verify that you can't pass in both real and fake docrefs"""
+        with self.assertRaises(SystemExit) as cm:
+            await self.run_chart_review(anon_docrefs="foo", docrefs="bar")
+        self.assertEqual(errors.ARGS_CONFLICT, cm.exception.code)
+
+    @respx.mock
+    async def test_anon_docrefs(self):
+        self.mock_search_url("P1", ["NotMe", "D1", "NotThis", "D3"])
+        self.mock_search_url("P2", ["D2"])
+
+        with tempfile.NamedTemporaryFile() as file:
+            self.write_anon_docrefs(
+                file.name,
+                [
+                    (ANON_D1, ANON_P1),
+                    (ANON_D2, ANON_P2),
+                    (ANON_D3, ANON_P1),
+                    ("unknown-doc", "unknown-patient"),  # gracefully ignored
+                ],
+            )
+            await self.run_chart_review(input_path="https://localhost", anon_docrefs=file.name)
+
+        self.assertEqual({"D1", "D2", "D3"}, self.get_exported_ids())
+
+    @respx.mock
+    async def test_real_docrefs(self):
+        self.mock_read_url("D1")
+        self.mock_read_url("D2")
+        self.mock_read_url("D3")
+        self.mock_read_url("unknown-doc", code=404)
+
+        with tempfile.NamedTemporaryFile() as file:
+            self.write_real_docrefs(file.name, ["D1", "D2", "D3", "unknown-doc"])
+            await self.run_chart_review(input_path="https://localhost", docrefs=file.name)
+
+        self.assertEqual({"D1", "D2", "D3"}, self.get_exported_ids())

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,45 @@
+"""Tests for cli.py"""
+
+import contextlib
+import io
+import unittest
+from unittest import mock
+
+import ddt
+
+from cumulus import cli
+
+
+@ddt.ddt
+class TestCumulusCLI(unittest.IsolatedAsyncioTestCase):
+    """
+    Unit tests for our toplevel command line interface.
+    """
+
+    @ddt.data(
+        ([], "usage: cumulus-etl [OPTION]..."),
+        (["etl"], "usage: cumulus-etl etl [OPTION]..."),
+        (["chart-review"], "usage: cumulus-etl chart-review [OPTION]..."),
+    )
+    @ddt.unpack
+    async def test_usage(self, argv, expected_usage):
+        """Verify that we print the right usage for the various subcommands"""
+        stdout = io.StringIO()
+        with contextlib.redirect_stdout(stdout):
+            with self.assertRaises(SystemExit):
+                await cli.main(argv + ["--help"])
+
+        self.assertTrue(stdout.getvalue().startswith(expected_usage), stdout.getvalue())
+
+    @ddt.data(
+        ([], "cumulus.cli.run_etl"),
+        (["etl"], "cumulus.cli.run_etl"),
+        (["chart-review"], "cumulus.cli.run_chart_review"),
+    )
+    @ddt.unpack
+    async def test_routing(self, argv, main_method):
+        """Verify that we print the right usage for the various subcommands"""
+        with mock.patch(main_method) as mock_main:
+            await cli.main(argv)
+
+        self.assertTrue(mock_main.called)

--- a/tests/test_deid_mstool.py
+++ b/tests/test_deid_mstool.py
@@ -1,7 +1,6 @@
 """Tests for the mstool module"""
 
 import filecmp
-import json
 import os
 import shutil
 import tempfile
@@ -44,11 +43,10 @@ class TestMicrosoftTool(TreeCompareMixin, unittest.IsolatedAsyncioTestCase):
 
         for resource, unsorted_files in resource_buckets.items():
             os.makedirs(output_dir, exist_ok=True)
-            with open(f"{output_dir}/{resource}.ndjson", "w", encoding="utf8") as output_file:
+            with common.NdjsonWriter(f"{output_dir}/{resource}.ndjson") as output_file:
                 for filename in sorted(unsorted_files):
                     parsed_json = common.read_json(f"{input_dir}/{filename}")
-                    json.dump(parsed_json, output_file)
-                    output_file.write("\n")
+                    output_file.write(parsed_json)
 
     async def test_expected_transform(self):
         """Confirms that our sample input data results in the correct output"""

--- a/tests/test_ndjson_loader.py
+++ b/tests/test_ndjson_loader.py
@@ -238,16 +238,18 @@ class TestNdjsonLoader(unittest.IsolatedAsyncioTestCase):
             self.assertEqual(target, self.mock_exporter_class.call_args[0][3])
             self.assertEqual(target, folder.name)
 
-    def test_export_to_folder_has_contents(self):
+    async def test_export_to_folder_has_contents(self):
         """Verify we fail if an export folder already has contents"""
         with tempfile.TemporaryDirectory() as tmpdir:
             os.mkdir(f"{tmpdir}/stuff")
+            loader = loaders.FhirNdjsonLoader(store.Root("http://localhost:9999"), mock.AsyncMock(), export_to=tmpdir)
             with self.assertRaises(SystemExit) as cm:
-                loaders.FhirNdjsonLoader(store.Root("http://localhost:9999"), mock.AsyncMock(), export_to=tmpdir)
+                await loader.load_all([])
         self.assertEqual(cm.exception.code, errors.BULK_EXPORT_FOLDER_NOT_EMPTY)
 
-    def test_export_to_folder_not_local(self):
+    async def test_export_to_folder_not_local(self):
         """Verify we fail if an export folder is not local"""
+        loader = loaders.FhirNdjsonLoader(store.Root("http://localhost:9999"), mock.AsyncMock(), export_to="http://foo")
         with self.assertRaises(SystemExit) as cm:
-            loaders.FhirNdjsonLoader(store.Root("http://localhost:9999"), mock.AsyncMock(), export_to="http://foo/")
+            await loader.load_all([])
         self.assertEqual(cm.exception.code, errors.BULK_EXPORT_FOLDER_NOT_LOCAL)


### PR DESCRIPTION
### Description
This is a new and still in-progress mode for cumulus-etl, designed to assist in preparing chart reviews.

The idea is that you feed cumulus-etl some document references you want to review (likely from de-identified Athena data), and it will figure out which real documents map to those anonymous references, run NLP & philter on the doc, then upload it to Label Studio.

Only the first part (downloading the real docs from anonymous IDs) has been implemented in this commit.

The command is still hidden (i.e. does not show up on --help) and is not documented. It doesn't really do anything except download and then throw away some documents you asked for.

But this is a good checkpoint to build upon.

<!--- Describe your changes in detail -->

### Checklist
- [x] Consider if documentation (like in `docs/`) needs to be updated
- [x] Consider if tests should be added
