### PR TITLE
fix: always send *some* label metadata even if we didn't run NLP

### DIFF
--- a/cumulus/chart_review/labelstudio.py
+++ b/cumulus/chart_review/labelstudio.py
@@ -82,8 +82,7 @@ class LabelStudioClient:
             },
         }
 
-        if note.matches:
-            self._format_prediction(task, note)
+        self._format_prediction(task, note)
 
         return task
 

--- a/tests/test_chart_labelstudio.py
+++ b/tests/test_chart_labelstudio.py
@@ -106,6 +106,12 @@ class TestChartLabelStudio(AsyncTestCase):
                     "text": "Normal note text",
                     "ref_id": "D3",
                 },
+                "predictions": [
+                    {
+                        "model_version": "Cumulus",
+                        "result": [],
+                    }
+                ],
             },
             self.get_pushed_task(),
         )
@@ -124,6 +130,20 @@ class TestChartLabelStudio(AsyncTestCase):
                     {"value": "Itch"},
                     {"value": "Nausea"},
                 ],
+            },
+            self.get_pushed_task()["data"],
+        )
+
+    def test_dynamic_labels_no_matches(self):
+        self.ls_project.parsed_label_config = {
+            "mylabel": {"type": "Labels", "to_name": ["mytext"], "dynamic_labels": True},
+        }
+        self.push_tasks(self.make_note(matches=False))
+        self.assertEqual(
+            {
+                "text": "Normal note text",
+                "ref_id": "D3",
+                "mylabel": [],  # this needs to be sent, or the server will complain
             },
             self.get_pushed_task()["data"],
         )


### PR DESCRIPTION
### Description
Label Studio will error out if dynamic labels are enabled but you don't push any label metadata at all.

But previously if you turned off NLP, we wouldn't send any. Now, we send an empty list of labels in that case, which avoids the error.

<!--- Describe your changes in detail -->

### Checklist
- [x] Consider if documentation (like in `docs/`) needs to be updated
- [x] Consider if tests should be added
