### PR TITLE
fix: clean up AWS docs now that DeltaTargets is in CloudFormation

### DIFF
--- a/docs/howtos/cumulus-aws-template.yaml
+++ b/docs/howtos/cumulus-aws-template.yaml
@@ -166,15 +166,18 @@ Resources:
         # Schedule a monthly run to catch any newly-added fields automatically
         ScheduleExpression: "cron(0 8 1 * ? *)"  # 8am on the 1st of the month
       Targets:
-        # This S3Targets definition is suitable for parquet files, but we won't actually be using it.
-        # You'll want to use a Delta Lake crawler instead.
-        # CloudFormation requires *a* target be defined, but it does not yet support DeltaTargets.
-        # So we provide a valid definition, for a target that we don't actually intend to use.
-        # We'll later replace these manually with some DeltaTargets.
-        S3Targets:
-          - Path: !Sub "s3://${S3Bucket}/${EtlSubdir}/"
-            Exclusions:
-              - "JobConfig/**"
+        DeltaTargets:
+          - DeltaTables:
+              # Unfortunately, we can't seem to use wildcards to define tables
+              - !Sub "s3://${S3Bucket}/${EtlSubdir}/condition"
+              - !Sub "s3://${S3Bucket}/${EtlSubdir}/documentreference"
+              - !Sub "s3://${S3Bucket}/${EtlSubdir}/encounter"
+              - !Sub "s3://${S3Bucket}/${EtlSubdir}/medicationrequest"
+              - !Sub "s3://${S3Bucket}/${EtlSubdir}/observation"
+              - !Sub "s3://${S3Bucket}/${EtlSubdir}/patient"
+              - !Sub "s3://${S3Bucket}/${EtlSubdir}/covid_symptom__nlp_results"
+            CreateNativeDeltaTable: False
+            WriteManifest: False
 
   ####################################################
   # Athena queries and where to store them

--- a/docs/howtos/set-up-aws.md
+++ b/docs/howtos/set-up-aws.md
@@ -67,25 +67,5 @@ It takes four parameters:
 1. KMS key ARN for encryption
 1. Upload Role ARN, matching the user that runs Cumulus ETL
 
-Once you create this CloudFormation stack, you're almost done.
-Only one step left below: updating the Glue crawler.
-
-## Delta Lake Crawler Support
-
-Cumulus uses Delta Lakes to store your data.
-AWS Glue support for them is fairly new (September 2022),
-and CloudFormation does not yet support that syntax.
-
-But that's easy enough to work around.
-We'll just manually update the crawler to point at our delta lakes.
-
-Run the command below to update the crawler you just defined above,
-and replace `REPLACE_ME` with a bucket path (the bucket name and `EtlSubdir` you used above).
-
-For example, you might use `s3://my-cumulus-prefix-99999999999-us-east-2/subdir1`.
-
-(Make sure you have `jq` installed first.)
-
-```sh
-aws glue update-crawler --name cumulus --targets "`jq -n --arg prefix REPLACE_ME '{"DeltaTargets": [{"DeltaTables": [$prefix+"/condition", $prefix+"/covid_symptom__nlp_results", $prefix+"/documentreference", $prefix+"/encounter", $prefix+"/medicationrequest", $prefix+"/observation", $prefix+"/patient"], "WriteManifest": false}]}'`"
-```
+Once you create this CloudFormation stack, that's it!
+You've configured AWS to receive data from Cumulus ETL.


### PR DESCRIPTION
### Description
They finally added DeltaTargets support for crawlers, so we can drop some of the grosser steps during AWS setup

<!--- Describe your changes in detail -->

### Checklist
- [x] Consider if documentation (like in `docs/`) needs to be updated
- [x] Consider if tests should be added
