### PR TITLE
fix: allow contained Medication resources through

### DIFF
--- a/cumulus_etl/deid/ms-config.json
+++ b/cumulus_etl/deid/ms-config.json
@@ -156,6 +156,18 @@
     {"path": "Encounter.serviceProvider", "method": "keep"},
     {"path": "Encounter.partOf", "method": "keep"},
 
+    {"comment": "** https://www.hl7.org/fhir/R4/medication.html **", "path": "xxx", "method": "redact"},
+    {"path": "Medication.code", "method": "keep"},
+    {"path": "Medication.status", "method": "keep"},
+    {"path": "Medication.manufacturer", "method": "keep"},
+    {"path": "Medication.form", "method": "keep"},
+    {"path": "Medication.amount", "method": "keep"},
+    {"path": "Medication.ingredient.item", "method": "keep"},
+    {"path": "Medication.ingredient.isActive", "method": "keep"},
+    {"path": "Medication.ingredient.strength", "method": "keep"},
+    {"path": "Medication.batch.lotNumber", "method": "keep"},
+    {"path": "Medication.batch.expirationDate", "method": "keep"},
+
     {"comment": "** https://www.hl7.org/fhir/R4/medicationrequest.html **", "path": "xxx", "method": "redact"},
     {"path": "MedicationRequest.status", "method": "keep"},
     {"path": "MedicationRequest.statusReason", "method": "keep"},

--- a/cumulus_etl/deid/scrubber.py
+++ b/cumulus_etl/deid/scrubber.py
@@ -110,7 +110,7 @@ class Scrubber:
     ) -> None:
         """Examines one single property of a node"""
         # For now, just manually run each operation. If this grows further, we can abstract it more.
-        self._check_ids(node_path, node, key, value)
+        self._check_ids(node, key, value)
         self._check_modifier_extensions(key, value)
         self._check_security(node_path, node, key, value)
         self._check_text(node, key, value)
@@ -139,10 +139,13 @@ class Scrubber:
             if url not in known_extensions:
                 raise SkipResource(f'Unrecognized modifierExtension with URL "{url}"')
 
-    def _check_ids(self, node_path: str, node: dict, key: str, value: Any) -> None:
+    def _check_ids(self, node: dict, key: str, value: Any) -> None:
         """Converts any IDs and references to a de-identified version"""
-        # ID values ("id" is only ever used as a resource ID)
-        if node_path == "root" and key == "id":
+        # ID values ("id" is only ever used as a resource/element ID)
+        # Can occur at the root node, contained resources, and TECHNICALLY in any backbone element.
+        # But the backbone elements won't have resourceType, and we can ignore those as non-resources/non-PHI.
+        # So we only convert if there's also a resourceType present.
+        if key == "id" and "resourceType" in node:
             node["id"] = self.codebook.fake_id(node["resourceType"], value)
 
         # References

--- a/tests/data/mstool/input/Condition.1.json
+++ b/tests/data/mstool/input/Condition.1.json
@@ -20,8 +20,8 @@
       "gender": "male"
     },
     {
-      "resourceType": "Medication",
-      "id": "#med",
+      "resourceType": "CarePlan",
+      "id": "#careplan",
       "status": "active"
     }
   ],

--- a/tests/data/mstool/input/Medication.1.json
+++ b/tests/data/mstool/input/Medication.1.json
@@ -1,0 +1,70 @@
+{
+  "resourceType": "Medication",
+  "id": "med0301",
+  "text": {
+    "status": "generated",
+    "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\"><p><b>Generated Narrative with Details</b></p><p><b>id</b>: med0301</p><p><b>contained</b>: </p><p><b>code</b>: Vancomycin Hydrochloride (VANCOMYCIN HYDROCHLORIDE) <span>(Details : {http://hl7.org/fhir/sid/ndc code '0069-2587-10' = 'n/a', given as 'Vancomycin Hydrochloride (VANCOMYCIN HYDROCHLORIDE)'})</span></p><p><b>status</b>: active</p><p><b>manufacturer</b>: id: org4; name: Pfizer Laboratories Div Pfizer Inc</p><p><b>form</b>: Injection Solution (qualifier value) <span>(Details : {SNOMED CT code '385219001' = 'Injection solution', given as 'Injection Solution (qualifier value)'})</span></p><h3>Ingredients</h3><table><tr><td>-</td><td><b>Item[x]</b></td><td><b>IsActive</b></td><td><b>Strength</b></td></tr><tr><td>*</td><td>Vancomycin Hydrochloride <span>(Details : {RxNorm code '66955' = 'Vancomycin Hydrochloride', given as 'Vancomycin Hydrochloride'})</span></td><td>true</td><td>500 mg<span> (Details: UCUM code mg = 'mg')</span>/10 mL<span> (Details: UCUM code mL = 'mL')</span></td></tr></table><h3>Batches</h3><table><tr><td>-</td><td><b>LotNumber</b></td><td><b>ExpirationDate</b></td></tr><tr><td>*</td><td>9494788</td><td>22/05/2017</td></tr></table></div>"
+  },
+  "contained": [
+    {
+      "resourceType": "Organization",
+      "id": "org4",
+      "name": "Pfizer Laboratories Div Pfizer Inc"
+    }
+  ],
+
+  "identifier" : [{ "value": "drop" }],
+  "code": {
+    "coding": [
+      {
+        "system": "http://hl7.org/fhir/sid/ndc",
+        "code": "0069-2587-10",
+        "display": "Vancomycin Hydrochloride (VANCOMYCIN HYDROCHLORIDE)"
+      }
+    ]
+  },
+  "status": "active",
+  "manufacturer": {
+    "reference": "#org4"
+  },
+  "form": {
+    "coding": [
+      {
+        "system": "http://snomed.info/sct",
+        "code": "385219001",
+        "display": "Injection Solution (qualifier value)"
+      }
+    ]
+  },
+  "amount": {"numerator": {"value": 1.0}, "denominator": {"value":  2.0}},
+  "ingredient": [
+    {
+      "itemCodeableConcept": {
+        "coding": [
+          {
+            "system": "http://www.nlm.nih.gov/research/umls/rxnorm",
+            "code": "66955",
+            "display": "Vancomycin Hydrochloride"
+          }
+        ]
+      },
+      "isActive": true,
+      "strength": {
+        "numerator": {
+          "value": 500,
+          "system": "http://unitsofmeasure.org",
+          "code": "mg"
+        },
+        "denominator": {
+          "value": 10,
+          "system": "http://unitsofmeasure.org",
+          "code": "mL"
+        }
+      }
+    }
+  ],
+  "batch": {
+    "lotNumber": "9494788",
+    "expirationDate": "2017-05-22"
+  }
+}

--- a/tests/data/mstool/input/MedicationRequest.2.json
+++ b/tests/data/mstool/input/MedicationRequest.2.json
@@ -1,0 +1,21 @@
+{
+  "resourceType": "MedicationRequest",
+  "id": "2-contained",
+  "contained": [
+    {
+      "resourceType": "Medication",
+      "id": "contained",
+      "status": "active",
+      "code": {
+        "coding": [
+          {
+            "system": "http://hl7.org/fhir/sid/ndc",
+            "code": "0069-2587-10",
+            "display": "Vancomycin Hydrochloride (VANCOMYCIN HYDROCHLORIDE)"
+          }
+        ]
+      }
+    }
+  ],
+  "medicationReference": { "reference": "#contained" }
+}

--- a/tests/data/mstool/output/Condition.1.json
+++ b/tests/data/mstool/output/Condition.1.json
@@ -18,8 +18,8 @@
       "gender": "male"
     },
     {
-      "resourceType": "Medication",
-      "id": "#med"
+      "resourceType": "CarePlan",
+      "id": "#careplan"
     }
   ],
 

--- a/tests/data/mstool/output/Medication.1.json
+++ b/tests/data/mstool/output/Medication.1.json
@@ -1,0 +1,71 @@
+{
+  "resourceType": "Medication",
+  "id": "med0301",
+  "meta": {
+    "security": [{
+      "code": "REDACTED",
+      "display": "redacted",
+      "system": "http://terminology.hl7.org/CodeSystem/v3-ObservationValue"
+    }]
+  },
+  "contained": [
+    {
+      "resourceType": "Organization",
+      "id": "org4"
+    }
+  ],
+
+  "code": {
+    "coding": [
+      {
+        "system": "http://hl7.org/fhir/sid/ndc",
+        "code": "0069-2587-10",
+        "display": "Vancomycin Hydrochloride (VANCOMYCIN HYDROCHLORIDE)"
+      }
+    ]
+  },
+  "status": "active",
+  "manufacturer": {
+    "reference": "#org4"
+  },
+  "form": {
+    "coding": [
+      {
+        "system": "http://snomed.info/sct",
+        "code": "385219001",
+        "display": "Injection Solution (qualifier value)"
+      }
+    ]
+  },
+  "amount": {"numerator": {"value": 1.0}, "denominator": {"value":  2.0}},
+  "ingredient": [
+    {
+      "itemCodeableConcept": {
+        "coding": [
+          {
+            "system": "http://www.nlm.nih.gov/research/umls/rxnorm",
+            "code": "66955",
+            "display": "Vancomycin Hydrochloride"
+          }
+        ]
+      },
+      "isActive": true,
+      "strength": {
+        "numerator": {
+          "value": 500,
+          "system": "http://unitsofmeasure.org",
+          "code": "mg"
+        },
+        "denominator": {
+          "value": 10,
+          "system": "http://unitsofmeasure.org",
+          "code": "mL"
+        }
+      }
+    }
+  ],
+  "batch": {
+    "lotNumber": "9494788",
+    "expirationDate": "2017-05-22"
+  }
+}

--- a/tests/data/mstool/output/MedicationRequest.2.json
+++ b/tests/data/mstool/output/MedicationRequest.2.json
@@ -1,0 +1,21 @@
+{
+  "resourceType": "MedicationRequest",
+  "id": "2-contained",
+  "contained": [
+    {
+      "resourceType": "Medication",
+      "id": "contained",
+      "status": "active",
+      "code": {
+        "coding": [
+          {
+            "system": "http://hl7.org/fhir/sid/ndc",
+            "code": "0069-2587-10",
+            "display": "Vancomycin Hydrochloride (VANCOMYCIN HYDROCHLORIDE)"
+          }
+        ]
+      }
+    }
+  ],
+  "medicationReference": { "reference": "#contained" }
+}

--- a/tests/deid/test_deid_scrubber.py
+++ b/tests/deid/test_deid_scrubber.py
@@ -69,15 +69,21 @@ class TestScrubber(utils.AsyncTestCase):
         self.assertNotIn("data", docref["content"][0]["attachment"])
 
     def test_contained_reference(self):
-        """Verify that we leave contained references contained"""
+        """Verify that we leave contained references contained but scrubbed"""
         scrubber = Scrubber()
         condition = i2b2_mock_data.condition()
+        condition["contained"] = [
+            {
+                "resourceType": "Patient",
+                "id": "p12",
+            }
+        ]
         condition["subject"]["reference"] = "#p12"
 
         self.assertTrue(scrubber.scrub_resource(condition))
-        self.assertEqual(
-            "#221044b59936243b79da55c551b0c60ec7278733dde4acf65f83468cbd64bd0f", condition["subject"]["reference"]
-        )
+        fake_id = "221044b59936243b79da55c551b0c60ec7278733dde4acf65f83468cbd64bd0f"
+        self.assertEqual(fake_id, condition["contained"][0]["id"])
+        self.assertEqual(f"#{fake_id}", condition["subject"]["reference"])
 
     def test_unknown_modifier_extension(self):
         """Confirm we skip resources with unknown modifier extensions"""


### PR DESCRIPTION
- Start anonymizing contained "id" fields (that's an oversight that should have already happened, but contained resources are not widely used and I don't expect this to require much backfilling)
- Add an MS tool config for Medication, so that any MedicationRequests that contain a Medication will allow its interesting values through.


### Checklist
- [x] Consider if documentation (like in `docs/`) needs to be updated
- [x] Consider if tests should be added
