### PR TITLE
bulk: add some quality of life improvements to bulk exports

### DIFF
--- a/cumulus/common.py
+++ b/cumulus/common.py
@@ -170,6 +170,16 @@ class NdjsonWriter:
 ###############################################################################
 
 
+def _pretty_float(num: float, precision: int = 1) -> str:
+    """
+    Returns a formatted float with trailing zeros chopped off.
+
+    Could not find a cleaner builtin solution.
+    Prior art: https://stackoverflow.com/questions/2440692/formatting-floats-without-trailing-zeros
+    """
+    return f"{num:.{precision}f}".rstrip("0").rstrip(".")
+
+
 def human_file_size(count: int) -> str:
     """
     Returns a human-readable version of a count of bytes.
@@ -180,8 +190,28 @@ def human_file_size(count: int) -> str:
     for suffix in ("KB", "MB"):
         count /= 1024
         if count < 1024:
-            return f"{count:.1f}{suffix}"
-    return f"{count / 1024:.1f}GB"
+            return f"{_pretty_float(count)}{suffix}"
+    return f"{_pretty_float(count / 1024)}GB"
+
+
+def human_time_offset(seconds: int) -> str:
+    """
+    Returns a (fuzzy) human-readable version of a count of seconds.
+
+    Examples:
+      49 => "49s"
+      90 => "1.5m"
+      18000 => "5h"
+    """
+    if seconds < 60:
+        return f"{seconds}s"
+
+    minutes = seconds / 60
+    if minutes < 60:
+        return f"{_pretty_float(minutes)}m"
+
+    hours = minutes / 60
+    return f"{_pretty_float(hours)}h"
 
 
 def info_mode():

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,6 +23,7 @@ dependencies = [
     "pandas < 3",
     "philter-lite < 1",
     "pyarrow < 12",
+    "rich < 14",
     "s3fs",
 ]
 authors = [

--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -1,0 +1,35 @@
+"""Tests for common.py"""
+
+import ddt
+
+from cumulus import common
+from tests.utils import AsyncTestCase
+
+
+@ddt.ddt
+class TestLogging(AsyncTestCase):
+    """
+    Test case for common logging methods.
+    """
+
+    @ddt.data(
+        (0, "0KB"),
+        (2000, "2KB"),
+        (2000000, "1.9MB"),
+        (2000000000, "1.9GB"),
+    )
+    @ddt.unpack
+    def test_human_file_size(self, byte_count, expected_str):
+        """Verify human_file_size works correctly"""
+        self.assertEqual(expected_str, common.human_file_size(byte_count))
+
+    @ddt.data(
+        (0, "0s"),
+        (59, "59s"),
+        (60, "1m"),
+        (9010, "2.5h"),
+    )
+    @ddt.unpack
+    def test_human_time_offset(self, seconds, expected_str):
+        """Verify human_time_offset works correctly"""
+        self.assertEqual(expected_str, common.human_time_offset(seconds))


### PR DESCRIPTION
### Description
- Run status checks at most every 5 minutes. So if the server asks us to check in again in five hours and they aren't overloaded (i.e. they aren't giving us a 429), check in at five minutes.
- Print the status check timings in a more human readable way (e.g. 600s => 5m and 9010s => 2.5h)
- Print configuration up front in a prettier way, and include a few extra parameters like since/until.

This adds a new runtime dependency on the "rich" library.

Old config print:
```
Configuration:
{
    "dir_input": "https://fhir-ehr-code.cerner.com/r4/ec2458f2-1e24-41c8-b71b-0e701af7583d/Group/11ec-d16a-c763b73e-98e8-a31715e6a2bf",
    "dir_output": "/tmp/sandbox-output",
    "dir_phi": "/tmp/sandbox-phi",
    "path": "/tmp/sandbox-output/JobConfig/2023-04-10__17.42.27/job_config.json",
    "input_format": "ndjson",
    "output_format": "deltalake",
    "comment": "",
    "batch_size": 200000,
    "tasks": "condition,documentreference,encounter,medicationrequest,observation,patient,covid_symptom__nlp_results"
}
```

New config print:
```
Configuration:
 Input path:      https://fhir-ehr-code.cerner.com/r4/ec2458f2-1e24-41c8-b71b-0 
                  e701af7583d/Group/11ec-d16a-c763b73e-98e8-a31715e6a2bf        
  Since:          2023-01-01T00:00:00Z                                          
 Output path:     /tmp/sandbox-output                                           
  Format:         deltalake                                                     
 PHI/Build path:  /tmp/sandbox-phi                                              
 Current time:    2023-04-10 17:41:55 UTC                                       
 Batch size:      200000                                                        
 Tasks:           condition, covid_symptom__nlp_results, documentreference,     
                  encounter, medicationrequest, observation, patient            
```

<!--- Describe your changes in detail -->

### Checklist
- [x] Consider if documentation (like in `docs/`) needs to be updated
- [x] Consider if tests should be added
