### PR TITLE
chore: update to ctakesclient 3.0

### DIFF
--- a/cumulus/nlp/__init__.py
+++ b/cumulus/nlp/__init__.py
@@ -1,4 +1,4 @@
 """Support code for NLP servers"""
 
-from .extract import covid_symptoms_extract
+from .extract import covid_symptoms_extract, ctakes_httpx_client
 from .watcher import check_cnlpt, check_ctakes, restart_ctakes_with_bsv

--- a/docs/howtos/cumulus-aws-template.yaml
+++ b/docs/howtos/cumulus-aws-template.yaml
@@ -148,7 +148,7 @@ Resources:
     Properties:
       CatalogId: !Ref AWS::AccountId
       DatabaseInput:
-        Name: cumulus-deid-db
+        Name: cumulus_deid_db # use underscores for ease of SQL (hyphens are reserved)
 
   GlueCrawler:
     Type: AWS::Glue::Crawler

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ requires-python = ">= 3.8"
 # open-pinned dependencies so that we're more likely to notice new releases (we'll still have time
 # to fix any breakages since users won't immediately see the problem).
 dependencies = [
-    "ctakesclient >= 2.1, < 3",
+    "ctakesclient >= 3, < 4",
     "delta-spark >= 2.3, < 3",
     # This branch includes some jwt fixes we need (and will hopefully be in mainline in future)
     "fhirclient @ git+https://github.com/mikix/client-py.git@mikix/oauth2-jwt",

--- a/tests/ctakesmock.py
+++ b/tests/ctakesmock.py
@@ -234,7 +234,7 @@ def fake_ctakes_extract(sentence: str) -> typesystem.CtakesJSON:
     return typesystem.CtakesJSON(response)
 
 
-def fake_transformer_list_polarity(sentence: str, spans: List[tuple]) -> List[typesystem.Polarity]:
+async def fake_transformer_list_polarity(sentence: str, spans: List[tuple], client=None) -> List[typesystem.Polarity]:
     """Simple always-positive fake response from cNLP."""
-    del sentence
+    del sentence, client
     return [typesystem.Polarity.pos] * len(spans)

--- a/tests/test_chart_cli.py
+++ b/tests/test_chart_cli.py
@@ -175,6 +175,7 @@ class TestChartReview(CtakesMixin, AsyncTestCase):
     async def test_gather_anon_docrefs_from_server(self):
         self.mock_search_url("P1", ["NotMe", "D1", "NotThis", "D3"])
         self.mock_search_url("P2", ["D2"])
+        respx.post(os.environ["URL_CTAKES_REST"]).pass_through()  # ignore cTAKES
 
         with tempfile.NamedTemporaryFile() as file:
             self.write_anon_docrefs(
@@ -197,6 +198,7 @@ class TestChartReview(CtakesMixin, AsyncTestCase):
         self.mock_read_url("D2")
         self.mock_read_url("D3")
         self.mock_read_url("unknown-doc", code=404)
+        respx.post(os.environ["URL_CTAKES_REST"]).pass_through()  # ignore cTAKES
 
         with tempfile.NamedTemporaryFile() as file:
             self.write_real_docrefs(file.name, ["D1", "D2", "D3", "unknown-doc"])

--- a/tests/test_etl_cli.py
+++ b/tests/test_etl_cli.py
@@ -431,7 +431,7 @@ class TestEtlNlp(BaseEtlSimple):
     async def test_cnlp_rejects(self):
         """Verify that if the cnlp server negates a match, it does not show up"""
         # First match is fever, second is nausea
-        self.cnlp_mock.side_effect = lambda _, spans: [Polarity.neg, Polarity.pos]
+        self.cnlp_mock.side_effect = lambda *args, **kwargs: [Polarity.neg, Polarity.pos]
         await self.run_etl(tasks=["covid_symptom__nlp_results"])
 
         symptoms = self.read_symptoms()
@@ -475,7 +475,7 @@ class TestEtlNlp(BaseEtlSimple):
 
         # Now negate the second symptom, and notice that it has been dropped in the results for each docref
         shutil.rmtree(os.path.join(self.phi_path, "ctakes-cache"))  # clear cached results
-        self.cnlp_mock.side_effect = lambda _, spans: [Polarity.pos, Polarity.neg]
+        self.cnlp_mock.side_effect = lambda *args, **kwargs: [Polarity.pos, Polarity.neg]
         await self.run_etl(output_format="deltalake", tasks=["covid_symptom__nlp_results"])
         self.assertEqual(
             [

--- a/tests/test_etl_tasks.py
+++ b/tests/test_etl_tasks.py
@@ -264,6 +264,7 @@ class TestTasks(CtakesMixin, AsyncTestCase):
         # We return three words due to how our cTAKES mock works. It wants 3 words -- fever word is in middle.
         respx.get("http://localhost/file-cough").respond(text="has cough bad")
         respx.get("http://localhost/file-fever").respond(text="has fever bad")
+        respx.post(os.environ["URL_CTAKES_REST"]).pass_through()  # ignore cTAKES
 
         docref0 = i2b2_mock_data.documentreference()
         docref0["content"] = [{"attachment": {"url": a[0], "contentType": a[1]}} for a in attachments]


### PR DESCRIPTION
### Description
This converts the network calls to async methods.

This commit simply adapts to that API change, but does not take any real advantage of it to make parallel calls etc.

That might come later, but I just wanted to at least get us up to date.

<!--- Describe your changes in detail -->

### Checklist
- [x] Consider if documentation (like in `docs/`) needs to be updated
- [x] Consider if tests should be added
