### PR TITLE
feat: when writing delta lake tables, include a shallow FHIR schema

### DIFF
--- a/cumulus_etl/deid/scrubber.py
+++ b/cumulus_etl/deid/scrubber.py
@@ -4,7 +4,7 @@ import logging
 import tempfile
 from typing import Any
 
-from cumulus_etl import fhir_common
+from cumulus_etl import fhir
 from cumulus_etl.deid import codebook, mstool, philter
 
 
@@ -148,7 +148,7 @@ class Scrubber:
         # References
         # "reference" can sometimes be a URL or non-FHIRReference element -- at some point we'll need to be smarter.
         elif key == "reference":
-            resource_type, real_id = fhir_common.unref_resource(node)
+            resource_type, real_id = fhir.unref_resource(node)
 
             # Handle contained references (see comments in unref_resource for more detail)
             prefix = ""
@@ -157,7 +157,7 @@ class Scrubber:
                 real_id = real_id[1:]
 
             fake_id = f"{prefix}{self.codebook.fake_id(resource_type, real_id)}"
-            node["reference"] = fhir_common.ref_resource(resource_type, fake_id)["reference"]
+            node["reference"] = fhir.ref_resource(resource_type, fake_id)["reference"]
 
     def _check_text(self, node: dict, key: str, value: Any):
         """Scrubs text values that got through the MS config by passing them through philter"""

--- a/cumulus_etl/errors.py
+++ b/cumulus_etl/errors.py
@@ -31,6 +31,10 @@ LABEL_STUDIO_MISSING = 31
 FHIR_AUTH_FAILED = 32
 
 
+class FatalError(Exception):
+    """An unrecoverable error"""
+
+
 def fatal(message: str, status: int) -> NoReturn:
     """Convenience method to exit the program with a user-friendly error message a test-friendly status code"""
     print(message, file=sys.stderr)

--- a/cumulus_etl/etl/cli.py
+++ b/cumulus_etl/etl/cli.py
@@ -13,7 +13,7 @@ from collections.abc import Iterable
 import rich
 import rich.table
 
-from cumulus_etl import cli_utils, common, deid, errors, fhir_client, loaders, nlp, store
+from cumulus_etl import cli_utils, common, deid, errors, fhir, loaders, nlp, store
 from cumulus_etl.etl import context, tasks
 from cumulus_etl.etl.config import JobConfig, JobSummary
 
@@ -227,7 +227,7 @@ async def etl_main(args: argparse.Namespace) -> None:
     # This is useful even if we aren't doing a bulk export, because some resources like DocumentReference can still
     # reference external resources on the server (like the document text).
     # If we don't need this client (e.g. we're using local data and don't download any attachments), this is a no-op.
-    client = fhir_client.create_fhir_client_for_cli(args, root_input, required_resources)
+    client = fhir.create_fhir_client_for_cli(args, root_input, required_resources)
 
     async with client:
         if args.input_format == "i2b2":

--- a/cumulus_etl/etl/config.py
+++ b/cumulus_etl/etl/config.py
@@ -4,7 +4,7 @@ import datetime
 import os
 from socket import gethostname
 
-from cumulus_etl import common, fhir_client, formats, store
+from cumulus_etl import common, fhir, formats, store
 
 
 class JobConfig:
@@ -24,7 +24,7 @@ class JobConfig:
         dir_phi: str,
         input_format: str,
         output_format: str,
-        client: fhir_client.FhirClient,
+        client: fhir.FhirClient,
         timestamp: datetime.datetime = None,
         comment: str = None,
         batch_size: int = 1,  # this default is never really used - overridden by command line args
@@ -52,8 +52,8 @@ class JobConfig:
         self._format_class = formats.get_format_class(self._output_format)
         self._format_class.initialize_class(self._output_root)
 
-    def create_formatter(self, dbname: str, group_field: str = None) -> formats.Format:
-        return self._format_class(self._output_root, dbname, group_field)
+    def create_formatter(self, dbname: str, group_field: str = None, resource_type: str = None) -> formats.Format:
+        return self._format_class(self._output_root, dbname, group_field=group_field, resource_type=resource_type)
 
     def path_config(self) -> str:
         return os.path.join(self.dir_job_config(), "job_config.json")

--- a/cumulus_etl/etl/studies/covid_symptom/covid_ctakes.py
+++ b/cumulus_etl/etl/studies/covid_symptom/covid_ctakes.py
@@ -5,11 +5,11 @@ import logging
 import ctakesclient
 import httpx
 
-from cumulus_etl import fhir_client, fhir_common, nlp, store
+from cumulus_etl import fhir, nlp, store
 
 
 async def covid_symptoms_extract(
-    client: fhir_client.FhirClient,
+    client: fhir.FhirClient,
     cache: store.Root,
     docref: dict,
     ctakes_http_client: httpx.AsyncClient = None,
@@ -26,17 +26,17 @@ async def covid_symptoms_extract(
     :return: list of NLP results encoded as FHIR observations
     """
     docref_id = docref["id"]
-    _, subject_id = fhir_common.unref_resource(docref["subject"])
+    _, subject_id = fhir.unref_resource(docref["subject"])
 
     encounters = docref.get("context", {}).get("encounter", [])
     if not encounters:
         logging.warning("No encounters for docref %s", docref_id)
         return None
-    _, encounter_id = fhir_common.unref_resource(encounters[0])
+    _, encounter_id = fhir.unref_resource(encounters[0])
 
     # Find the clinical note among the attachments
     try:
-        clinical_note = await fhir_common.get_docref_note(client, docref)
+        clinical_note = await fhir.get_docref_note(client, docref)
     except Exception as exc:  # pylint: disable=broad-except
         logging.warning("Error getting text for docref %s: %s", docref_id, exc)
         return None

--- a/cumulus_etl/etl/studies/covid_symptom/covid_tasks.py
+++ b/cumulus_etl/etl/studies/covid_symptom/covid_tasks.py
@@ -63,6 +63,7 @@ class CovidSymptomNlpResultsTask(tasks.EtlTask):
     name = "covid_symptom__nlp_results"
     resource = "DocumentReference"
     tags = {"covid_symptom", "gpu"}
+    output_resource = None  # custom format
     group_field = "docref_id"
 
     async def prepare_task(self) -> bool:

--- a/cumulus_etl/fhir/__init__.py
+++ b/cumulus_etl/fhir/__init__.py
@@ -1,0 +1,5 @@
+"""Support for talking to FHIR servers & handling the FHIR spec"""
+
+from .fhir_client import FhirClient, create_fhir_client_for_cli
+from .fhir_schemas import create_spark_schema_for_resource
+from .fhir_utils import get_docref_note, ref_resource, unref_resource

--- a/cumulus_etl/fhir/fhir_client.py
+++ b/cumulus_etl/fhir/fhir_client.py
@@ -16,10 +16,6 @@ from jwcrypto import jwk, jwt
 from cumulus_etl import common, errors, store
 
 
-class FatalError(Exception):
-    """An unrecoverable error"""
-
-
 def _urljoin(base: str, path: str) -> str:
     """Basically just urllib.parse.urljoin, but with some extra error checking"""
     path_is_absolute = bool(urllib.parse.urlparse(path).netloc)
@@ -131,7 +127,9 @@ class JwksAuth(Auth):
             or not {"ES384", "RS384"} & set(config.get("token_endpoint_auth_signing_alg_values_supported", []))
             or not config.get("token_endpoint")
         ):
-            raise FatalError(f"Server {self._server_root} does not support the client-confidential-asymmetric protocol")
+            raise errors.FatalError(
+                f"Server {self._server_root} does not support the client-confidential-asymmetric protocol"
+            )
 
         return config["token_endpoint"]
 
@@ -148,7 +146,7 @@ class JwksAuth(Auth):
             if key.get("alg") in ["ES384", "RS384"] and "sign" in key.get("key_ops", []) and key.get("kid"):
                 break
         else:  # no valid private JWK found
-            raise FatalError("No private ES384 or RS384 key found in the provided JWKS file.")
+            raise errors.FatalError("No private ES384 or RS384 key found in the provided JWKS file.")
 
         # Now generate a signed JWT based off the given JWK
         header = {
@@ -308,7 +306,7 @@ class FhirClient:
             if not message:
                 message = str(exc)
 
-            raise FatalError(f'An error occurred when connecting to "{url}": {message}') from exc
+            raise errors.FatalError(f'An error occurred when connecting to "{url}": {message}') from exc
 
         return response
 

--- a/cumulus_etl/fhir/fhir_schemas.py
+++ b/cumulus_etl/fhir/fhir_schemas.py
@@ -1,0 +1,84 @@
+"""Manage FHIR resource schemas in certain formats"""
+
+from collections import namedtuple
+from functools import partial
+
+from fhirclient.models import fhirabstractbase, fhirdate, fhirelementfactory
+import pyspark
+
+
+FhirProperty = namedtuple("FhirProperty", ["name", "json_name", "pytype", "is_list", "of_many", "required"])
+
+
+def create_spark_schema_for_resource(resource_type: str) -> pyspark.sql.types.StructType:
+    """
+    Creates a Pyspark StructType schema based off the named resource (like 'Observation').
+
+    Note that this schema will not be deep (fully nested all the way down),
+    it will simply be wide (covering each toplevel field, each likely nullable).
+
+    The primary goal here is to simplify complexity in the consuming SQL so that it
+    can assume each column is at least defined.
+    """
+    instance = fhirelementfactory.FHIRElementFactory.instantiate(resource_type, None)
+    return fhir_obj_to_pyspark_fields(instance, recurse=True)
+
+
+def fhir_obj_to_pyspark_fields(
+    base_obj: fhirabstractbase.FHIRAbstractBase, *, recurse: bool
+) -> pyspark.sql.types.StructType:
+    """Convert a FHIR instance to a Pyspark StructType schema definition"""
+    properties = map(FhirProperty._make, base_obj.elementProperties())
+    return pyspark.sql.types.StructType(
+        list(filter(None, map(partial(fhir_to_spark_property, recurse=recurse), properties)))
+    )
+
+
+def fhir_to_spark_property(prop: FhirProperty, *, recurse: bool) -> pyspark.sql.types.StructField | None:
+    """Converts a single FhirProperty to a Pyspark StructField, returning None if this field should be skipped"""
+    spark_type = fhir_to_spark_type(prop.pytype, recurse=recurse)
+    if spark_type is None:
+        return None
+
+    # Wrap lists in an ArrayType
+    if prop.is_list:
+        spark_type = pyspark.sql.types.ArrayType(spark_type)
+
+    # Mark all types as nullable, don't worry about the prop.required field.
+    # The ETL itself doesn't need to be in the business of validation, we just want to push the data through.
+    return pyspark.sql.types.StructField(prop.json_name, spark_type, nullable=True)
+
+
+def fhir_to_spark_type(pytype: type, recurse=False) -> pyspark.sql.types.DataType | None:
+    """Converts a basic python type to a Pyspark type, returning None if this element should be skipped"""
+    if pytype is int:
+        # TODO: investigate if we can reduce this to IntegerType (32-bit) safely.
+        #  The FHIR spec is 32-bit only (but does include some unsigned variants), while LongType is 64-bit.
+        #  I've started this off as LongType because that matches the historical inferred types before we used a
+        #  pre-calculated schema.
+        return pyspark.sql.types.LongType()
+    elif pytype is float:
+        # TODO: the FHIR spec suggests that double might not even be enough:
+        #  From https://www.hl7.org/fhir/R4/datatypes.html:
+        #  "In object code, implementations that might meet this constraint are GMP implementations or equivalents
+        #   to Java BigDecimal that implement arbitrary precision, or a combination of a (64 bit) floating point
+        #   value with a precision field"
+        #  But for now, we are matching the inferred types from before we used a pre-calculated schema.
+        #  We can presumably up-scale this at some point if we find limitations.
+        return pyspark.sql.types.DoubleType()
+    elif pytype is str:
+        return pyspark.sql.types.StringType()
+    elif pytype is bool:
+        return pyspark.sql.types.BooleanType()
+    elif pytype is fhirdate.FHIRDate:
+        return pyspark.sql.types.StringType()  # just leave it as a string, like it appears in the JSON
+    elif issubclass(pytype, fhirabstractbase.FHIRAbstractBase):
+        if recurse:
+            return fhir_obj_to_pyspark_fields(pytype(), recurse=False)
+
+        # Else skip this element entirely and do not descend, to avoid infinite recursion.
+        # Note that in theory this might leave a struct with no child fields (if a struct's only children where also
+        # structs), which parquet/spark would have an issue with -- it won't allow empty structs.
+        # But in practice with FHIR, all BackboneElements have at least an id (string) field, so we dodge that bullet.
+        return None
+    raise ValueError(f"Unexpected type: {pytype}")

--- a/cumulus_etl/fhir/fhir_utils.py
+++ b/cumulus_etl/fhir/fhir_utils.py
@@ -6,7 +6,7 @@ import re
 
 import inscriptis
 
-from cumulus_etl import fhir_client
+from cumulus_etl.fhir import fhir_client
 
 # A relative reference is something like Patient/123 or Patient?identifier=http://hl7.org/fhir/sid/us-npi|9999999299
 # (vs a contained reference that starts with # or an absolute URL reference like http://example.org/Patient/123)

--- a/cumulus_etl/formats/base.py
+++ b/cumulus_etl/formats/base.py
@@ -23,7 +23,7 @@ class Format(abc.ABC):
         (e.g. some expensive setup that can be shared across per-table format instances, or eventually across threads)
         """
 
-    def __init__(self, root: store.Root, dbname: str, group_field: str = None):
+    def __init__(self, root: store.Root, dbname: str, group_field: str = None, resource_type: str = None):
         """
         Initialize a new Format class
         :param root: the base location to write data to
@@ -32,10 +32,12 @@ class Format(abc.ABC):
          deleted -- for example "docref_id" will mean that any existing rows matching docref_id will be deleted before
          inserting any from this dataframe. Make sure that all records for a given group are in one single dataframe.
          See the comments for the EtlTask.group_field class attribute for more context.
+        :param resource_type: the name of the FHIR resource being stored, in case a fuller schema is needed
         """
         self.root = root
         self.dbname = dbname
         self.group_field = group_field
+        self.resource_type = resource_type
 
     def write_records(self, dataframe: pandas.DataFrame, batch: int) -> bool:
         """

--- a/cumulus_etl/loaders/fhir/ndjson_loader.py
+++ b/cumulus_etl/loaders/fhir/ndjson_loader.py
@@ -3,8 +3,7 @@
 import logging
 import tempfile
 
-from cumulus_etl import cli_utils, common, errors, store
-from cumulus_etl.fhir_client import FatalError, FhirClient
+from cumulus_etl import cli_utils, common, errors, fhir, store
 from cumulus_etl.loaders import base
 from cumulus_etl.loaders.fhir.bulk_export import BulkExporter
 
@@ -20,7 +19,7 @@ class FhirNdjsonLoader(base.Loader):
     def __init__(
         self,
         root: store.Root,
-        client: FhirClient = None,
+        client: fhir.FhirClient = None,
         export_to: str = None,
         since: str = None,
         until: str = None,
@@ -75,7 +74,7 @@ class FhirNdjsonLoader(base.Loader):
                 self.client, resources, self.root.path, target_dir.name, self.since, self.until
             )
             await bulk_exporter.export()
-        except FatalError as exc:
+        except errors.FatalError as exc:
             errors.fatal(str(exc), errors.BULK_EXPORT_FAILED)
 
         return target_dir

--- a/cumulus_etl/loaders/i2b2/transform.py
+++ b/cumulus_etl/loaders/i2b2/transform.py
@@ -3,7 +3,7 @@
 import base64
 import logging
 
-from cumulus_etl import fhir_common
+from cumulus_etl import fhir
 from cumulus_etl.loaders.i2b2 import external_mappings
 from cumulus_etl.loaders.i2b2.schema import PatientDimension, VisitDimension, ObservationFact
 
@@ -88,7 +88,7 @@ def to_fhir_encounter(visit: VisitDimension) -> dict:
     encounter = {
         "resourceType": "Encounter",
         "id": str(visit.encounter_num),
-        "subject": fhir_common.ref_resource("Patient", visit.patient_num),
+        "subject": fhir.ref_resource("Patient", visit.patient_num),
         "meta": {"profile": ["http://hl7.org/fhir/us/core/StructureDefinition/us-core-encounter"]},
         "status": "unknown",
         "period": {"start": chop_to_date(visit.start_date), "end": chop_to_date(visit.end_date)},
@@ -124,8 +124,8 @@ def to_fhir_observation_lab(obsfact: ObservationFact) -> dict:
     observation = {
         "resourceType": "Observation",
         "id": str(obsfact.instance_num),
-        "subject": fhir_common.ref_resource("Patient", obsfact.patient_num),
-        "encounter": fhir_common.ref_resource("Encounter", obsfact.encounter_num),
+        "subject": fhir.ref_resource("Patient", obsfact.patient_num),
+        "encounter": fhir.ref_resource("Encounter", obsfact.encounter_num),
         "category": [make_concept("laboratory", "http://terminology.hl7.org/CodeSystem/observation-category")],
         "effectiveDateTime": chop_to_date(obsfact.start_date),
         "status": "unknown",
@@ -165,8 +165,8 @@ def to_fhir_observation_vitals(obsfact: ObservationFact) -> dict:
         "status": "unknown",
         "category": [make_concept("vital-signs", "http://terminology.hl7.org/CodeSystem/observation-category")],
         "code": make_concept(obsfact.concept_cd, "http://cumulus.smarthealthit.org/i2b2"),
-        "subject": fhir_common.ref_resource("Patient", obsfact.patient_num),
-        "encounter": fhir_common.ref_resource("Encounter", obsfact.encounter_num),
+        "subject": fhir.ref_resource("Patient", obsfact.patient_num),
+        "encounter": fhir.ref_resource("Encounter", obsfact.encounter_num),
         "effectiveDateTime": chop_to_date(obsfact.start_date),
     }
 
@@ -184,8 +184,8 @@ def to_fhir_condition(obsfact: ObservationFact) -> dict:
     condition = {
         "resourceType": "Condition",
         "id": str(obsfact.instance_num),
-        "subject": fhir_common.ref_resource("Patient", obsfact.patient_num),
-        "encounter": fhir_common.ref_resource("Encounter", obsfact.encounter_num),
+        "subject": fhir.ref_resource("Patient", obsfact.patient_num),
+        "encounter": fhir.ref_resource("Encounter", obsfact.encounter_num),
         "meta": {"profile": ["http://hl7.org/fhir/us/core/StructureDefinition/us-core-condition"]},
         "category": [
             make_concept(
@@ -235,8 +235,8 @@ def to_fhir_medicationrequest(obsfact: ObservationFact) -> dict:
         "medicationCodeableConcept": make_concept(
             obsfact.concept_cd, "http://cumulus.smarthealthit.org/i2b2", display=obsfact.concept_cd
         ),
-        "subject": fhir_common.ref_resource("Patient", obsfact.patient_num),
-        "encounter": fhir_common.ref_resource("Encounter", obsfact.encounter_num),
+        "subject": fhir.ref_resource("Patient", obsfact.patient_num),
+        "encounter": fhir.ref_resource("Encounter", obsfact.encounter_num),
         "authoredOn": chop_to_date(obsfact.start_date),
     }
 
@@ -259,9 +259,9 @@ def to_fhir_documentreference(obsfact: ObservationFact) -> dict:
     return {
         "resourceType": "DocumentReference",
         "id": str(obsfact.instance_num),
-        "subject": fhir_common.ref_resource("Patient", obsfact.patient_num),
+        "subject": fhir.ref_resource("Patient", obsfact.patient_num),
         "context": {
-            "encounter": [fhir_common.ref_resource("Encounter", obsfact.encounter_num)],
+            "encounter": [fhir.ref_resource("Encounter", obsfact.encounter_num)],
             "period": {"start": chop_to_date(obsfact.start_date), "end": chop_to_date(obsfact.end_date)},
         },
         # It would be nice to get a real mapping for the "NOTE:" concept CD types to a real system.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,6 +13,7 @@ requires-python = ">= 3.10"
 dependencies = [
     "ctakesclient >= 3, < 4",
     "delta-spark >= 2.3, < 3",
+    "fhirclient < 5",
     "httpx < 1",
     "inscriptis < 3",
     "jwcrypto < 2",
@@ -20,7 +21,7 @@ dependencies = [
     "oracledb < 2",
     "pandas < 3",
     "philter-lite < 1",
-    "pyarrow < 12",
+    "pyarrow < 13",
     "rich < 14",
     "s3fs",
 ]

--- a/tests/fhir/test_fhir_utils.py
+++ b/tests/fhir/test_fhir_utils.py
@@ -1,9 +1,9 @@
-"""Tests for fhir_common.py"""
+"""Tests for fhir_utils.py"""
 import base64
 
 import ddt
 
-from cumulus_etl import fhir_common
+from cumulus_etl import fhir
 from tests import utils
 
 
@@ -20,7 +20,7 @@ class TestReferenceHandlers(utils.AsyncTestCase):
     )
     @ddt.unpack
     def test_unref_successes(self, full_reference, expected_type, expected_id):
-        parsed = fhir_common.unref_resource(full_reference)
+        parsed = fhir.unref_resource(full_reference)
         self.assertEqual((expected_type, expected_id), parsed)
 
     @ddt.data(
@@ -32,7 +32,7 @@ class TestReferenceHandlers(utils.AsyncTestCase):
     )
     def test_unref_failures(self, reference):
         with self.assertRaises(ValueError):
-            fhir_common.unref_resource({"reference": reference})
+            fhir.unref_resource({"reference": reference})
 
     @ddt.data(
         ("Patient", "123", "Patient/123"),
@@ -40,7 +40,7 @@ class TestReferenceHandlers(utils.AsyncTestCase):
     )
     @ddt.unpack
     def test_ref_resource(self, resource_type, resource_id, expected):
-        self.assertEqual({"reference": expected}, fhir_common.ref_resource(resource_type, resource_id))
+        self.assertEqual({"reference": expected}, fhir.ref_resource(resource_type, resource_id))
 
     @ddt.data(
         ("text/html", "<html><body>He<b>llooooo</b></html>", "Hellooooo"),  # strips html
@@ -63,5 +63,5 @@ class TestReferenceHandlers(utils.AsyncTestCase):
                 },
             ],
         }
-        resulting_note = await fhir_common.get_docref_note(None, docref)
+        resulting_note = await fhir.get_docref_note(None, docref)
         self.assertEqual(resulting_note, expected_note)

--- a/tests/test_etl_tasks.py
+++ b/tests/test_etl_tasks.py
@@ -8,7 +8,7 @@ from unittest import mock
 
 import ddt
 
-from cumulus_etl import common, deid, errors, fhir_client
+from cumulus_etl import common, deid, errors, fhir
 from cumulus_etl.etl import config, tasks
 
 from tests.utils import AsyncTestCase
@@ -20,7 +20,7 @@ class TaskTestCase(AsyncTestCase):
     def setUp(self) -> None:
         super().setUp()
 
-        client = fhir_client.FhirClient("http://localhost/", [])
+        client = fhir.FhirClient("http://localhost/", [])
         self.tmpdir = tempfile.TemporaryDirectory()  # pylint: disable=consider-using-with
         self.input_dir = os.path.join(self.tmpdir.name, "input")
         self.phi_dir = os.path.join(self.tmpdir.name, "phi")


### PR DESCRIPTION
This helps downstream SQL not have to worry about whether the incoming data has a particular optional FHIR field (which before, would mean that the Athena schema didn't define it, which would yield a SQL error).

Now, all the R4 FHIR fields will be represented at least at the toplevel, and SQL can rest a bit easier.


### Checklist
- [x] Consider if documentation (like in `docs/`) needs to be updated
- [x] Consider if tests should be added
