### PR TITLE
fix: handle errors more gracefully during NLP

### DIFF
--- a/.github/workflows/pages.yaml
+++ b/.github/workflows/pages.yaml
@@ -1,0 +1,24 @@
+name: Update Cumulus docs
+on:
+  push:
+    branches: ["main"]
+    paths: ["docs/**"]
+
+jobs:
+  update-docs:
+    name: Update Cumulus docs
+    runs-on: ubuntu-latest
+    steps:
+      - name: Send workflow dispatch
+        uses: actions/github-script@v6
+        with:
+          # This token is set to expire in May 2024.
+          # You can make a new one with write access to Actions on the cumulus repo.
+          github-token: ${{ secrets.CUMULUS_DOC_TOKEN }}
+          script: |
+            await github.rest.actions.createWorkflowDispatch({
+              owner: 'smart-on-fhir',
+              repo: 'cumulus',
+              ref: 'main',
+              workflow_id: 'pages.yaml',
+            })

--- a/cumulus_etl/chart_review/selector.py
+++ b/cumulus_etl/chart_review/selector.py
@@ -51,6 +51,10 @@ def _filter_real_docrefs(docrefs_csv: str, docrefs: Iterable[dict]) -> Iterator[
         if docref["id"] in real_docref_ids:
             yield docref
 
+            real_docref_ids.remove(docref["id"])
+            if not real_docref_ids:
+                break
+
 
 def _filter_fake_docrefs(root_phi: store.Root, anon_docrefs_csv: str, docrefs: Iterable[dict]) -> Iterator[dict]:
     """Calculates the fake ID for all docrefs found, and keeps any that match the csv list"""
@@ -63,3 +67,7 @@ def _filter_fake_docrefs(root_phi: store.Root, anon_docrefs_csv: str, docrefs: I
         fake_id = codebook.fake_id("DocumentReference", docref["id"], caching_allowed=False)
         if fake_id in fake_docref_ids:
             yield docref
+
+            fake_docref_ids.remove(fake_id)
+            if not fake_docref_ids:
+                break

--- a/cumulus_etl/cli.py
+++ b/cumulus_etl/cli.py
@@ -3,6 +3,7 @@
 import argparse
 import asyncio
 import enum
+import logging
 import sys
 from typing import List, Optional
 
@@ -38,6 +39,8 @@ def get_subcommand(argv: List[str]) -> Optional[str]:
 
 
 async def main(argv: List[str]) -> None:
+    logging.basicConfig(format="%(message)s")  # hide gross log prefix of "WARNING:root:" etc, just display message
+
     subcommand = get_subcommand(argv)
 
     prog = "cumulus-etl"

--- a/cumulus_etl/store.py
+++ b/cumulus_etl/store.py
@@ -29,10 +29,9 @@ class Root:
         :param path: location (local path or URL)
         :param create: whether to create the folder if it doesn't exist
         """
-        self.path = path
-
         parsed = urlparse(path)
         self.protocol = parsed.scheme or "file"  # assume local if no obvious scheme
+        self.path = path if parsed.scheme else os.path.abspath(path)
 
         try:
             self.fs = fsspec.filesystem(self.protocol, **self.fsspec_options())


### PR DESCRIPTION
### Description
Plus some other minor fixes

- Add workflow to update cumulus docs when our docs change, which is pointless right now but harmless -- we'll eventually want this in all repos, and I'm just getting ahead of the big switchover
- During chart review, stop looping over docrefs as soon as we've hit all the ones we were looking for
- If an error occurs when downloading a document from the FHIR server, don't error out the whole ETL -- simply log it and keep moving
- Update the cTAKES timeout from 20s to 5m -- I was seeing timeouts and lets be generous
- Don't print giant exceptions when we fail to talk to cTAKES - instead print a shorter message (including exception type, because I seem to have run into some empty-string exceptions)
- Resolve relative paths to absolute paths before using them

<!--- Describe your changes in detail -->

### Checklist
- [x] Consider if documentation (like in `docs/`) needs to be updated
- [x] Consider if tests should be added
