### PR TITLE
fix: revert previous atomic fixes - incomplete files being written

### DIFF
--- a/cumulus_etl/chart_review/cli.py
+++ b/cumulus_etl/chart_review/cli.py
@@ -159,7 +159,7 @@ async def chart_review_main(args: argparse.Namespace) -> None:
     """
     init_checks(args)
 
-    store.set_user_fs_options(vars(args))  # record filesystem options like --s3-region before creating Roots
+    common.set_user_fs_options(vars(args))  # record filesystem options like --s3-region before creating Roots
     root_input = store.Root(args.dir_input)
     root_phi = store.Root(args.dir_phi, create=True)
 

--- a/cumulus_etl/common.py
+++ b/cumulus_etl/common.py
@@ -7,9 +7,10 @@ import json
 import logging
 import re
 from collections.abc import Iterator
-from typing import Any, TextIO
+from typing import Any
+from urllib.parse import urlparse
 
-from cumulus_etl import store
+import fsspec
 
 
 ###############################################################################
@@ -31,17 +32,49 @@ def ls_resources(root, resource: str) -> list[str]:
 #
 ###############################################################################
 
+_user_fs_options = {}  # don't access this directly, use get_fs_options()
 
-@contextlib.contextmanager
-def _atomic_open(path: str, mode: str) -> TextIO:
-    """A version of open() that handles atomic file access across many filesystems (like S3)"""
-    root = store.Root(path)
 
-    # fsspec is atomic per-transaction -- if an error occurs inside the transaction, partial writes will be discarded
-    with root.fs.transaction:
-        file = root.fs.open(path, mode=mode, encoding="utf8")
-        yield file
-        file.flush()
+def set_user_fs_options(args: dict) -> None:
+    """Records user arguments that can affect filesystem options (like s3_region)"""
+    _user_fs_options.update(args)
+
+
+def get_fs_options(protocol: str) -> dict:
+    """Provides a set of storage option kwargs for fsspec calls or pandas storage_options arguments"""
+    options = {}
+
+    if protocol == "s3":
+        # Check for region manually. If you aren't using us-east-1, you usually need to specify the region
+        # explicitly, and fsspec doesn't seem to check the environment variables for us, nor pull it from
+        # ~/.aws/config
+        region_name = _user_fs_options.get("s3_region")
+        if region_name:
+            options["client_kwargs"] = {"region_name": region_name}
+
+        # Assume KMS encryption for now - we can make this tunable to AES256 if folks have a need.
+        # But in general, I believe we want to enforce server side encryption when possible, KMS or not.
+        options["s3_additional_kwargs"] = {
+            "ServerSideEncryption": "aws:kms",
+        }
+
+        # Buckets can be set up to require a specific KMS key ID, so allow specifying it here
+        kms_key = _user_fs_options.get("s3_kms_key")
+        if kms_key:
+            options["s3_additional_kwargs"]["SSEKMSKeyId"] = kms_key
+
+    return options
+
+
+def open_file(path: str, mode: str):
+    """A version of open() that handles remote access, like to S3"""
+    # Grab protocol if present
+    parsed = urlparse(path)
+    protocol = parsed.scheme or "file"  # assume local if no obvious scheme
+
+    # We pass auto_mkdir because on some backends (like S3), we may not have permissions that fsspec might want,
+    # like CreateBucket. We elsewhere call Root.makedirs as needed.
+    return fsspec.open(path, mode, encoding="utf8", auto_mkdir=False, **get_fs_options(protocol))
 
 
 def read_text(path: str) -> str:
@@ -52,7 +85,7 @@ def read_text(path: str) -> str:
     """
     logging.debug("read_text() %s", path)
 
-    with _atomic_open(path, "r") as f:
+    with open_file(path, "r") as f:
         return f.read()
 
 
@@ -64,7 +97,7 @@ def write_text(path: str, text: str) -> None:
     """
     logging.debug("write_text() %s", path)
 
-    with _atomic_open(path, "w") as f:
+    with open_file(path, "w") as f:
         f.write(text)
 
 
@@ -76,7 +109,7 @@ def read_json(path: str) -> Any:
     """
     logging.debug("read_json() %s", path)
 
-    with _atomic_open(path, "r") as f:
+    with open_file(path, "r") as f:
         return json.load(f)
 
 
@@ -89,7 +122,7 @@ def write_json(path: str, data: Any, indent: int = None) -> None:
     """
     logging.debug("write_json() %s", path)
 
-    with _atomic_open(path, "w") as f:
+    with open_file(path, "w") as f:
         json.dump(data, f, indent=indent)
 
 
@@ -101,7 +134,7 @@ def read_csv(path: str) -> csv.DictReader:
 
 def read_ndjson(path: str) -> Iterator[dict]:
     """Yields parsed json from the input ndjson file, line-by-line."""
-    with _atomic_open(path, "r") as f:
+    with open_file(path, "r") as f:
         for line in f:
             yield json.loads(line)
 
@@ -117,7 +150,7 @@ def read_resource_ndjson(root, resource: str) -> Iterator[dict]:
 
 
 class NdjsonWriter:
-    """Convenience context manager to write multiple objects to a local ndjson file."""
+    """Convenience context manager to write multiple objects to an ndjson file."""
 
     def __init__(self, path: str, mode: str = "w"):
         self._path = path

--- a/cumulus_etl/etl/cli.py
+++ b/cumulus_etl/etl/cli.py
@@ -197,7 +197,7 @@ def print_config(args: argparse.Namespace, job_datetime: datetime.datetime, all_
 
 async def etl_main(args: argparse.Namespace) -> None:
     # Set up some common variables
-    store.set_user_fs_options(vars(args))  # record filesystem options like --s3-region before creating Roots
+    common.set_user_fs_options(vars(args))  # record filesystem options like --s3-region before creating Roots
 
     root_input = store.Root(args.dir_input)
     root_phi = store.Root(args.dir_phi, create=True)

--- a/cumulus_etl/etl/convert/cli.py
+++ b/cumulus_etl/etl/convert/cli.py
@@ -135,7 +135,7 @@ def define_convert_parser(parser: argparse.ArgumentParser) -> None:
 
 async def convert_main(args: argparse.Namespace) -> None:
     """Main logic for converting"""
-    store.set_user_fs_options(vars(args))  # record filesystem options like --s3-region before creating Roots
+    common.set_user_fs_options(vars(args))  # record filesystem options like --s3-region before creating Roots
 
     input_root = store.Root(args.input_dir)
     validate_input_dir(input_root)

--- a/cumulus_etl/etl/tasks/base.py
+++ b/cumulus_etl/etl/tasks/base.py
@@ -145,8 +145,7 @@ class EtlTask:
                 self.table_batch_cleanup(table_index, batch_index)
 
                 print(f"  {summary.success:,} processed for {formatter.dbname}")
-
-            batch_index += 1
+                batch_index += 1
 
     def _touch_remaining_tables(self):
         """Writes empty dataframe to any table we haven't written to yet"""

--- a/tests/deid/test_deid_codebook.py
+++ b/tests/deid/test_deid_codebook.py
@@ -128,9 +128,6 @@ class TestCodebookDB(utils.AsyncTestCase):
             # Confirm that an empty book starts modified
             db = CodebookDB()
             self.assertTrue(db.save(tmpdir))
-            self.assertTrue(os.path.exists(f"{tmpdir}/codebook.json"))
-            self.assertFalse(os.path.exists(f"{tmpdir}/codebook-cached-mappings.json"))
-            codebook_mtime = os.path.getmtime(f"{tmpdir}/codebook.json")
 
             # But after a save, we are no longer modified
             self.assertFalse(db.save(tmpdir))
@@ -142,9 +139,6 @@ class TestCodebookDB(utils.AsyncTestCase):
             # Add a new patient, and we can save (because cached mapping changed)
             db.patient("1")
             self.assertTrue(db.save(tmpdir))
-            self.assertTrue(os.path.exists(f"{tmpdir}/codebook-cached-mappings.json"))
-            # main codebook shouldn't be written for just mappings changes
-            self.assertEqual(codebook_mtime, os.path.getmtime(f"{tmpdir}/codebook.json"))
 
             # But if we make a call that doesn't modify the db, don't save
             db.patient("1")

--- a/tests/deid/test_deid_scrubber.py
+++ b/tests/deid/test_deid_scrubber.py
@@ -5,7 +5,6 @@ from unittest import mock
 
 from ctakesclient import text2fhir, typesystem
 
-from cumulus_etl import common
 from cumulus_etl.deid import Scrubber
 from cumulus_etl.deid.codebook import CodebookDB
 from tests import i2b2_mock_data, utils
@@ -137,7 +136,9 @@ class TestScrubber(utils.AsyncTestCase):
             scrubber.scrub_resource(encounter_bad)
 
             # make sure that we raise an error on an unexpected cookbook version
-            common.write_json(f"{tmpdir}/codebook.json", {"version": ".99"})
+            db.settings["version"] = ".99"
+            db.modified = True
+            db.save(tmpdir)
             with self.assertRaises(Exception) as context:
                 Scrubber(tmpdir)
             self.assertIn(".99", str(context.exception))

--- a/tests/etl/test_etl_cli.py
+++ b/tests/etl/test_etl_cli.py
@@ -108,9 +108,9 @@ class TestEtlJobFlow(BaseEtlSimple):
 
             # Run a couple checks to ensure that we do indeed have PHI in this dir
             self.assertIn("Patient.ndjson", os.listdir(phi_dir))
-            patients = list(common.read_ndjson(os.path.join(phi_dir, "Patient.ndjson")))
-            first = patients[0]
-            self.assertEqual("02139", first["address"][0]["postalCode"])
+            with common.open_file(os.path.join(phi_dir, "Patient.ndjson"), "r") as f:
+                first = json.loads(f.readlines()[0])
+                self.assertEqual("02139", first["address"][0]["postalCode"])
 
             # Then raise an exception to interrupt the ETL flow before we normally would be able to clean up
             raise KeyboardInterrupt

--- a/tests/test_chart_cli.py
+++ b/tests/test_chart_cli.py
@@ -1,6 +1,7 @@
 """Tests for chart_review/cli.py"""
 
 import base64
+import json
 import os
 import shutil
 import tempfile
@@ -156,8 +157,8 @@ class TestChartReview(CtakesMixin, AsyncTestCase):
             f.write("\n".join(lines))
 
     def get_exported_ids(self) -> set[str]:
-        rows = common.read_ndjson(f"{self.export_path}/DocumentReference.ndjson")
-        return {row["id"] for row in rows}
+        with common.open_file(os.path.join(self.export_path, "DocumentReference.ndjson"), "r") as f:
+            return {json.loads(line)["id"] for line in f}
 
     def get_pushed_ids(self) -> set[str]:
         notes = self.ls_client.push_tasks.call_args[0][0]

--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -1,20 +1,13 @@
 """Tests for common.py"""
-import contextlib
-import io
-import os
-import tempfile
-from unittest import mock
 
 import ddt
-import fsspec
-from fsspec.implementations.local import LocalFileOpener
 
 from cumulus_etl import common
-from tests import utils
+from tests.utils import AsyncTestCase
 
 
 @ddt.ddt
-class TestLogging(utils.AsyncTestCase):
+class TestLogging(AsyncTestCase):
     """
     Test case for common logging methods.
     """
@@ -40,37 +33,3 @@ class TestLogging(utils.AsyncTestCase):
     def test_human_time_offset(self, seconds, expected_str):
         """Verify human_time_offset works correctly"""
         self.assertEqual(expected_str, common.human_time_offset(seconds))
-
-
-@ddt.ddt
-class TestIOUtils(utils.AsyncTestCase):
-    """Tests for our read/write helper methods"""
-
-    @contextlib.contextmanager
-    def exploding_text(self):
-        """Yields text data that when fed to S3 writes, will explode after some but not all data has been uploaded"""
-        orig_write = LocalFileOpener.write
-
-        def exploding_write(*args, **kwargs):
-            orig_write(*args, **kwargs)
-            raise KeyboardInterrupt
-
-        with mock.patch("fsspec.implementations.local.LocalFileOpener.write", new=exploding_write):
-            with self.assertRaises(KeyboardInterrupt):
-                yield "1" * io.DEFAULT_BUFFER_SIZE
-
-    async def test_writes_are_atomic(self):
-        """Verify that our write utilities are atomic."""
-        with tempfile.TemporaryDirectory() as tmpdir:
-            # Try a couple of our write methods, confirm that nothing makes it through
-            with self.exploding_text() as text:
-                common.write_text(f"{tmpdir}/atomic.txt", text)
-            with self.exploding_text() as text:
-                common.write_json(f"{tmpdir}/atomic.json", {"hello": text})
-            self.assertEqual([], os.listdir(tmpdir))
-
-            # By default, fsspec writes are not atomic - just sanity check that text _can_ get through exploding_text
-            with self.exploding_text() as text:
-                with fsspec.open(f"{tmpdir}/partial.txt", "w") as f:
-                    f.write(text)
-            self.assertEqual(["partial.txt"], os.listdir(tmpdir))


### PR DESCRIPTION
OK another problem has been observed with the atomic file change, where a file isn't completely written out (missing last chunk), seemingly even with the recent flush change.

Reverting this all until I can properly debug.

### Checklist
- [x] Consider if documentation (like in `docs/`) needs to be updated
- [x] Consider if tests should be added
