### PR TITLE
feat: strip HTML from all notes before passing to NLP

### DIFF
--- a/cumulus_etl/nlp/extract.py
+++ b/cumulus_etl/nlp/extract.py
@@ -44,7 +44,7 @@ async def covid_symptoms_extract(
 
     # Find the clinical note among the attachments
     try:
-        clinical_note, _ = await fhir_common.get_docref_note(client, docref)
+        clinical_note = await fhir_common.get_docref_note(client, docref)
     except Exception as exc:  # pylint: disable=broad-except
         logging.warning("Error getting text for docref %s: %s", docref_id, exc)
         return None

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,8 +15,8 @@ dependencies = [
     "delta-spark >= 2.3, < 3",
     # This branch includes some jwt fixes we need (and will hopefully be in mainline in future)
     "fhirclient @ git+https://github.com/mikix/client-py.git@mikix/oauth2-jwt",
-    "html2text",
     "httpx < 1",
+    "inscriptis < 3",
     "jwcrypto < 2",
     "label-studio-sdk < 1",
     "oracledb < 2",

--- a/tests/test_etl_tasks.py
+++ b/tests/test_etl_tasks.py
@@ -251,11 +251,11 @@ class TestTasks(CtakesMixin, AsyncTestCase):
     @ddt.data(
         # list of (URL, contentType), expected text
         ([("http://localhost/file-cough", "text/plain")], "cough"),  # handles absolute URL
-        ([("file-cough", "text/html")], "cough"),  # handles text/*
+        ([("file-cough", "text/html")], "cough"),  # handles html
         ([("file-cough", "application/xhtml+xml")], "cough"),  # handles xhtml
-        ([("file-cough", "text/html"), ("file-fever", "text/plain")], "fever"),  # prefers text/plain to text/*
-        ([("file-cough", "application/xhtml+xml"), ("file-fever", "text/blarg")], "fever"),  # prefers text/* to xhtml
-        ([("file-cough", "nope/nope")], None),  # ignores unsupported mimetypes
+        ([("file-cough", "text/html"), ("file-fever", "text/plain")], "fever"),  # prefers text/plain to html
+        ([("file-cough", "application/xhtml+xml"), ("file-fever", "text/html")], "fever"),  # prefers html to xhtml
+        ([("file-cough", "text/nope")], None),  # ignores unsupported mimetypes
     )
     @ddt.unpack
     @respx.mock


### PR DESCRIPTION
We found it can confuse NLP so bad that cTAKES will get stuck.

NLP results are slightly different with stripped notes, but it is a minor change in covid symptom counts (<1%) and spot checking the differences, it seems to just be around slightly different negation conclusions -- which went both ways for html & stripped.

Or a few places where cTAKES gave up on long complicated HTML (so in those cases, a clear improvement).

This commit adds stripping via the inscriptis library to the ETL and changes the chart review mode to use inscriptis rather than html2text (which gave decent results, but they weren't quite as good as inscriptis and html2text is gpl-licensed, so we shouldn't ship that if we want the resulting combo to be Apache licensed)


### Checklist
- [x] Consider if documentation (like in `docs/`) needs to be updated
- [x] Consider if tests should be added
