### PR TITLE
fix: allow old DSTU1 ethnicity & race extension URLs

### DIFF
--- a/cumulus/deid/ms-config.json
+++ b/cumulus/deid/ms-config.json
@@ -21,6 +21,8 @@
   "processingErrors": "raise",
   "fhirPathRules": [
     {"comment": "** Only allow a few known extensions **", "path": "xxx", "method": "redact"},
+    {"path": "Patient.extension('http://hl7.org/fhir/Profile/us-core#ethnicity')", "method": "keep", "comment": "Old DSTU1 URL, still out there in the wild: https://www.hl7.org/fhir/DSTU1/us-core.html"},
+    {"path": "Patient.extension('http://hl7.org/fhir/Profile/us-core#race')", "method": "keep", "comment": "Old DSTU1 URL, still out there in the wild: https://www.hl7.org/fhir/DSTU1/us-core.html"},
     {"path": "Patient.extension('http://hl7.org/fhir/us/core/StructureDefinition/us-core-birthsex')", "method": "keep"},
     {"path": "Patient.extension('http://hl7.org/fhir/us/core/StructureDefinition/us-core-ethnicity')", "method": "keep"},
     {"path": "Patient.extension('http://hl7.org/fhir/us/core/StructureDefinition/us-core-genderIdentity')", "method": "keep"},

--- a/tests/data/mstool/input/Patient.1.json
+++ b/tests/data/mstool/input/Patient.1.json
@@ -23,6 +23,14 @@
       "valueDecimal": 53.69437199788911
     },
     {
+      "url": "http://hl7.org/fhir/Profile/us-core#ethnicity",
+      "valueString": "kept"
+    },
+    {
+      "url": "http://hl7.org/fhir/Profile/us-core#race",
+      "valueString": "kept"
+    },
+    {
       "url": "http://hl7.org/fhir/us/core/StructureDefinition/us-core-birthsex",
       "valueString": "kept"
     },

--- a/tests/data/mstool/output/Patient.1.json
+++ b/tests/data/mstool/output/Patient.1.json
@@ -17,6 +17,14 @@
   },
   "extension": [
     {
+      "url": "http://hl7.org/fhir/Profile/us-core#ethnicity",
+      "valueString": "kept"
+    },
+    {
+      "url": "http://hl7.org/fhir/Profile/us-core#race",
+      "valueString": "kept"
+    },
+    {
       "url": "http://hl7.org/fhir/us/core/StructureDefinition/us-core-birthsex",
       "valueString": "kept"
     },


### PR DESCRIPTION
### Description
See the draft spec here: https://www.hl7.org/fhir/DSTU1/us-core.html

Fixes https://github.com/smart-on-fhir/cumulus-etl/issues/193

<!--- Describe your changes in detail -->

### Checklist
- [x] Consider if documentation (like in `docs/`) needs to be updated
- [x] Consider if tests should be added
