### PR TITLE
ci: run less often, in pointless cases

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,5 +1,18 @@
 name: CI
-on: [push]
+on:
+  pull_request:
+    paths-ignore:
+      - 'docs/**'
+  push:
+    branches:
+      - main
+    paths-ignore:
+      - 'docs/**'
+
+# The goal here is to cancel older workflows when a PR is updated (because it's pointless work)
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.ref_name }}
+  cancel-in-progress: true
 
 jobs:
   unittest:


### PR DESCRIPTION
(CI is disabled right now, but this will hopefully be useful when it's back on)

- Cancel older runs of a given branch
- Skip CI if it's only docs/ changes
- Don't run for branches that don't have a PR yet


### Checklist
- [x] Consider if documentation (like in `docs/`) needs to be updated
- [x] Consider if tests should be added
