### PR TITLE
docs: send user to Library docs when done with these

### DIFF
--- a/docs/setup/aws.md
+++ b/docs/setup/aws.md
@@ -68,7 +68,12 @@ The easy way to set this all up is simply use a CloudFormation template.
 [Here's an example template](cumulus-aws-template.yaml) that should work for your needs,
 but can be customized as you like.
 
-It takes four parameters:
+That's worth emphasizing - your setup does not need to be this exact CloudFormation setup.
+This is provided merely for convenience, but if you want to use one bucket instead of three
+or change the name of the database, that's totally fine.
+The important thing is that you end up with a crawler that feeds data to a database for Athena.
+
+Though if you do use this template, it takes four parameters:
 1. Bucket prefix
 1. ETL Subdirectory, matching the subdirectory you pass to Cumulus ETL
 1. KMS key ARN for encryption

--- a/docs/setup/index.md
+++ b/docs/setup/index.md
@@ -79,9 +79,12 @@ results.
 
 ## Going Forward
 
-Now that you've done a end-to-end run (well, a FHIR-to-Athena run),
-the next step is to finish the Cumulus ETL guide and customize your runner for your environment.
-
-Then once you do your first large-scale Cumulus ETL run, re-run the Crawler (the last time you'll
-need to re-run it unless Cumulus changes its format) and Athena will then be ready to query against
-your production data.
+Now that you've done a sample end-to-end run (well, a FHIR-to-Athena run):
+1. The next step is to finish reading the rest of this Cumulus ETL guide and
+   customize it for your environment.
+1. Delete the sample data you made above (delete the output S3 folder).
+1. Run the ETL again with some of your real patient data.
+1. After that, re-run the Glue crawler to crawl your actual data schema
+   (the last time you'll need to re-run it unless Cumulus changes its format)
+1. You are now ready to set up the
+   [Cumulus Library](https://docs.smarthealthit.org/cumulus/library/) to query that data.


### PR DESCRIPTION
### Description
Some leftover tweaks from my doc cleanup. Wanted to have a better "end" for the ETL docs, which sent them on their way to the Library.

### Checklist
- [x] Consider if documentation (like in `docs/`) needs to be updated
- [x] Consider if tests should be added
