### PR TITLE
fix: avoid schema-mismatch errors for int columns that have nulls

### DIFF
--- a/cumulus_etl/formats/deltalake.py
+++ b/cumulus_etl/formats/deltalake.py
@@ -186,8 +186,10 @@ class DeltaLakeFormat(Format):
             data_path = os.path.join(parquet_dir, "data.parquet")
             schema_path = os.path.join(parquet_dir, "schema.parquet")
 
-            # Write the pandas dataframe to parquet to force full nested schemas
-            dataframe.to_parquet(data_path, index=False)
+            # Write the pandas dataframe to parquet to force full nested schemas.
+            # We also convert dtypes, to get modern nullable pandas types (rather than using its default behavior of
+            # converting a nullable integer column into a float column).
+            dataframe.convert_dtypes().to_parquet(data_path, index=False)
             del dataframe  # allow GC to clean this up
             paths = [data_path]
 

--- a/cumulus_etl/loaders/i2b2/extract.py
+++ b/cumulus_etl/loaders/i2b2/extract.py
@@ -19,10 +19,10 @@ def extract_csv(path_csv: str, batch_size: int) -> Iterator[dict]:
         with pandas.read_csv(path_csv, dtype=str, na_filter=False, chunksize=batch_size) as reader:
             print(f"Reading csv {path_csv}...")
             for chunk in reader:
-                print(f"  Read {count:,} entries...")
                 for _, row in chunk.iterrows():
                     yield dict(row)
                 count += batch_size
+                print(f"  Read {count:,} entries...")
             print(f"Done reading {path_csv}.")
     except FileNotFoundError:
         print(f"No {path_csv}, skipping.")


### PR DESCRIPTION
Pandas converts integer columns with nulls to float columns by default. This confused our new schema merging feature.

So now we ask Pandas to use more modern column types (ones that can handle nulls better). This fixes the schema issue.

BUT it might introduce incompatibilities with existing tables. If so, the easiest fix is to blow away the table and recreate it.


### Checklist
- [x] Consider if documentation (like in `docs/`) needs to be updated
- [x] Consider if tests should be added
