### PR TITLE
chore: pin pandas to less than 2.0 for now

### DIFF
--- a/cumulus/chart_review/labelstudio.py
+++ b/cumulus/chart_review/labelstudio.py
@@ -1,6 +1,6 @@
 """LabelStudio document annotation"""
 
-from typing import Collection, Iterable, List, Tuple
+from typing import Collection, Dict, Iterable, List, Tuple
 
 import ctakesclient.typesystem
 import label_studio_sdk
@@ -27,7 +27,7 @@ class LabelStudioNote:
 class LabelStudioClient:
     """Client to talk to Label Studio"""
 
-    def __init__(self, url: str, api_key: str, project_id: int, cui_labels: dict[str, str]):
+    def __init__(self, url: str, api_key: str, project_id: int, cui_labels: Dict[str, str]):
         self._client = label_studio_sdk.Client(url, api_key)
         self._client.check_connection()
         self._project = self._client.get_project(project_id)
@@ -113,7 +113,7 @@ class LabelStudioClient:
             #
             # The rule that Cumulus uses is that the value= variable must equal the name= of the <Labels> element.
             # TODO: add this quirk to our eventual documentation for this feature.
-            task["data"][self._labels_name] = [{"value": l} for l in sorted(used_labels)]
+            task["data"][self._labels_name] = [{"value": x} for x in sorted(used_labels)]
 
         task["predictions"] = [prediction]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ dependencies = [
     "jwcrypto",
     "label-studio-sdk",
     "oracledb",
-    "pandas",
+    "pandas < 2",
     "philter-lite",
     "pyarrow",
     "s3fs",

--- a/tests/test_i2b2_etl.py
+++ b/tests/test_i2b2_etl.py
@@ -64,7 +64,7 @@ class TestI2b2Etl(CtakesMixin, TreeCompareMixin, AsyncTestCase):
                     "--input-format=i2b2",
                     "--output-format=ndjson",
                     f"--export-to={export_path}",
-                    f"--task=patient",  # just to make the test faster and confirm we don't export unnecessary files
+                    "--task=patient",  # just to make the test faster and confirm we don't export unnecessary files
                 ]
             )
 


### PR DESCRIPTION
### Description
<!--- Describe your changes in detail -->
They just released 2.0 with some breaking changes.

Not opposed to upgrading, but that'll happen later.

### Checklist
- [x] Consider if documentation (like in `docs/`) needs to be updated
- [x] Consider if tests should be added
