### PR TITLE
feat: keep ages 90+ intact, as they will be grouped downstream

### DIFF
--- a/cumulus/deid/ms-config.json
+++ b/cumulus/deid/ms-config.json
@@ -33,7 +33,6 @@
     {"path": "nodesByType('Extension')", "method": "redact", "comment": "drop all unknown extensions"},
 
     {"comment": "** Elements that might be embedded and kept elsewhere -- redact pieces of the whole **", "path": "xxx", "method": "redact"},
-    {"path": "nodesByType('Age').value", "method": "redact", "comment": "note that this is a partial redaction, only removing ages above 89"},
     {"path": "nodesByType('Attachment').title", "method": "redact"},
     {"path": "nodesByType('Reference').display", "method": "redact"},
     {"path": "nodesByType('Reference').identifier", "method": "redact"},
@@ -54,7 +53,7 @@
 
     {"comment": "** Shared backbone elements **", "path": "xxx", "method": "redact"},
 
-    {"comment": "** https://www.hl7.org/fhir/dosage.html **", "path": "xxx", "method": "redact"},
+    {"comment": "** https://www.hl7.org/fhir/R4/dosage.html **", "path": "xxx", "method": "redact"},
     {"path": "nodesByType('Dosage').sequence", "method": "keep"},
     {"path": "nodesByType('Dosage').additionalInstruction", "method": "keep"},
     {"path": "nodesByType('Dosage').timing", "method": "keep"},
@@ -72,7 +71,7 @@
 
     {"comment": "** Top-level resources **", "path": "xxx", "method": "redact"},
 
-    {"comment": "** https://www.hl7.org/fhir/condition.html **", "path": "xxx", "method": "redact"},
+    {"comment": "** https://www.hl7.org/fhir/R4/condition.html **", "path": "xxx", "method": "redact"},
     {"path": "Condition.clinicalStatus", "method": "keep"},
     {"path": "Condition.verificationStatus", "method": "keep"},
     {"path": "Condition.category", "method": "keep"},
@@ -94,7 +93,7 @@
     {"path": "Condition.evidence.code", "method": "keep"},
     {"path": "Condition.evidence.detail", "method": "keep"},
 
-    {"comment": "** https://www.hl7.org/fhir/documentreference.html **", "path": "xxx", "method": "redact"},
+    {"comment": "** https://www.hl7.org/fhir/R4/documentreference.html **", "path": "xxx", "method": "redact"},
     {"path": "DocumentReference.status", "method": "keep"},
     {"path": "DocumentReference.docStatus", "method": "keep"},
     {"path": "DocumentReference.type", "method": "keep"},
@@ -117,7 +116,7 @@
     {"path": "DocumentReference.context.sourcePatientInfo", "method": "keep"},
     {"path": "DocumentReference.context.related", "method": "keep"},
 
-    {"comment": "** https://www.hl7.org/fhir/encounter.html **", "path": "xxx", "method": "redact"},
+    {"comment": "** https://www.hl7.org/fhir/R4/encounter.html **", "path": "xxx", "method": "redact"},
     {"path": "Encounter.status", "method": "keep"},
     {"path": "Encounter.statusHistory.status", "method": "keep"},
     {"path": "Encounter.statusHistory.period", "method": "keep"},
@@ -157,7 +156,7 @@
     {"path": "Encounter.serviceProvider", "method": "keep"},
     {"path": "Encounter.partOf", "method": "keep"},
 
-    {"comment": "** https://www.hl7.org/fhir/medicationrequest.html **", "path": "xxx", "method": "redact"},
+    {"comment": "** https://www.hl7.org/fhir/R4/medicationrequest.html **", "path": "xxx", "method": "redact"},
     {"path": "MedicationRequest.status", "method": "keep"},
     {"path": "MedicationRequest.statusReason", "method": "keep"},
     {"path": "MedicationRequest.intent", "method": "keep"},
@@ -196,7 +195,7 @@
     {"path": "MedicationRequest.detectedIssue", "method": "keep"},
     {"path": "MedicationRequest.eventHistory", "method": "keep"},
 
-    {"comment": "** https://www.hl7.org/fhir/observation.html **", "path": "xxx", "method": "redact"},
+    {"comment": "** https://www.hl7.org/fhir/R4/observation.html **", "path": "xxx", "method": "redact"},
     {"path": "Observation.basedOn", "method": "keep"},
     {"path": "Observation.partOf", "method": "keep"},
     {"path": "Observation.status", "method": "keep"},
@@ -222,9 +221,12 @@
     {"path": "Observation.component.dataAbsentReason", "method": "keep"},
     {"path": "Observation.component.interpretation", "method": "keep"},
 
-    {"comment": "** https://www.hl7.org/fhir/patient.html **", "path": "xxx", "method": "redact"},
+    {"comment": "** https://www.hl7.org/fhir/R4/patient.html **", "path": "xxx", "method": "redact"},
     {"path": "Patient.active", "method": "keep"},
     {"path": "Patient.gender", "method": "keep"},
+    {"path": "Patient.birthDate", "method": "generalize",
+     "comment": "keep just the year for privacy (note: 90+ HIPAA grouping is done downstream in SQL)",
+     "cases": {"true": "$this.toString().replaceMatches('^(?<year>\\\\d+).*', '${year}')"}},
     {"path": "Patient.deceased", "method": "keep"},
     {"path": "Patient.maritalStatus", "method": "keep"},
     {"path": "Patient.multipleBirth", "method": "keep"},
@@ -239,7 +241,7 @@
     {"path": "Patient.link.other", "method": "keep"},
     {"path": "Patient.link.type", "method": "keep"},
 
-    {"comment": "** https://www.hl7.org/fhir/resource.html **", "path": "xxx", "method": "redact"},
+    {"comment": "** https://www.hl7.org/fhir/R4/resource.html **", "path": "xxx", "method": "redact"},
     {"path": "Resource.id", "method": "keep"},
     {"path": "Resource.implicitRules", "method": "keep"},
     {"path": "Resource.language", "method": "keep"},
@@ -248,8 +250,6 @@
     {"path": "Resource", "method": "redact", "comment": "Catch-all removal of anything not specifically allowed above"}
   ],
   "parameters": {
-    "enablePartialAgesForRedact": true,
-    "enablePartialDatesForRedact": true,
     "enablePartialZipCodesForRedact": true,
     "restrictedZipCodeTabulationAreas": [
       "036",

--- a/docs/explanations/deid.md
+++ b/docs/explanations/deid.md
@@ -81,7 +81,8 @@ Most dates are left alone, as precise timing is useful for studies and carries
 But anything age related is carefully handled in the usual HIPAA manner:
 
 - Birthdates are redacted down to just the year (no month or day)
-- If the birthdate (or other age field) indicates an age over 89, the field is entirely removed.
+- If the birthdate (or other age field) indicates an age over 89,
+  those patients will be grouped together as one cohort
 
 #### Zip Codes
 

--- a/tests/data/mstool/input/Patient.2.json
+++ b/tests/data/mstool/input/Patient.2.json
@@ -119,7 +119,7 @@
     }
   ],
   "gender": "female",
-  "birthDate": "1971-04-05",
+  "birthDate": "1971",
   "deceasedDateTime": "2023-03-02",
   "address": [
     {

--- a/tests/data/mstool/output/Condition.3.json
+++ b/tests/data/mstool/output/Condition.3.json
@@ -1,12 +1,5 @@
 {
   "resourceType": "Condition",
-  "meta": {
-    "security": [{
-      "code": "REDACTED",
-      "display": "redacted",
-      "system": "http://terminology.hl7.org/CodeSystem/v3-ObservationValue"
-    }]
-  },
   "id": "con3-age-redaction",
   "subject": { "reference": "Patient/3" },
   "onsetAge": {
@@ -17,6 +10,7 @@
   },
   "abatementAge": {
     "unit": "year",
+    "value": 90,
     "system": "http://unitsofmeasure.org",
     "code": "year"
   }

--- a/tests/data/mstool/output/Observation.1.json
+++ b/tests/data/mstool/output/Observation.1.json
@@ -61,9 +61,6 @@
       }
     ]
   }],
-  "note": [{
-    "time": "2011"
-  }],
   "bodySite": {
     "coding": [
       {

--- a/tests/data/mstool/output/Patient.1.json
+++ b/tests/data/mstool/output/Patient.1.json
@@ -12,6 +12,10 @@
         "code": "ABSTRED",
         "display": "abstracted",
         "system": "http://terminology.hl7.org/CodeSystem/v3-ObservationValue"
+      },
+      {
+        "code": "GENERALIZED",
+        "display": "exact value is replaced with a general value"
       }
     ]
   },
@@ -76,9 +80,6 @@
     "text": "M"
   },
   "multipleBirthBoolean": false,
-  "photo": [{
-    "creation": "1965"
-  }],
   "contact": [{
     "relationship": [{
       "coding": [
@@ -88,9 +89,6 @@
         }
       ]
     }],
-    "name": {
-      "period": {"start": "2018", "end": "2020"}
-    },
     "address": {
       "state": "Massachusetts",
       "postalCode": "01000",

--- a/tests/data/mstool/output/Patient.2.json
+++ b/tests/data/mstool/output/Patient.2.json
@@ -12,6 +12,10 @@
         "code": "ABSTRED",
         "display": "abstracted",
         "system": "http://terminology.hl7.org/CodeSystem/v3-ObservationValue"
+      },
+      {
+        "code": "GENERALIZED",
+        "display": "exact value is replaced with a general value"
       }
     ]
   },

--- a/tests/data/mstool/output/Patient.3.json
+++ b/tests/data/mstool/output/Patient.3.json
@@ -12,10 +12,15 @@
         "code": "ABSTRED",
         "display": "abstracted",
         "system": "http://terminology.hl7.org/CodeSystem/v3-ObservationValue"
+      },
+      {
+        "code": "GENERALIZED",
+        "display": "exact value is replaced with a general value"
       }
     ]
   },
   "gender": "male",
+  "birthDate": "1910",
   "address": [
     {
       "state": "Massachusetts",


### PR DESCRIPTION
### Description
The Athena-side SQL can group them. Removing them at ETL time presents some problems:
- Can't distinguish between missing data and 90+
- Can't know "age at time of condition" for 90+ folks
- The SQL will have to have grouping logic anyway, since a patient onboarded by the ETL 5 years ago may have aged into the 90+ demo

So this commit stops deleting birthDates for the 90+ cohort. It also keeps onsetAge and abatementAge in place for 90+ values.

Fixes https://github.com/smart-on-fhir/cumulus-etl/issues/201

<!--- Describe your changes in detail -->

### Checklist
- [x] Consider if documentation (like in `docs/`) needs to be updated
- [x] Consider if tests should be added
