### PR TITLE
fix: don't send application/xml documents to NLP

### DIFF
--- a/cumulus_etl/fhir_common.py
+++ b/cumulus_etl/fhir_common.py
@@ -94,7 +94,7 @@ def _mimetype_priority(mimetype: str) -> int:
         return 3
     elif mimetype.startswith("text/"):
         return 2
-    elif mimetype in ("application/xml", "application/xhtml+xml"):
+    elif mimetype == "application/xhtml+xml":
         return 1
     return 0
 

--- a/tests/test_etl_tasks.py
+++ b/tests/test_etl_tasks.py
@@ -252,9 +252,9 @@ class TestTasks(CtakesMixin, AsyncTestCase):
         # list of (URL, contentType), expected text
         ([("http://localhost/file-cough", "text/plain")], "cough"),  # handles absolute URL
         ([("file-cough", "text/html")], "cough"),  # handles text/*
-        ([("file-cough", "application/xml")], "cough"),  # handles app/xml
+        ([("file-cough", "application/xhtml+xml")], "cough"),  # handles xhtml
         ([("file-cough", "text/html"), ("file-fever", "text/plain")], "fever"),  # prefers text/plain to text/*
-        ([("file-cough", "application/xml"), ("file-fever", "text/blarg")], "fever"),  # prefers text/* to app/xml
+        ([("file-cough", "application/xhtml+xml"), ("file-fever", "text/blarg")], "fever"),  # prefers text/* to xhtml
         ([("file-cough", "nope/nope")], None),  # ignores unsupported mimetypes
     )
     @ddt.unpack


### PR DESCRIPTION
I had optimistically assumed they might be parsable documents, but in practice we can get all sorts of weird things, including giant base-64-encoded rtf files in a vendor-custom xml doc.

Let's not try to parse them, because sending them direct to cTAKES is unlikely to yield good results and because it often puts cTAKES into a stuck position, where it can't process the doc.


### Checklist
- [x] Consider if documentation (like in `docs/`) needs to be updated
- [x] Consider if tests should be added
