### PR TITLE
fix: make NLP tests a little less flaky

### DIFF
--- a/tests/test_bulk_export.py
+++ b/tests/test_bulk_export.py
@@ -7,7 +7,6 @@ from json import dumps
 from unittest import mock
 
 import ddt
-import freezegun
 import responses
 import respx
 from jwcrypto import jwk
@@ -19,7 +18,6 @@ from tests.utils import AsyncTestCase, make_response
 
 
 @ddt.ddt
-@freezegun.freeze_time("Sep 15th, 2021 1:23:45")
 class TestBulkExporter(AsyncTestCase):
     """
     Test case for bulk export logic.

--- a/tests/test_etl_cli.py
+++ b/tests/test_etl_cli.py
@@ -8,7 +8,6 @@ import tempfile
 from typing import Optional
 from unittest import mock
 
-import freezegun
 import pytest
 import s3fs
 from ctakesclient.typesystem import Polarity
@@ -19,11 +18,10 @@ from cumulus.formats.deltalake import DeltaLakeFormat
 
 from tests.ctakesmock import CtakesMixin, fake_ctakes_extract
 from tests.s3mock import S3Mixin
-from tests.utils import AsyncTestCase, TreeCompareMixin
+from tests.utils import FROZEN_TIME_UTC, AsyncTestCase, TreeCompareMixin
 
 
 @pytest.mark.skipif(not shutil.which(deid.MSTOOL_CMD), reason="MS tool not installed")
-@freezegun.freeze_time("Sep 15th, 2021 1:23:45", tz_offset=-4)
 class BaseEtlSimple(CtakesMixin, TreeCompareMixin, AsyncTestCase):
     """
     Base test case for basic runs of etl methods
@@ -226,7 +224,7 @@ class TestEtlJobContext(BaseEtlSimple):
         """Verify that we update the success timestamp etc. when the job succeeds"""
         await self.run_etl()
         job_context = context.JobContext(self.context_path)
-        self.assertEqual("2021-09-14T21:23:45+00:00", job_context.last_successful_datetime.isoformat())
+        self.assertEqual(FROZEN_TIME_UTC, job_context.last_successful_datetime)
         self.assertEqual(self.input_path, job_context.last_successful_input_dir)
         self.assertEqual(self.output_path, job_context.last_successful_output_dir)
 

--- a/tests/test_etl_config.py
+++ b/tests/test_etl_config.py
@@ -1,17 +1,14 @@
 """Tests for etl/config.py"""
 
-import unittest
 from socket import gethostname
 
-import freezegun
-
 from cumulus.etl import config
+from tests.utils import FROZEN_TIME_UTC, AsyncTestCase
 
 
-class TestConfigSummary(unittest.TestCase):
+class TestConfigSummary(AsyncTestCase):
     """Test case for JobSummary"""
 
-    @freezegun.freeze_time("Sep 15th, 2021 1:23:45")
     def test_empty_summary(self):
         summary = config.JobSummary("empty")
         expected = {
@@ -20,6 +17,6 @@ class TestConfigSummary(unittest.TestCase):
             "label": "empty",
             "success": 0,
             "success_rate": 1.0,
-            "timestamp": "2021-09-15 01:23:45",
+            "timestamp": FROZEN_TIME_UTC.strftime("%Y-%m-%d %H:%M:%S"),
         }
         self.assertEqual(expected, summary.as_json())

--- a/tests/test_fhir_client.py
+++ b/tests/test_fhir_client.py
@@ -5,7 +5,6 @@ import time
 from unittest import mock
 
 import ddt
-import freezegun
 import httpx
 import respx
 from jwcrypto import jwk, jwt
@@ -16,7 +15,6 @@ from tests.utils import AsyncTestCase, make_response
 
 
 @ddt.ddt
-@freezegun.freeze_time("Sep 15th, 2021 1:23:45")
 @mock.patch("cumulus.fhir_client.uuid.uuid4", new=lambda: "1234")
 class TestFhirClient(AsyncTestCase):
     """

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -1,6 +1,7 @@
 """Various test helper methods"""
 
 import contextlib
+import datetime
 import filecmp
 import functools
 import inspect
@@ -10,10 +11,19 @@ import time
 import unittest
 from unittest import mock
 
+import freezegun
 import httpx
 import respx
 
+# Pass a non-UTC time to freezegun to help notice any bad timezone handling.
+# But only bother exposing the UTC version to other test code, since that's what will be most useful/common.
+_FROZEN_TIME = datetime.datetime(2021, 9, 15, 1, 23, 45, tzinfo=datetime.timezone(datetime.timedelta(hours=4)))
+FROZEN_TIME_UTC = _FROZEN_TIME.astimezone(datetime.timezone.utc)
 
+
+# Several tests involve timestamps in some form, so just pick a standard time for all tests.
+# We ignore socketserver because it checks the result of time() when evaluating timeouts.
+@freezegun.freeze_time(_FROZEN_TIME, ignore=["socketserver"])
 class AsyncTestCase(unittest.IsolatedAsyncioTestCase):
     """
     Test case to hold some common code (suitable for async *OR* sync tests)


### PR DESCRIPTION
### Description
This commit has three fixes and one refactor:
- When starting the mock cTAKES server, don't check for an initial timestamp on the symptoms file. If the server process starts slow, it would not notice a file that was placed there before it started. We already know the test started with no file, so no need to check.
- Don't proceed with tests until the mock cTAKES server is ready to process requests (needed because ETL tests often skip the init checks that normally ensure that).
- Ignore the "socketserver" module when freezing time with freezegun. It uses time() to check for timeouts, and was not timing out our request handler. (Filed https://github.com/spulec/freezegun/issues/502 upstream)
- Refactor: use the same freezegun freeze call for all our tests, for simplicity (and to spread little fixes like above all around).

<!--- Describe your changes in detail -->

### Checklist
- [x] Consider if documentation (like in `docs/`) needs to be updated
- [x] Consider if tests should be added
