### PR TITLE
fix: adjust compose syntax to not have two volume keys

### DIFF
--- a/compose.yaml
+++ b/compose.yaml
@@ -14,12 +14,11 @@ services:
       - URL_CNLP_NEGATION=http://cnlp-transformers:8000/negation/process
     volumes:
       - $HOME/.aws/:/root/.aws/:ro
+      - ctakes-overrides:/ctakes-overrides
     networks:
       - cumulus-etl
     profiles:
       - base
-    volumes:
-      - ctakes-overrides:/ctakes-overrides
 
   cumulus-etl:
     extends: cumulus-etl-base


### PR DESCRIPTION
### Description
This was preventing docker build from working

Another reason to probably add a docker build CI test.

<!--- Describe your changes in detail -->

### Checklist
- [x] Consider if documentation (like in `docs/`) needs to be updated
- [x] Consider if tests should be added
