### PR TITLE
feat!: require Python 3.10

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -7,7 +7,8 @@ jobs:
     runs-on: ubuntu-22.04
     strategy:
       matrix:
-        python-version: ["3.8", "3.9", "3.10"]
+        # while we are still private, don't go crazy with the Python versions as they eat up CI minutes
+        python-version: ["3.10"]
 
     steps:
       - uses: actions/checkout@v3

--- a/cumulus_etl/chart_review/cli.py
+++ b/cumulus_etl/chart_review/cli.py
@@ -3,7 +3,7 @@
 import argparse
 import asyncio
 import sys
-from typing import Collection, List
+from collections.abc import Collection
 
 import ctakesclient
 from ctakesclient.typesystem import Polarity
@@ -49,7 +49,7 @@ async def gather_docrefs(
         )
 
 
-async def read_notes_from_ndjson(client: fhir_client.FhirClient, dirname: str) -> List[LabelStudioNote]:
+async def read_notes_from_ndjson(client: fhir_client.FhirClient, dirname: str) -> list[LabelStudioNote]:
     common.print_header("Downloading note text...")
     docref_ids = []
     coroutines = []
@@ -119,7 +119,7 @@ def define_chart_review_parser(parser: argparse.ArgumentParser) -> None:
     parser.add_argument(
         "--export-to", metavar="PATH", help="Where to put exported documents (default is to delete after use)"
     )
-    parser.add_argument(  # when we rely on Python 3.9, we can use BooleanOptionalAction instead
+    parser.add_argument(
         "--no-philter", action="store_false", dest="philter", default=True, help="Don’t run philter on notes"
     )
 
@@ -137,9 +137,7 @@ def define_chart_review_parser(parser: argparse.ArgumentParser) -> None:
         help="BSV file with concept CUIs (defaults to Covid)",
         default=ctakesclient.filesystem.covid_symptoms_path(),
     )
-    group.add_argument(  # when we rely on Python 3.9, we can use BooleanOptionalAction instead
-        "--no-nlp", action="store_false", dest="nlp", default=True, help="Don’t run NLP on notes"
-    )
+    group.add_argument("--no-nlp", action="store_false", dest="nlp", default=True, help="Don’t run NLP on notes")
 
     group = parser.add_argument_group("Label Studio")
     group.add_argument("--ls-token", metavar="PATH", help="Token file for Label Studio access", required=True)
@@ -179,7 +177,7 @@ async def chart_review_main(args: argparse.Namespace) -> None:
     push_to_label_studio(notes, access_token, labels, args)
 
 
-async def run_chart_review(parser: argparse.ArgumentParser, argv: List[str]) -> None:
+async def run_chart_review(parser: argparse.ArgumentParser, argv: list[str]) -> None:
     """Parses a chart review CLI"""
     define_chart_review_parser(parser)
     args = parser.parse_args(argv)

--- a/cumulus_etl/chart_review/downloader.py
+++ b/cumulus_etl/chart_review/downloader.py
@@ -5,7 +5,7 @@ import itertools
 import logging
 import os
 import urllib.parse
-from typing import Container, Iterable, List, Optional
+from collections.abc import Container, Iterable
 
 from cumulus_etl import cli_utils, common, deid, fhir_client, loaders, store
 
@@ -93,7 +93,7 @@ def _write_docrefs_to_output_folder(docrefs: Iterable[dict], output_folder: str)
 
 async def _request_docrefs_for_patient(
     client: fhir_client.FhirClient, patient_id: str, codebook: deid.Codebook, fake_docref_ids: Container[str]
-) -> List[dict]:
+) -> list[dict]:
     """Returns all DocumentReferences for a given patient"""
     params = {
         "patient": patient_id,
@@ -115,7 +115,7 @@ async def _request_docrefs_for_patient(
     return docrefs
 
 
-async def _request_docref(client: fhir_client.FhirClient, docref_id: str) -> Optional[dict]:
+async def _request_docref(client: fhir_client.FhirClient, docref_id: str) -> dict | None:
     """Returns one DocumentReference for a given ID"""
     print(f"  Downloading docref {docref_id}.")
     try:

--- a/cumulus_etl/chart_review/labelstudio.py
+++ b/cumulus_etl/chart_review/labelstudio.py
@@ -1,6 +1,6 @@
 """LabelStudio document annotation"""
 
-from typing import Collection, Dict, Iterable, List, Tuple
+from collections.abc import Collection, Iterable
 
 import ctakesclient.typesystem
 import label_studio_sdk
@@ -21,13 +21,13 @@ class LabelStudioNote:
     def __init__(self, ref_id: str, text: str):
         self.ref_id = ref_id
         self.text = text
-        self.matches: List[ctakesclient.typesystem.MatchText] = []
+        self.matches: list[ctakesclient.typesystem.MatchText] = []
 
 
 class LabelStudioClient:
     """Client to talk to Label Studio"""
 
-    def __init__(self, url: str, api_key: str, project_id: int, cui_labels: Dict[str, str]):
+    def __init__(self, url: str, api_key: str, project_id: int, cui_labels: dict[str, str]):
         self._client = label_studio_sdk.Client(url, api_key)
         self._client.check_connection()
         self._project = self._client.get_project(project_id)
@@ -60,7 +60,7 @@ class LabelStudioClient:
             if new_task_count:
                 print(f"  Imported {new_task_count} new tasks")
 
-    def _get_labels_config(self) -> Tuple[str, dict]:
+    def _get_labels_config(self) -> tuple[str, dict]:
         """Finds the first <Labels> tag in the config and returns its name and values, falling back to <Choices>"""
         for k, v in self._project.parsed_label_config.items():
             if v.get("type") == "Labels":

--- a/cumulus_etl/chart_review/selector.py
+++ b/cumulus_etl/chart_review/selector.py
@@ -2,7 +2,7 @@
 
 import functools
 import os
-from typing import Callable, Iterable, Iterator
+from collections.abc import Callable, Iterable, Iterator
 
 from cumulus_etl import cli_utils, common, deid, loaders, store
 

--- a/cumulus_etl/cli.py
+++ b/cumulus_etl/cli.py
@@ -5,7 +5,6 @@ import asyncio
 import enum
 import logging
 import sys
-from typing import List, Optional
 
 from cumulus_etl import chart_review, etl
 from cumulus_etl.etl import convert
@@ -22,7 +21,7 @@ class Command(enum.Enum):
         return [e.value for e in cls]
 
 
-def get_subcommand(argv: List[str]) -> Optional[str]:
+def get_subcommand(argv: list[str]) -> str | None:
     """
     Determines which subcommand was requested by the given command line.
 
@@ -38,7 +37,7 @@ def get_subcommand(argv: List[str]) -> Optional[str]:
             return None  # first positional arg did not match a known command, assume default command
 
 
-async def main(argv: List[str]) -> None:
+async def main(argv: list[str]) -> None:
     logging.basicConfig(format="%(message)s")  # hide gross log prefix of "WARNING:root:" etc, just display message
 
     subcommand = get_subcommand(argv)

--- a/cumulus_etl/common.py
+++ b/cumulus_etl/common.py
@@ -6,7 +6,8 @@ import datetime
 import json
 import logging
 import re
-from typing import Any, Iterator, List, Optional
+from collections.abc import Iterator
+from typing import Any
 from urllib.parse import urlparse
 
 import fsspec
@@ -19,7 +20,7 @@ import fsspec
 ###############################################################################
 
 
-def ls_resources(root, resource: str) -> List[str]:
+def ls_resources(root, resource: str) -> list[str]:
     pattern = re.compile(rf".*/([0-9]+.)?{resource}(.[0-9]+)?.ndjson")
     all_files = root.ls()
     return sorted(filter(pattern.match, all_files))
@@ -112,7 +113,7 @@ def read_json(path: str) -> Any:
         return json.load(f)
 
 
-def write_json(path: str, data: Any, indent: Optional[int] = None) -> None:
+def write_json(path: str, data: Any, indent: int = None) -> None:
     """
     Writes data to the given path, in json format
     :param path: filesystem path

--- a/cumulus_etl/deid/codebook.py
+++ b/cumulus_etl/deid/codebook.py
@@ -5,7 +5,7 @@ import hmac
 import logging
 import os
 import secrets
-from typing import Dict, Iterable, Iterator, Optional
+from collections.abc import Iterable, Iterator
 
 from cumulus_etl import common
 
@@ -28,7 +28,7 @@ class Codebook:
         except (FileNotFoundError, PermissionError):
             self.db = CodebookDB()
 
-    def fake_id(self, resource_type: Optional[str], real_id: str, caching_allowed: bool = True) -> str:
+    def fake_id(self, resource_type: str | None, real_id: str, caching_allowed: bool = True) -> str:
         """
         Returns a new fake ID in place of the provided real ID
 
@@ -58,7 +58,7 @@ class Codebook:
         else:
             return self.db.resource_hash(real_id)
 
-    def real_ids(self, resource_type: str, fake_ids: Iterable[str]) -> Iterator[Optional[str]]:
+    def real_ids(self, resource_type: str, fake_ids: Iterable[str]) -> Iterator[str]:
         """
         Reverse-maps a list of fake IDs into real IDs.
 
@@ -178,7 +178,7 @@ class CodebookDB:
 
         return fake_id
 
-    def get_reverse_mapping(self, resource_type: str) -> Dict[str, str]:
+    def get_reverse_mapping(self, resource_type: str) -> dict[str, str]:
         """
         Returns reversed cached mappings for a given resource.
 

--- a/cumulus_etl/etl/cli.py
+++ b/cumulus_etl/etl/cli.py
@@ -8,7 +8,7 @@ import os
 import shutil
 import sys
 import tempfile
-from typing import Iterable, List, Type
+from collections.abc import Iterable
 
 import rich
 import rich.table
@@ -41,8 +41,8 @@ async def load_and_deidentify(loader: loaders.Loader, resources: Iterable[str]) 
 
 
 async def etl_job(
-    config: JobConfig, selected_tasks: List[Type[tasks.EtlTask]], use_philter: bool = False
-) -> List[JobSummary]:
+    config: JobConfig, selected_tasks: list[type[tasks.EtlTask]], use_philter: bool = False
+) -> list[JobSummary]:
     """
     :param config: job config
     :param selected_tasks: the tasks to run
@@ -279,7 +279,7 @@ async def etl_main(args: argparse.Namespace) -> None:
         raise SystemExit(errors.TASK_FAILED)
 
 
-async def run_etl(parser: argparse.ArgumentParser, argv: List[str]) -> None:
+async def run_etl(parser: argparse.ArgumentParser, argv: list[str]) -> None:
     """Parses an etl CLI"""
     define_etl_parser(parser)
     args = parser.parse_args(argv)

--- a/cumulus_etl/etl/config.py
+++ b/cumulus_etl/etl/config.py
@@ -3,7 +3,6 @@
 import datetime
 import os
 from socket import gethostname
-from typing import List
 
 from cumulus_etl import common, fhir_client, formats, store
 
@@ -31,7 +30,7 @@ class JobConfig:
         batch_size: int = 1,  # this default is never really used - overridden by command line args
         ctakes_overrides: str = None,
         dir_errors: str = None,
-        tasks: List[str] = None,
+        tasks: list[str] = None,
     ):
         self._dir_input_orig = dir_input_orig
         self.dir_input = dir_input_deid

--- a/cumulus_etl/etl/context.py
+++ b/cumulus_etl/etl/context.py
@@ -3,7 +3,6 @@ ETL job context, holding some persistent state between runs.
 """
 
 import datetime
-from typing import Optional
 
 from cumulus_etl import common
 
@@ -38,7 +37,7 @@ class JobContext:
             self._data = {}
 
     @property
-    def last_successful_datetime(self) -> Optional[datetime.datetime]:
+    def last_successful_datetime(self) -> datetime.datetime | None:
         value = self._data.get(self._LAST_SUCCESSFUL_DATETIME)
         if value is not None:
             return datetime.datetime.fromisoformat(value)
@@ -49,7 +48,7 @@ class JobContext:
         self._data[self._LAST_SUCCESSFUL_DATETIME] = value.isoformat()
 
     @property
-    def last_successful_input_dir(self) -> Optional[str]:
+    def last_successful_input_dir(self) -> str | None:
         return self._data.get(self._LAST_SUCCESSFUL_INPUT_DIR)
 
     @last_successful_input_dir.setter
@@ -57,7 +56,7 @@ class JobContext:
         self._data[self._LAST_SUCCESSFUL_INPUT_DIR] = value
 
     @property
-    def last_successful_output_dir(self) -> Optional[str]:
+    def last_successful_output_dir(self) -> str | None:
         return self._data.get(self._LAST_SUCCESSFUL_OUTPUT_DIR)
 
     @last_successful_output_dir.setter

--- a/cumulus_etl/etl/convert/cli.py
+++ b/cumulus_etl/etl/convert/cli.py
@@ -7,7 +7,6 @@ Usually used for ndjson -> deltalake conversions, after the ndjson has been manu
 import argparse
 import os
 import tempfile
-from typing import List, Type
 
 import pandas
 import rich.progress
@@ -28,10 +27,10 @@ def make_progress_bar() -> rich.progress.Progress:
 
 
 def convert_task(
-    task: Type[tasks.EtlTask],
+    task: type[tasks.EtlTask],
     input_root: store.Root,
     output_root: store.Root,
-    formatter_class: Type[formats.Format],
+    formatter_class: type[formats.Format],
     progress: rich.progress.Progress,
 ) -> None:
     """Converts a single task folder (like output/observation/ or output/covid_symptom__nlp_results/)"""
@@ -77,7 +76,7 @@ def copy_job_configs(input_root: store.Root, output_root: store.Root) -> None:
         output_root.put(job_config_path, output_root.path, recursive=True)
 
 
-def walk_tree(input_root: store.Root, output_root: store.Root, formatter_class: Type[formats.Format]) -> None:
+def walk_tree(input_root: store.Root, output_root: store.Root, formatter_class: type[formats.Format]) -> None:
     all_tasks = tasks.EtlTask.get_all_tasks()
 
     with make_progress_bar() as progress:
@@ -140,7 +139,7 @@ async def convert_main(args: argparse.Namespace) -> None:
     walk_tree(input_root, output_root, formatter_class)
 
 
-async def run_convert(parser: argparse.ArgumentParser, argv: List[str]) -> None:
+async def run_convert(parser: argparse.ArgumentParser, argv: list[str]) -> None:
     """Parse arguments and do the work"""
     define_convert_parser(parser)
     args = parser.parse_args(argv)

--- a/cumulus_etl/etl/studies/covid_symptom/covid_ctakes.py
+++ b/cumulus_etl/etl/studies/covid_symptom/covid_ctakes.py
@@ -1,7 +1,6 @@
 """Helper code for asking cTAKES & cNLP to process docrefs for covid symptoms"""
 
 import logging
-from typing import List, Optional
 
 import ctakesclient
 import httpx
@@ -15,7 +14,7 @@ async def covid_symptoms_extract(
     docref: dict,
     ctakes_http_client: httpx.AsyncClient = None,
     cnlp_http_client: httpx.AsyncClient = None,
-) -> Optional[List[dict]]:
+) -> list[dict] | None:
     """
     Extract a list of Observations from NLP-detected symptoms in clinical notes
 

--- a/cumulus_etl/etl/studies/covid_symptom/covid_tasks.py
+++ b/cumulus_etl/etl/studies/covid_symptom/covid_tasks.py
@@ -3,7 +3,7 @@
 import copy
 import itertools
 import os
-from typing import AsyncIterator, List, Union
+from collections.abc import AsyncIterator
 
 import ctakesclient
 
@@ -81,7 +81,7 @@ class CovidSymptomNlpResultsTask(tasks.EtlTask):
         with common.NdjsonWriter(error_path, "a") as writer:
             writer.write(docref)
 
-    async def read_entries(self) -> AsyncIterator[Union[List[dict], dict]]:
+    async def read_entries(self) -> AsyncIterator[dict | list[dict]]:
         """Passes clinical notes through NLP and returns any symptoms found"""
         phi_root = store.Root(self.task_config.dir_phi, create=True)
 

--- a/cumulus_etl/fhir_client.py
+++ b/cumulus_etl/fhir_client.py
@@ -8,7 +8,7 @@ import time
 import urllib.parse
 import uuid
 from json import JSONDecodeError
-from typing import Iterable, Optional
+from collections.abc import Iterable
 
 import httpx
 from jwcrypto import jwk, jwt
@@ -214,7 +214,7 @@ class FhirClient:
 
     def __init__(
         self,
-        url: Optional[str],
+        url: str | None,
         resources: Iterable[str],
         basic_user: str = None,
         basic_password: str = None,
@@ -237,7 +237,7 @@ class FhirClient:
         if self._server_root and not self._server_root.endswith("/"):
             self._server_root += "/"  # This will ensure the last segment does not get chopped off by urljoin
         self._auth = self._make_auth(resources, basic_user, basic_password, bearer_token, smart_client_id, smart_jwks)
-        self._session: Optional[httpx.AsyncClient] = None
+        self._session: httpx.AsyncClient | None = None
 
     async def __aenter__(self):
         # Limit the number of connections open at once, because EHRs tend to be very busy.

--- a/cumulus_etl/fhir_common.py
+++ b/cumulus_etl/fhir_common.py
@@ -3,7 +3,6 @@
 import base64
 import cgi
 import re
-from typing import Optional
 
 import inscriptis
 
@@ -20,7 +19,7 @@ RELATIVE_SEPARATOR_REGEX = re.compile("[/?]")
 ###############################################################################
 
 
-def ref_resource(resource_type: Optional[str], resource_id: str) -> dict:
+def ref_resource(resource_type: str | None, resource_id: str) -> dict:
     """
     Reference the FHIR proper way
     :param resource_type: Name of resource, like "Patient"
@@ -32,7 +31,7 @@ def ref_resource(resource_type: Optional[str], resource_id: str) -> dict:
     return {"reference": f"{resource_type}/{resource_id}" if resource_type else resource_id}
 
 
-def unref_resource(ref: dict) -> (Optional[str], str):
+def unref_resource(ref: dict) -> (str | None, str):
     """
     Returns the type & ID for the target of the reference
 

--- a/cumulus_etl/formats/factory.py
+++ b/cumulus_etl/formats/factory.py
@@ -1,14 +1,12 @@
 """Create a Format instance"""
 
-from typing import Type
-
 from .base import Format
 from .deltalake import DeltaLakeFormat
 from .ndjson import NdjsonFormat
 from .parquet import ParquetFormat
 
 
-def get_format_class(name: str) -> Type[Format]:
+def get_format_class(name: str) -> type[Format]:
     """
     Returns a Format class of the named type for the target output path.
     """

--- a/cumulus_etl/loaders/base.py
+++ b/cumulus_etl/loaders/base.py
@@ -1,7 +1,7 @@
 """Base abstract loader"""
 
 import abc
-from typing import List, Protocol
+from typing import Protocol
 
 from cumulus_etl.store import Root
 
@@ -36,7 +36,7 @@ class Loader(abc.ABC):
         self.root = root
 
     @abc.abstractmethod
-    async def load_all(self, resources: List[str]) -> Directory:
+    async def load_all(self, resources: list[str]) -> Directory:
         """
         Loads the listed remote resources and places them into a local folder as FHIR ndjson
 

--- a/cumulus_etl/loaders/fhir/bulk_export.py
+++ b/cumulus_etl/loaders/fhir/bulk_export.py
@@ -4,7 +4,6 @@ import asyncio
 import json
 import os
 import urllib.parse
-from typing import List
 
 import httpx
 
@@ -24,7 +23,7 @@ class BulkExporter:
     _TIMEOUT_THRESHOLD = 60 * 60 * 24  # a day, which is probably an overly generous timeout
 
     def __init__(
-        self, client: FhirClient, resources: List[str], url: str, destination: str, since: str = None, until: str = None
+        self, client: FhirClient, resources: list[str], url: str, destination: str, since: str = None, until: str = None
     ):
         """
         Initialize a bulk exporter (but does not start an export).
@@ -163,7 +162,7 @@ class BulkExporter:
 
         raise FatalError("Timed out waiting for the bulk FHIR export to finish.")
 
-    async def _gather_all_messages(self, errors: List[dict]) -> (List[str], List[str]):
+    async def _gather_all_messages(self, errors: list[dict]) -> (list[str], list[str]):
         """
         Downloads all outcome message ndjson files from the bulk export server.
 
@@ -192,7 +191,7 @@ class BulkExporter:
 
         return fatal_messages, info_messages
 
-    async def _download_all_ndjson_files(self, files: List[dict]) -> None:
+    async def _download_all_ndjson_files(self, files: list[dict]) -> None:
         """
         Downloads all exported ndjson files from the bulk export server.
 

--- a/cumulus_etl/loaders/fhir/ndjson_loader.py
+++ b/cumulus_etl/loaders/fhir/ndjson_loader.py
@@ -2,7 +2,6 @@
 
 import logging
 import tempfile
-from typing import List
 
 from cumulus_etl import cli_utils, common, errors, store
 from cumulus_etl.fhir_client import FatalError, FhirClient
@@ -39,7 +38,7 @@ class FhirNdjsonLoader(base.Loader):
         self.since = since
         self.until = until
 
-    async def load_all(self, resources: List[str]) -> base.Directory:
+    async def load_all(self, resources: list[str]) -> base.Directory:
         # Are we doing a bulk FHIR export from a server?
         if self.root.protocol in ["http", "https"]:
             return await self._load_from_bulk_export(resources)
@@ -68,7 +67,7 @@ class FhirNdjsonLoader(base.Loader):
                 logging.warning("No resources found for %s", resource)
         return tmpdir
 
-    async def _load_from_bulk_export(self, resources: List[str]) -> base.Directory:
+    async def _load_from_bulk_export(self, resources: list[str]) -> base.Directory:
         target_dir = cli_utils.make_export_dir(self.export_to)
 
         try:

--- a/cumulus_etl/loaders/i2b2/extract.py
+++ b/cumulus_etl/loaders/i2b2/extract.py
@@ -1,7 +1,7 @@
 """Read files into data structures"""
 
 import logging
-from typing import Iterator
+from collections.abc import Iterator
 
 import pandas
 

--- a/cumulus_etl/loaders/i2b2/loader.py
+++ b/cumulus_etl/loaders/i2b2/loader.py
@@ -1,8 +1,9 @@
 """I2B2 loader"""
 
 import os
+from collections.abc import Callable, Iterable
 from functools import partial
-from typing import Callable, Iterable, List, TypeVar
+from typing import TypeVar
 
 from cumulus_etl import cli_utils, common, store
 from cumulus_etl.loaders.base import Directory, Loader
@@ -33,7 +34,7 @@ class I2b2Loader(Loader):
         self.batch_size = batch_size
         self.export_to = export_to
 
-    async def load_all(self, resources: List[str]) -> Directory:
+    async def load_all(self, resources: list[str]) -> Directory:
         if self.root.protocol in ["tcp"]:
             return self._load_all_from_oracle(resources)
 
@@ -41,7 +42,7 @@ class I2b2Loader(Loader):
 
     def _load_all_with_extractors(
         self,
-        resources: List[str],
+        resources: list[str],
         conditions: I2b2ExtractorCallable,
         lab_views: I2b2ExtractorCallable,
         medicationrequests: I2b2ExtractorCallable,
@@ -127,7 +128,7 @@ class I2b2Loader(Loader):
     #
     ###################################################################################################################
 
-    def _load_all_from_csv(self, resources: List[str]) -> Directory:
+    def _load_all_from_csv(self, resources: list[str]) -> Directory:
         path = self.root.path
         return self._load_all_with_extractors(
             resources,
@@ -166,7 +167,7 @@ class I2b2Loader(Loader):
     #
     ###################################################################################################################
 
-    def _load_all_from_oracle(self, resources: List[str]) -> Directory:
+    def _load_all_from_oracle(self, resources: list[str]) -> Directory:
         path = self.root.path
         return self._load_all_with_extractors(
             resources,

--- a/cumulus_etl/loaders/i2b2/oracle/extract.py
+++ b/cumulus_etl/loaders/i2b2/oracle/extract.py
@@ -1,7 +1,7 @@
 """Extract data types from oracle"""
 
 import time
-from typing import Iterable, List
+from collections.abc import Iterable
 
 from cumulus_etl import common
 from cumulus_etl.loaders.i2b2.schema import ObservationFact, PatientDimension, VisitDimension
@@ -40,7 +40,7 @@ def execute(dsn: str, desc: str, sql_statement: str) -> Iterable[dict]:
     print(f"Done with {desc}! Downloaded {count:,} total.")
 
 
-def list_observation_fact(dsn: str, categories: List[str]) -> List[ObservationFact]:
+def list_observation_fact(dsn: str, categories: list[str]) -> list[ObservationFact]:
     """
     Grabs a single category of observation facts.
 
@@ -68,28 +68,28 @@ def list_observation_fact(dsn: str, categories: List[str]) -> List[ObservationFa
     return facts
 
 
-def list_patient(dsn: str) -> List[PatientDimension]:
+def list_patient(dsn: str) -> list[PatientDimension]:
     patients = []
     for row in execute(dsn, "PatientDimension", query.sql_patient()):
         patients.append(PatientDimension(row))
     return patients
 
 
-def list_visit(dsn: str) -> List[VisitDimension]:
+def list_visit(dsn: str) -> list[VisitDimension]:
     visits = []
     for row in execute(dsn, "VisitDimension", query.sql_visit()):
         visits.append(VisitDimension(row))
     return visits
 
 
-def list_concept(dsn: str) -> List[ConceptDimension]:
+def list_concept(dsn: str) -> list[ConceptDimension]:
     concepts = []
     for row in execute(dsn, "ConceptDimension", query.sql_concept()):
         concepts.append(ConceptDimension(row))
     return concepts
 
 
-def list_provider(dsn: str) -> List[ProviderDimension]:
+def list_provider(dsn: str) -> list[ProviderDimension]:
     providers = []
     for row in execute(dsn, "ProviderDimension", query.sql_provider()):
         providers.append(ProviderDimension(row))

--- a/cumulus_etl/loaders/i2b2/oracle/query.py
+++ b/cumulus_etl/loaders/i2b2/oracle/query.py
@@ -1,7 +1,5 @@
 """Actual queries to oracle"""
 
-from typing import List
-
 from cumulus_etl.loaders.i2b2.schema import Table, ValueType
 
 
@@ -83,7 +81,7 @@ def sql_concept() -> str:
 ###############################################################################
 
 
-def sql_observation_fact(categories: List[str]) -> str:
+def sql_observation_fact(categories: list[str]) -> str:
     """
     :param categories: the types of fact (or "concept cd" in the database's term)
     :return: SQL for ObservationFact

--- a/cumulus_etl/loaders/i2b2/transform.py
+++ b/cumulus_etl/loaders/i2b2/transform.py
@@ -2,7 +2,6 @@
 
 import base64
 import logging
-from typing import Optional
 
 from cumulus_etl import fhir_common
 from cumulus_etl.loaders.i2b2 import external_mappings
@@ -288,7 +287,7 @@ def to_fhir_documentreference(obsfact: ObservationFact) -> dict:
 ###############################################################################
 
 
-def chop_to_date(yyyy_mm_dd: Optional[str]) -> Optional[str]:
+def chop_to_date(yyyy_mm_dd: str | None) -> str | None:
     """
     To be less sensitive to how i2b2 datetimes are formatted, chop to just the day/date part.
 
@@ -344,7 +343,7 @@ def get_observation_value(obsfact: ObservationFact) -> dict:
     return {"valueQuantity": quantity}
 
 
-def make_concept(code: str, system: Optional[str], display: str = None) -> dict:
+def make_concept(code: str, system: str | None, display: str = None) -> dict:
     """Syntactic sugar to make a codeable concept"""
     coding = {"code": code, "system": system}
     if display is not None:

--- a/cumulus_etl/nlp/extract.py
+++ b/cumulus_etl/nlp/extract.py
@@ -2,7 +2,6 @@
 
 import hashlib
 import os
-from typing import List
 
 import ctakesclient
 import httpx
@@ -41,9 +40,9 @@ async def list_polarity(
     cache: store.Root,
     namespace: str,
     sentence: str,
-    spans: List[tuple],
+    spans: list[tuple],
     client: httpx.AsyncClient = None,
-) -> List[ctakesclient.typesystem.Polarity]:
+) -> list[ctakesclient.typesystem.Polarity]:
     """
     This is a version of ctakesclient.transformer.list_polarity() that also uses a cache
 

--- a/cumulus_etl/store.py
+++ b/cumulus_etl/store.py
@@ -1,7 +1,7 @@
 """Abstraction for where to write and read data"""
 
 import os
-from typing import Iterator
+from collections.abc import Iterator
 from urllib.parse import urlparse
 
 import fsspec

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "cumulus-etl"
-requires-python = ">= 3.8"
+requires-python = ">= 3.10"
 # These dependencies are mostly pinned to be under the next major version.
 # That makes particular sense as long as we don't have official releases yet and our code is used
 # by pulling from main directly.

--- a/tests/ctakesmock.py
+++ b/tests/ctakesmock.py
@@ -9,7 +9,6 @@ import socketserver
 import tempfile
 import unittest
 from functools import partial
-from typing import List, Optional
 from unittest import mock
 
 from ctakesclient import typesystem
@@ -67,7 +66,7 @@ class CtakesMixin(unittest.TestCase):
         has_started.wait()  # make sure we don't proceed with test until the server we started is ready
 
 
-def _get_mtime(path) -> Optional[float]:
+def _get_mtime(path) -> float | None:
     """Gets mtime of a filename"""
     try:
         return os.stat(path).st_mtime
@@ -234,7 +233,7 @@ def fake_ctakes_extract(sentence: str) -> typesystem.CtakesJSON:
     return typesystem.CtakesJSON(response)
 
 
-async def fake_transformer_list_polarity(sentence: str, spans: List[tuple], client=None) -> List[typesystem.Polarity]:
+async def fake_transformer_list_polarity(sentence: str, spans: list[tuple], client=None) -> list[typesystem.Polarity]:
     """Simple always-positive fake response from cNLP."""
     del sentence, client
     return [typesystem.Polarity.pos] * len(spans)

--- a/tests/s3mock.py
+++ b/tests/s3mock.py
@@ -7,7 +7,7 @@ See https://github.com/aio-libs/aiobotocore/issues/755
 
 import os
 import unittest
-from typing import Callable
+from collections.abc import Callable
 from unittest.mock import MagicMock, patch
 
 import aiobotocore.awsrequest

--- a/tests/test_chart_cli.py
+++ b/tests/test_chart_cli.py
@@ -5,7 +5,7 @@ import json
 import os
 import shutil
 import tempfile
-from typing import Iterable, List, Set, Tuple
+from collections.abc import Iterable
 from unittest import mock
 
 import ddt
@@ -105,7 +105,7 @@ class TestChartReview(CtakesMixin, AsyncTestCase):
         await cli.main(args)
 
     @staticmethod
-    def make_docref(doc_id: str, text: str = None, content: List[dict] = None) -> dict:
+    def make_docref(doc_id: str, text: str = None, content: list[dict] = None) -> dict:
         if content is None:
             text = text or "What's up doc?"
             content = [
@@ -143,24 +143,24 @@ class TestChartReview(CtakesMixin, AsyncTestCase):
         respx.get(f"https://localhost/DocumentReference/{doc_id}").respond(status_code=code, json=docref)
 
     @staticmethod
-    def write_anon_docrefs(path: str, ids: List[Tuple[str, str]]) -> None:
+    def write_anon_docrefs(path: str, ids: list[tuple[str, str]]) -> None:
         """Fills a file with the provided docref ids of (docref_id, patient_id) tuples"""
         lines = ["docref_id,patient_id"] + [f"{x[0]},{x[1]}" for x in ids]
         with open(path, "w", encoding="utf8") as f:
             f.write("\n".join(lines))
 
     @staticmethod
-    def write_real_docrefs(path: str, ids: List[str]) -> None:
+    def write_real_docrefs(path: str, ids: list[str]) -> None:
         """Fills a file with the provided docref ids"""
         lines = ["docref_id"] + ids
         with open(path, "w", encoding="utf8") as f:
             f.write("\n".join(lines))
 
-    def get_exported_ids(self) -> Set[str]:
+    def get_exported_ids(self) -> set[str]:
         with common.open_file(os.path.join(self.export_path, "DocumentReference.ndjson"), "r") as f:
             return {json.loads(line)["id"] for line in f}
 
-    def get_pushed_ids(self) -> Set[str]:
+    def get_pushed_ids(self) -> set[str]:
         notes = self.ls_client.push_tasks.call_args[0][0]
         return {n.ref_id for n in notes}
 

--- a/tests/test_etl_cli.py
+++ b/tests/test_etl_cli.py
@@ -5,7 +5,6 @@ import json
 import os
 import shutil
 import tempfile
-from typing import Optional
 from unittest import mock
 
 import pytest
@@ -49,7 +48,7 @@ class BaseEtlSimple(CtakesMixin, TreeCompareMixin, AsyncTestCase):
         input_path=None,
         output_path=None,
         phi_path=None,
-        output_format: Optional[str] = "ndjson",
+        output_format: str | None = "ndjson",
         comment=None,
         batch_size=None,
         tasks=None,

--- a/tests/test_etl_tasks.py
+++ b/tests/test_etl_tasks.py
@@ -3,7 +3,7 @@
 import os
 import shutil
 import tempfile
-from typing import AsyncIterator, List
+from collections.abc import AsyncIterator
 from unittest import mock
 
 import ddt
@@ -68,12 +68,12 @@ class TestTasks(TaskTestCase):
         # pylint: disable=protected-access
 
         # Tiny little convenience method to be turn sync lists into async iterators.
-        async def async_iter(values: List) -> AsyncIterator:
+        async def async_iter(values: list) -> AsyncIterator:
             for x in values:
                 yield x
 
         # Handles converting all the async code into synchronous lists for ease of testing
-        async def assert_batches_equal(expected: List, values: List, batch_size: int) -> None:
+        async def assert_batches_equal(expected: list, values: list, batch_size: int) -> None:
             collected = []
             async for batch in tasks._batch_iterate(async_iter(values), batch_size):
                 batch_list = []

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -9,7 +9,6 @@ import json
 import os
 import time
 import unittest
-from typing import List
 from unittest import mock
 
 import freezegun
@@ -171,7 +170,7 @@ def make_response(status_code=200, json_payload=None, text=None, reason=None, he
     )
 
 
-def read_delta_lake(lake_path: str, *, version: int = None) -> List[dict]:
+def read_delta_lake(lake_path: str, *, version: int = None) -> list[dict]:
     """
     Reads in a delta lake folder at a certain time, sorted by id.
 


### PR DESCRIPTION
The motivating factor here is reducing CI minutes by not testing on three different versions of Python.

Since in practice, we only really ship one version (3.10) in our production Docker images, let's just standardize on that.

This means our minimum Python goes from 3.8 to 3.10 (and our max tested Python remains at 3.10).

A few related code changes while I was doing this:
- Use `aiter()` and `anext()` instead of `__aiter__()` and `__anext__()`
- Drop "from typing import List" etc and just use types directly
- Likewise, use the | operator to replace Optional & Union typing
- Drop a comment in chart-review about using `BooleanOptionalAction` (without actually switching) because I found that I didn't like the behavior of that flag after all -- I just need the --no- versions without the "True" versions of the flags.


### Checklist
- [x] Consider if documentation (like in `docs/`) needs to be updated
- [x] Consider if tests should be added
