### PR TITLE
fix: stop writing out zero-length files for anything < 5MB

### DIFF
--- a/cumulus_etl/common.py
+++ b/cumulus_etl/common.py
@@ -39,7 +39,9 @@ def _atomic_open(path: str, mode: str) -> TextIO:
 
     # fsspec is atomic per-transaction -- if an error occurs inside the transaction, partial writes will be discarded
     with root.fs.transaction:
-        yield root.fs.open(path, mode=mode, encoding="utf8")
+        file = root.fs.open(path, mode=mode, encoding="utf8")
+        yield file
+        file.flush()
 
 
 def read_text(path: str) -> str:


### PR DESCRIPTION
The previous atomic commit had a bug that wrote out zero-length files due to a missing flush.

This is an emergency weekend stop-gap fix. Will add tests next week and investigate a little more.


### Checklist
- [x] Consider if documentation (like in `docs/`) needs to be updated
- [x] Consider if tests should be added
