### PR TITLE
chore: bump pandas to 2.x

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,19 +1,28 @@
 [project]
 name = "cumulus"
 requires-python = ">= 3.8"
+# These dependencies are mostly pinned to be under the next major version.
+# That makes particular sense as long as we don't have official releases yet and our code is used
+# by pulling from main directly.
+# But now there's a risk of missing a major release and bit-rotting the dependency tree.
+#
+# We should either (a) configure a bot to warn us about stale dependencies, or
+# (b) once we switch to a more planned release schedule (via docker or similar), just go back to
+# open-pinned dependencies so that we're more likely to notice new releases (we'll still have time
+# to fix any breakages since users won't immediately see the problem).
 dependencies = [
     "ctakesclient >= 2.1, < 3",
-    "delta-spark >= 2.1",
+    "delta-spark >= 2.1, < 3",
     # This branch includes some jwt fixes we need (and will hopefully be in mainline in future)
     "fhirclient @ git+https://github.com/mikix/client-py.git@mikix/oauth2-jwt",
     "html2text",
-    "httpx",
-    "jwcrypto",
-    "label-studio-sdk",
-    "oracledb",
-    "pandas < 2",
-    "philter-lite",
-    "pyarrow",
+    "httpx < 1",
+    "jwcrypto < 2",
+    "label-studio-sdk < 1",
+    "oracledb < 2",
+    "pandas < 3",
+    "philter-lite < 1",
+    "pyarrow < 12",
     "s3fs",
 ]
 authors = [

--- a/tests/test_etl_cli.py
+++ b/tests/test_etl_cli.py
@@ -40,7 +40,7 @@ class BaseEtlSimple(CtakesMixin, TreeCompareMixin, AsyncTestCase):
 
         tmpdir = tempfile.mkdtemp()
         # Comment out this next line when debugging, to persist directory
-        # self.addCleanup(shutil.rmtree, tmpdir)
+        self.addCleanup(shutil.rmtree, tmpdir)
 
         self.output_path = os.path.join(tmpdir, "output")
         self.phi_path = os.path.join(tmpdir, "phi")
@@ -305,8 +305,12 @@ class TestEtlFormats(BaseEtlSimple):
         # Check metadata files (these have consistent names)
         self.assertEqual(
             {
-                "_delta_log/00000000000000000000.json",
+                "_delta_log/00000000000000000000.json",  # write
                 "_delta_log/.00000000000000000000.json.crc",
+                "_delta_log/00000000000000000001.json",  # vacuum start
+                "_delta_log/.00000000000000000001.json.crc",
+                "_delta_log/00000000000000000002.json",  # vacuum end
+                "_delta_log/.00000000000000000002.json.crc",
                 "_symlink_format_manifest/manifest",
                 "_symlink_format_manifest/.manifest.crc",
             },


### PR DESCRIPTION
### Description
This does two things:
1. Unpin pandas from 1.x to 2.x. I looked at the [release notes](https://pandas.pydata.org/docs/whatsnew/v2.0.0.html) and the breaking changes felt extremely minor. Stuff like "when passing an invalid dtype= arg, pandas now does the sensible thing and raises" or the behavior of methods we don't call (like `value_counts`). I confirmed we passed our test suite with 2.x.
2. Add upper pins for all semantic-versioned dependencies (I left a couple that were date-versioned alone). Explanation in code comment, but tl;dr; is that while we are releasing from `main`, we should probably be cautious. But once we aren't, I'd vote for unpinning these again.

### Checklist
- [x] Consider if documentation (like in `docs/`) needs to be updated
- [x] Consider if tests should be added