### PR TITLE
fix(deltalake): use a better group-merge strategy

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ requires-python = ">= 3.8"
 # to fix any breakages since users won't immediately see the problem).
 dependencies = [
     "ctakesclient >= 2.1, < 3",
-    "delta-spark >= 2.1, < 3",
+    "delta-spark >= 2.3, < 3",
     # This branch includes some jwt fixes we need (and will hopefully be in mainline in future)
     "fhirclient @ git+https://github.com/mikix/client-py.git@mikix/oauth2-jwt",
     "html2text",

--- a/tests/test_deltalake.py
+++ b/tests/test_deltalake.py
@@ -166,18 +166,19 @@ class TestDeltaLake(unittest.TestCase):
     def test_group_field(self):
         """Verify that we can safely delete some data from the lake using groups"""
         self.store(
-            self.df(aa={"group": 1, "val": 5}, ab={"group": 1, "val": 10}, b={"group": 2, "val": 1}),
+            self.df(aa={"group": "X", "val": 5}, ab={"group": "X", "val": 10}, b={"group": "Y", "val": 1}),
             group_field="value.group",
         )
         self.store(
-            self.df(ab={"group": 1, "val": 11}, ac={"group": 1, "val": 16}, c={"group": 3, "val": 2}),
+            # Add a quote as part of the Z group identifier, just to confirm we escape these strings
+            self.df(ab={"group": "X", "val": 11}, ac={"group": "X", "val": 16}, c={"group": 'Z"', "val": 2}),
             group_field="value.group",
         )
         self.assert_lake_equal(
             self.df(
-                ab={"group": 1, "val": 11},
-                ac={"group": 1, "val": 16},
-                b={"group": 2, "val": 1},
-                c={"group": 3, "val": 2},
+                ab={"group": "X", "val": 11},
+                ac={"group": "X", "val": 16},
+                b={"group": "Y", "val": 1},
+                c={"group": 'Z"', "val": 2},
             )
         )


### PR DESCRIPTION
### Description
Now that delta-spark 2.3.0 is out, we can use the new "when not matched by source, delete" functionality of a merge.

This increases the atomicity of our updates, removing a gap where we deleted old data before adding the new.

<!--- Describe your changes in detail -->

### Checklist
- [x] Consider if documentation (like in `docs/`) needs to be updated
- [x] Consider if tests should be added
