### PR TITLE
docs: add chart review documentation, mark chart review as stable

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Cumulus will capitalize on “21st Century Cures Act” availability of EHR data
 
 # Cumulus Features
 * Extracts bulk FHIR data
-* Performs natural language processing (NLP) on physician notes via [cTAKES](https://ctakes.apache.org/) to extract symptoms and other information
+* Performs natural language processing (NLP) on clinical notes via [cTAKES](https://ctakes.apache.org/) to extract symptoms and other information
 * De-identifies protected health information (PHI) before any data leaves your health institution
 * All data is encrypted at rest and in transit
 * Focuses on non-human-subject research and minimal disclosures -- researchers only see patient counts

--- a/cumulus_etl/chart_review/cli.py
+++ b/cumulus_etl/chart_review/cli.py
@@ -179,12 +179,6 @@ async def chart_review_main(args: argparse.Namespace) -> None:
     access_token = common.read_text(args.ls_token).strip()
     labels = ctakesclient.filesystem.map_cui_pref(args.symptoms_bsv)
 
-    # TODO: to remove this warning:
-    #  1. Decide that chart-review is good to go for wide release
-    #  2. Make chart-review mode discoverable on standard --help, in some fashion
-    #  3. Make some user docs
-    common.print_header("Chart review support is in development.\nPlease do not attempt to use for anything real.")
-
     async with client:
         ndjson_folder = await gather_docrefs(client, root_input, root_phi, args)
         notes = await read_notes_from_ndjson(client, ndjson_folder.name)

--- a/cumulus_etl/cli.py
+++ b/cumulus_etl/cli.py
@@ -57,7 +57,7 @@ async def main(argv: List[str]) -> None:
         if not subcommand:
             # Add a note about other subcommands we offer, and tell argparse not to wrap our formatting
             parser.formatter_class = argparse.RawDescriptionHelpFormatter
-            parser.description += "\n\n" "other commands available:\n" "  convert"
+            parser.description += "\n\n" "other commands available:\n" "  chart-review\n" "  convert"
         await etl.run_etl(parser, argv)
 
 

--- a/cumulus_etl/etl/tasks.py
+++ b/cumulus_etl/etl/tasks.py
@@ -408,7 +408,7 @@ class CovidSymptomNlpResultsTask(EtlTask):
             writer.write(docref)
 
     async def read_entries(self) -> AsyncIterator[Union[List[dict], dict]]:
-        """Passes physician notes through NLP and returns any symptoms found"""
+        """Passes clinical notes through NLP and returns any symptoms found"""
         phi_root = store.Root(self.task_config.dir_phi, create=True)
 
         # one client for both NLP services for now -- no parallel requests yet, so no need to be fancy

--- a/cumulus_etl/loaders/i2b2/schema.py
+++ b/cumulus_etl/loaders/i2b2/schema.py
@@ -203,7 +203,7 @@ class ValueType(Enum):
     no_value = "@"
     numeric = "N"
     text = "T"
-    physician_notes = "B"
+    clinical_notes = "B"
     NLP = "NLP"
 
 
@@ -265,7 +265,7 @@ class ObservationFact(Dimension):
         LOCATION_CD     -> ref i2b2.visit_dimension
         CONCEPT_CD      -> ref i2b2.concept_dimension
 
-        OBSERVATION_BLOB -> Physician Notes (usually)
+        OBSERVATION_BLOB -> Clinical Notes (usually)
         INSTANCE_NUM    -> unique ID of observation
         VALTYPE_CD      -> @see ValueType(Enum)
         TVAL_CHAR       -> @see ValueEquality(Enum) Labs "Negative" or

--- a/cumulus_etl/loaders/i2b2/transform.py
+++ b/cumulus_etl/loaders/i2b2/transform.py
@@ -245,7 +245,7 @@ def to_fhir_medicationrequest(obsfact: ObservationFact) -> dict:
 
 ###############################################################################
 #
-# Physician Notes and NLP
+# Clinical Notes and NLP
 #
 ###############################################################################
 

--- a/docs/chart-review.md
+++ b/docs/chart-review.md
@@ -1,0 +1,235 @@
+---
+title: Chart Review
+parent: ETL
+nav_order: 20
+# audience: engineer familiar with the project
+# type: tutorial
+---
+
+# Chart Review
+
+Cumulus ETL also offers a chart review mode,
+where it sends clinical notes to [Label Studio](https://labelstud.io/) for expert review.
+Along the way, it can mark the note with NLP results and/or anonymize the note with
+[philter](https://github.com/SironaMedical/philter-lite).
+
+This is useful for not just actual chart reviews, but also for developing a custom NLP dictionary.
+You can feed Cumulus ETL a custom NLP dictionary, review how it performs, and iterate upon it.
+
+## Basic Operation
+
+At its core, chart review mode is just another ETL (extract, transform, load) operation.
+1. It extracts DocumentReference resources from your EHR.
+2. It transforms the contained notes via NLP & `philter`.
+3. It loads the results into Label Studio.
+
+### Minimal Command Line
+
+Chart review mode takes three main arguments:
+1. Input path (local dir of ndjson or a FHIR server to perform a bulk export on)
+2. URL for Label Studio
+3. PHI/build path (the same PHI/build path you normally provide to Cumulus ETL)
+
+Additionally, there are two required Label Studio parameters:
+1. `--ls-token PATH` (a file holding your Label Studio authentication token)
+2. `--ls-project ID` (the number of the Label Studio project you want to push notes to)
+
+Taken altogether, here is an example minimal chart review command:
+```sh
+docker compose run \
+ --volume /local/path:/in \
+ cumulus-etl \
+ chart-review \
+  --ls-token /in/label-studio-token.txt \
+  --ls-project 3 \
+  https://my-ehr-server/R4/12345/Group/67890 \
+  https://my-label-studio-server/ \
+  s3://my-cumulus-prefix-phi-99999999999-us-east-2/subdir1/
+```
+
+The above command will take all the DocumentReferences in Group `67890` from the EHR,
+mark the notes with the default NLP dictionary,
+anonymize the notes with `philter`,
+and then push the results to your Label Studio project number `3`.
+
+## Bulk Export Options
+
+You can point chart review mode at either a folder with DocumentReference ndjson files
+or your EHR server (in which case it will do a bulk export from the target Group).
+
+Chart review mode takes all the same [bulk export options](bulk-exports.md) that the normal
+ETL mode supports.
+
+Note that even if you provide a folder of DocumentReference ndjson resources,
+you will still likely need to pass `--fhir-url` and FHIR authentication options,
+so that chart review mode can download the referenced clinical notes _inside_ the DocumentReference,
+which usually hold an external URL rather than inline note data.
+
+## Document Selection Options
+
+By default, chart review mode will grab _all documents_ in the target Group or folder.
+But usually you will probably want to only select a few documents for testing purposes.
+More in the realm of 10-100 specific documents.
+
+You have two options here:
+selection by either the original EHR IDs or by the anonymized Cumulus IDs.
+
+### By Original ID
+If you happen to know the original (pre-anonymized) IDs for the documents you want, that's easy!
+
+Make a csv file that has a `docref_id` column, with those docrefs.
+For example:
+```
+docref_id
+123
+6972
+1D3D
+```
+
+Then pass in an argument like `--docrefs /in/docrefs.csv`.
+
+Chart review mode will only export & process the specified documents, saving a lot of time.
+
+### By Anonymized ID
+If you are working with your existing de-identified limited data set in Athena,
+you will only have references to the anonymized document IDs and no direct clinical notes.
+
+But that's fine!
+Chart review mode can use the PHI folder to grab the cached mappings of patient IDs
+and then work to reverse-engineer the correct document IDs (to then download from the EHR).
+
+For this to work, you will need to provide both the anonymized docref ID **and**
+the anonymized patient ID.
+
+Back in Athena, run a query like this and download the result as a csv file:
+```sql
+select
+  replace(subject_ref, 'Patient/', '') as patient_id,
+  doc_id as docref_id
+from
+  core__documentreference
+limit 10;
+```
+
+(Obviously, modify as needed to select the documents you care about.)
+
+You'll notice we are defining two columns: patient_id and docref_id (those must be the names).
+
+Then, pass in an argument like `--anon-docrefs /in/docrefs.csv`.
+Chart review mode will reverse-engineer the original document IDs and export them from your EHR.
+
+#### I Thought the Anonymized IDs Could Not Be Reversed?
+
+True!
+But Cumulus ETL saves a cache of all the IDs it makes for your patients (and encounters).
+You can see this cache in your PHI folder, named `codebook-cached-mappings.json`.
+
+By using this mapping file,
+chart review mode can find all the original patient IDs using the `patient_id` column you gave it.
+
+Once it has the original patients, it will ask the EHR for all of those patients' documents.
+And it will anonymize each document ID it sees.
+This anonymization step is stable over time, because it always uses the same cryptographic salt
+(stored in your PHI folder).
+
+When it sees a match for one of the anonymous docref IDs you gave in the `docref_id` column
+(among all the patient's documents), it will download that document.
+
+### Saving the Selected Documents
+
+It might be useful to save the exported documents from the EHR
+(or even the smaller selection from a giant ndjson folder),
+for faster iterations of the chart review mode or
+just confirming the correct documents were chosen.
+
+Pass in an argument like `--export-to /in/export` to save the ndjson for the selected documents
+in the given folder. (Note this does not save the clinical note text unless it is already inline
+-- this is just saving the DocumentReference resources).
+
+## Custom NLP Dictionaries
+
+If you would like to customize the dictionary terms that are marked up and sent to Label Studio,
+simply pass in a new dictionary like so: `--symptoms-bsv /in/my-symptoms.bsv`.
+
+This file should look like (this is a portion of the default Covid dictionary):
+```
+##  Columns = CUI|TUI|CODE|SAB|STR|PREF
+##      CUI = Concept Unique Identifier
+##      TUI = Type Unique Identifier
+##     CODE = Vocabulary Code
+##      SAB = Vocabulary Source Abbreviation (SNOMEDCT_US)
+##      STR = String text in clinical note (case insensitive)
+##     PREF = Preferred output concept label
+
+##  Congestion or runny nose
+C0027424|T184|68235000|SNOMEDCT_US|nasal congestion|Congestion or runny nose
+C0027424|T184|68235000|SNOMEDCT_US|stuffed-up nose|Congestion or runny nose
+C0027424|T184|68235000|SNOMEDCT_US|stuffy nose|Congestion or runny nose
+C0027424|T184|68235000|SNOMEDCT_US|congested nose|Congestion or runny nose
+C1260880|T184|64531003|SNOMEDCT_US|rhinorrhea|Congestion or runny nose
+C1260880|T184|64531003|SNOMEDCT_US|Nasal discharge|Congestion or runny nose
+C1260880|T184|64531003|SNOMEDCT_US|discharge from nose|Congestion or runny nose
+C1260880|T184|267101005|SNOMEDCT_US|nose dripping|Congestion or runny nose
+C1260880|T184|267101005|SNOMEDCT_US|nose running|Congestion or runny nose
+C1260880|T184|267101005|SNOMEDCT_US|running nose|Congestion or runny nose
+C1260880|T184|HP:0031417|HPO|runny nose|Congestion or runny nose
+C0027424|T184|R09.81|ICD10CM|R09.81|Congestion or runny nose
+
+##  Diarrhea
+C0011991|T184|62315008|SNOMEDCT_US|diarrhea|Diarrhea
+C0011991|T184|R19.7|ICD10CM|R19.7|Diarrhea
+C0011991|T184|HP:0002014|HPO|Watery stool|Diarrhea
+C0011991|T184|HP:0002014|HPO|Watery stools|Diarrhea
+```
+
+Chart review mode will only label phrases whose CUI appears in this symptom file.
+And the label used will be the last part of each line (the `PREF` part).
+
+That is, with the above symptoms file, the word `headache` would not be labelled at all
+because no CUI for headache is listed in the file.
+But any phrases that cTAKES tags as CUI `C0011991` will be labelled as `Diarrhea`.
+
+cTAKES has an internal dictionary and knows some phrases already.
+But you may get better results by adding extra terms and variations in your symptoms file.
+
+## Disabling Features
+
+You may not need NLP or `philter` processing.
+Simply pass `--no-nlp` or `--no-philter` and those steps will be skipped.
+
+## Label Studio
+
+### Overwriting
+
+By default, chart review mode will never overwrite any data in Label Studio.
+It will push new notes and skip any that were already uploaded to Label Studio.
+
+But obviously, that becomes annoying if you are iterating on a dictionary or
+otherwise re-running chart review mode.
+
+So to overwrite existing notes, simply pass `--overwrite`.
+
+### Label Config
+
+Before using chart review mode, you should have already set up your Label Studio instance.
+Read [their docs](https://labelstud.io/guide/) to get started with that.
+
+Those docs can guide you through how to define your labels.
+But just briefly, a setup like this with hard-coded labels will work:
+```
+<View>
+  <Labels name="label" toName="text">
+    <Label value="Diarrhea" background="#3333cc"/>
+    <Label value="Congestion or runny nose" background="#99ccff"/>
+  </Labels>
+  <Text name="text" value="$text"/>
+</View>
+```
+
+Or you can use dynamic labels, and chart review mode will define them from your symptoms file:
+```
+<View>
+  <Labels name="label" toName="text" value="$label" />
+  <Text name="text" value="$text"/>
+</View>
+```

--- a/docs/deid.md
+++ b/docs/deid.md
@@ -65,7 +65,7 @@ There are three main transformations of PHI inside Cumulus ETL:
 1. A [Microsoft anonymization tool](https://github.com/microsoft/Tools-for-Health-Data-Anonymization)
    is run on the bulk data.
 2. Cumulus ETL replaces all resource IDs with anonymized IDs and runs philter on a few text fields
-3. NLP is run on physician notes (which are then discarded)
+3. NLP is run on clinical notes (which are then discarded)
 
 ### Microsoft Anonymizer
 
@@ -103,9 +103,9 @@ All extensions are removed, except for:
 - The USCDI patient extensions (birth sex, gender identity, race, and ethnicity)
 - "Modifier" extensions which will flag to the ETL that a resource should be skipped
 
-#### Physician Notes
+#### Clinical Notes
 
-Be aware that physician notes are not removed at this stage.
+Be aware that clinical notes are not removed at this stage.
 They are kept for now, so that Cumulus ETL can run natural language processing on them.
 See below for more information on that.
 
@@ -159,9 +159,9 @@ This replaces any detected PHI like names, phone numbers, MRNs, social security 
 
 But be warned that it will significantly slow down the ETL process.
 
-### NLP on Physician Notes
+### NLP on Clinical Notes
 
-Physician notes are kept long enough to run them through cTAKES natural language processing,
+Clinical notes are kept long enough to run them through cTAKES natural language processing,
 then they are thrown away.
 
 The resulting detected symptoms and other medical codes from cTAKES are then kept in the de-identified results.

--- a/docs/index.md
+++ b/docs/index.md
@@ -13,7 +13,7 @@ ETL stands for "extract, transform, load."
 
 1. Cumulus ETL first **extracts** data from the hospital servers
    (usually in the form of a [bulk FHIR export](bulk-exports.md)).
-1. Then it **transforms** that data by [de-identifying](deid.md) it and converting physician notes
+1. Then it **transforms** that data by [de-identifying](deid.md) it and converting clinical notes
    into lists of symptoms.
 1. And finally it **loads** that data onto the cloud to be consumed by the
    [next phase](https://docs.smarthealthit.org/cumulus/library/) of the Cumulus pipeline.

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -21,7 +21,7 @@ safely and while preserving privacy.
 
 Cumulus provides four main features:
 
-1. Natural language processing of physician notes (to extract symptoms, etc)
+1. Natural language processing of clinical notes (to extract symptoms, etc)
 2. De-identification of patient data
 3. Aggregation of multiple hospitals' data into one data stream
 4. A dashboard for monitoring health in that aggregate population
@@ -48,7 +48,7 @@ their own servers at regular intervals.
 ETL stands for "extract, transform, load."
 Cumulus ETL first **extracts** data from the hospital servers (usually in the form of
 a bulk FHIR export).
-Then it **transforms** that data by de-identifying it and converting physician notes into lists of
+Then it **transforms** that data by de-identifying it and converting clinical notes into lists of
 symptoms.
 And finally it **loads** that data onto the cloud to be consumed by the next phase of the Cumulus
 pipeline.

--- a/docs/performance.md
+++ b/docs/performance.md
@@ -57,7 +57,7 @@ That is, they are mostly concerned with processing data as fast as possible and 
 But the natural language processing (NLP) that Cumulus ETL does can also be _hugely_ sped up with access to a GPU.
 An order of magnitude faster.
 
-For example, BCH ran NLP on 370k physician notes with just a CPU in just under 6 weeks.
+For example, BCH ran NLP on 370k clinical notes with just a CPU in just under 6 weeks.
 But on a GPU, it took three days.
 
 Note that the machine-learning libraries we use depend on the CUDA framework,

--- a/docs/setup/sample-runs.md
+++ b/docs/setup/sample-runs.md
@@ -119,7 +119,7 @@ The docker-compose.yaml, which defines the network, adds the following container
 
 - The Cumulus ETL process itself
 - A [cTAKES](https://ctakes.apache.org/) server, to handle natural language 
-  processing of physician notes.
+  processing of clinical notes.
 
 ## Cumulus ETL
 


### PR DESCRIPTION
OK, chart-review mode seems good enough. Let's advertise it a bit more.

- Adds some chart review user docs
- Removes warning about chart-review mode being in development
- Add it to the advertised list of subcommands in --help
- Renames "physician note" -> "clinical note" (unrelated but good)


### Checklist
- [x] Consider if documentation (like in `docs/`) needs to be updated
- [x] Consider if tests should be added
