### PR TITLE
Return of the Atomic Writes

### DIFF
--- a/cumulus_etl/chart_review/cli.py
+++ b/cumulus_etl/chart_review/cli.py
@@ -159,7 +159,7 @@ async def chart_review_main(args: argparse.Namespace) -> None:
     """
     init_checks(args)
 
-    common.set_user_fs_options(vars(args))  # record filesystem options like --s3-region before creating Roots
+    store.set_user_fs_options(vars(args))  # record filesystem options like --s3-region before creating Roots
     root_input = store.Root(args.dir_input)
     root_phi = store.Root(args.dir_phi, create=True)
 

--- a/cumulus_etl/common.py
+++ b/cumulus_etl/common.py
@@ -39,9 +39,8 @@ def _atomic_open(path: str, mode: str) -> TextIO:
 
     # fsspec is atomic per-transaction -- if an error occurs inside the transaction, partial writes will be discarded
     with root.fs.transaction:
-        file = root.fs.open(path, mode=mode, encoding="utf8")
-        yield file
-        file.flush()
+        with root.fs.open(path, mode=mode, encoding="utf8") as file:
+            yield file
 
 
 def read_text(path: str) -> str:

--- a/cumulus_etl/common.py
+++ b/cumulus_etl/common.py
@@ -7,10 +7,9 @@ import json
 import logging
 import re
 from collections.abc import Iterator
-from typing import Any
-from urllib.parse import urlparse
+from typing import Any, TextIO
 
-import fsspec
+from cumulus_etl import store
 
 
 ###############################################################################
@@ -32,49 +31,15 @@ def ls_resources(root, resource: str) -> list[str]:
 #
 ###############################################################################
 
-_user_fs_options = {}  # don't access this directly, use get_fs_options()
 
+@contextlib.contextmanager
+def _atomic_open(path: str, mode: str) -> TextIO:
+    """A version of open() that handles atomic file access across many filesystems (like S3)"""
+    root = store.Root(path)
 
-def set_user_fs_options(args: dict) -> None:
-    """Records user arguments that can affect filesystem options (like s3_region)"""
-    _user_fs_options.update(args)
-
-
-def get_fs_options(protocol: str) -> dict:
-    """Provides a set of storage option kwargs for fsspec calls or pandas storage_options arguments"""
-    options = {}
-
-    if protocol == "s3":
-        # Check for region manually. If you aren't using us-east-1, you usually need to specify the region
-        # explicitly, and fsspec doesn't seem to check the environment variables for us, nor pull it from
-        # ~/.aws/config
-        region_name = _user_fs_options.get("s3_region")
-        if region_name:
-            options["client_kwargs"] = {"region_name": region_name}
-
-        # Assume KMS encryption for now - we can make this tunable to AES256 if folks have a need.
-        # But in general, I believe we want to enforce server side encryption when possible, KMS or not.
-        options["s3_additional_kwargs"] = {
-            "ServerSideEncryption": "aws:kms",
-        }
-
-        # Buckets can be set up to require a specific KMS key ID, so allow specifying it here
-        kms_key = _user_fs_options.get("s3_kms_key")
-        if kms_key:
-            options["s3_additional_kwargs"]["SSEKMSKeyId"] = kms_key
-
-    return options
-
-
-def open_file(path: str, mode: str):
-    """A version of open() that handles remote access, like to S3"""
-    # Grab protocol if present
-    parsed = urlparse(path)
-    protocol = parsed.scheme or "file"  # assume local if no obvious scheme
-
-    # We pass auto_mkdir because on some backends (like S3), we may not have permissions that fsspec might want,
-    # like CreateBucket. We elsewhere call Root.makedirs as needed.
-    return fsspec.open(path, mode, encoding="utf8", auto_mkdir=False, **get_fs_options(protocol))
+    # fsspec is atomic per-transaction -- if an error occurs inside the transaction, partial writes will be discarded
+    with root.fs.transaction:
+        yield root.fs.open(path, mode=mode, encoding="utf8")
 
 
 def read_text(path: str) -> str:
@@ -85,7 +50,7 @@ def read_text(path: str) -> str:
     """
     logging.debug("read_text() %s", path)
 
-    with open_file(path, "r") as f:
+    with _atomic_open(path, "r") as f:
         return f.read()
 
 
@@ -97,7 +62,7 @@ def write_text(path: str, text: str) -> None:
     """
     logging.debug("write_text() %s", path)
 
-    with open_file(path, "w") as f:
+    with _atomic_open(path, "w") as f:
         f.write(text)
 
 
@@ -109,7 +74,7 @@ def read_json(path: str) -> Any:
     """
     logging.debug("read_json() %s", path)
 
-    with open_file(path, "r") as f:
+    with _atomic_open(path, "r") as f:
         return json.load(f)
 
 
@@ -122,7 +87,7 @@ def write_json(path: str, data: Any, indent: int = None) -> None:
     """
     logging.debug("write_json() %s", path)
 
-    with open_file(path, "w") as f:
+    with _atomic_open(path, "w") as f:
         json.dump(data, f, indent=indent)
 
 
@@ -134,7 +99,7 @@ def read_csv(path: str) -> csv.DictReader:
 
 def read_ndjson(path: str) -> Iterator[dict]:
     """Yields parsed json from the input ndjson file, line-by-line."""
-    with open_file(path, "r") as f:
+    with _atomic_open(path, "r") as f:
         for line in f:
             yield json.loads(line)
 
@@ -150,7 +115,7 @@ def read_resource_ndjson(root, resource: str) -> Iterator[dict]:
 
 
 class NdjsonWriter:
-    """Convenience context manager to write multiple objects to an ndjson file."""
+    """Convenience context manager to write multiple objects to a local ndjson file."""
 
     def __init__(self, path: str, mode: str = "w"):
         self._path = path

--- a/cumulus_etl/common.py
+++ b/cumulus_etl/common.py
@@ -39,7 +39,9 @@ def _atomic_open(path: str, mode: str) -> TextIO:
 
     # fsspec is atomic per-transaction -- if an error occurs inside the transaction, partial writes will be discarded
     with root.fs.transaction:
-        yield root.fs.open(path, mode=mode, encoding="utf8")
+        file = root.fs.open(path, mode=mode, encoding="utf8")
+        yield file
+        file.flush()
 
 
 def read_text(path: str) -> str:

--- a/cumulus_etl/deid/codebook.py
+++ b/cumulus_etl/deid/codebook.py
@@ -103,8 +103,9 @@ class CodebookDB:
             "Encounter": {},
         }
 
-        # Modified is true if *either* setting or cached_mapping has changed
-        self.modified = True
+        # Tracks whether we need to write out our settings or mappings
+        self.settings_modified = False
+        self.mappings_modified = False
 
         if codebook_dir:
             self._load_saved_settings(common.read_json(os.path.join(codebook_dir, "codebook.json")))
@@ -112,7 +113,6 @@ class CodebookDB:
                 self.cached_mapping = common.read_json(os.path.join(codebook_dir, "codebook-cached-mappings.json"))
             except (FileNotFoundError, PermissionError):
                 pass
-            self.modified = False
 
         # Initialize salt if we don't have one yet
         if "id_salt" not in self.settings:
@@ -123,7 +123,7 @@ class CodebookDB:
             # The sha256 algorithm is sitting on top of this salt, and a key size equal to the output size is also
             # recommended, so 256 bits seem good (which is 32 bytes).
             self.settings["id_salt"] = secrets.token_hex(32)
-            self.modified = True
+            self.settings_modified = True
 
     def patient(self, real_id: str, cache_mapping: bool = True) -> str:
         """
@@ -174,7 +174,7 @@ class CodebookDB:
             # We expect the IDs to always be identical. The above check is mostly concerned with None != fake_id,
             # but is written defensively in case a bad mapping got saved for some reason.
             self.cached_mapping[resource_type][real_id] = fake_id
-            self.modified = True
+            self.mappings_modified = True
 
         return fake_id
 
@@ -242,16 +242,16 @@ class CodebookDB:
         """
         saved = False
 
-        if self.modified:
-            logging.info("Saving codebook to: %s", codebook_dir)
-
+        if self.settings_modified:
             codebook_path = os.path.join(codebook_dir, "codebook.json")
             common.write_json(codebook_path, self.settings)
+            self.settings_modified = False
+            saved = True
 
+        if self.mappings_modified:
             cached_mapping_path = os.path.join(codebook_dir, "codebook-cached-mappings.json")
             common.write_json(cached_mapping_path, self.cached_mapping)
-
-            self.modified = False
+            self.mappings_modified = False
             saved = True
 
         return saved

--- a/cumulus_etl/etl/cli.py
+++ b/cumulus_etl/etl/cli.py
@@ -197,7 +197,7 @@ def print_config(args: argparse.Namespace, job_datetime: datetime.datetime, all_
 
 async def etl_main(args: argparse.Namespace) -> None:
     # Set up some common variables
-    common.set_user_fs_options(vars(args))  # record filesystem options like --s3-region before creating Roots
+    store.set_user_fs_options(vars(args))  # record filesystem options like --s3-region before creating Roots
 
     root_input = store.Root(args.dir_input)
     root_phi = store.Root(args.dir_phi, create=True)

--- a/cumulus_etl/etl/convert/cli.py
+++ b/cumulus_etl/etl/convert/cli.py
@@ -135,7 +135,7 @@ def define_convert_parser(parser: argparse.ArgumentParser) -> None:
 
 async def convert_main(args: argparse.Namespace) -> None:
     """Main logic for converting"""
-    common.set_user_fs_options(vars(args))  # record filesystem options like --s3-region before creating Roots
+    store.set_user_fs_options(vars(args))  # record filesystem options like --s3-region before creating Roots
 
     input_root = store.Root(args.input_dir)
     validate_input_dir(input_root)

--- a/cumulus_etl/etl/tasks/base.py
+++ b/cumulus_etl/etl/tasks/base.py
@@ -145,7 +145,8 @@ class EtlTask:
                 self.table_batch_cleanup(table_index, batch_index)
 
                 print(f"  {summary.success:,} processed for {formatter.dbname}")
-                batch_index += 1
+
+            batch_index += 1
 
     def _touch_remaining_tables(self):
         """Writes empty dataframe to any table we haven't written to yet"""

--- a/cumulus_etl/store.py
+++ b/cumulus_etl/store.py
@@ -6,7 +6,38 @@ from urllib.parse import urlparse
 
 import fsspec
 
-from cumulus_etl import common
+_user_fs_options = {}  # don't access this directly, use get_fs_options()
+
+
+def set_user_fs_options(args: dict) -> None:
+    """Records user arguments that can affect filesystem options (like s3_region)"""
+    _user_fs_options.update(args)
+
+
+def get_fs_options(protocol: str) -> dict:
+    """Provides a set of storage option kwargs for fsspec calls or pandas storage_options arguments"""
+    options = {}
+
+    if protocol == "s3":
+        # Check for region manually. If you aren't using us-east-1, you usually need to specify the region
+        # explicitly, and fsspec doesn't seem to check the environment variables for us, nor pull it from
+        # ~/.aws/config
+        region_name = _user_fs_options.get("s3_region")
+        if region_name:
+            options["client_kwargs"] = {"region_name": region_name}
+
+        # Assume KMS encryption for now - we can make this tunable to AES256 if folks have a need.
+        # But in general, I believe we want to enforce server side encryption when possible, KMS or not.
+        options["s3_additional_kwargs"] = {
+            "ServerSideEncryption": "aws:kms",
+        }
+
+        # Buckets can be set up to require a specific KMS key ID, so allow specifying it here
+        kms_key = _user_fs_options.get("s3_kms_key")
+        if kms_key:
+            options["s3_additional_kwargs"]["SSEKMSKeyId"] = kms_key
+
+    return options
 
 
 class Root:
@@ -100,4 +131,4 @@ class Root:
 
     def fsspec_options(self) -> dict:
         """Provides a set of storage option kwargs for fsspec calls or pandas storage_options arguments"""
-        return common.get_fs_options(self.protocol)
+        return get_fs_options(self.protocol)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -71,7 +71,7 @@ tests = [
     "coverage",
     "ddt",
     "freezegun",
-    "moto[s3]",
+    "moto[server,s3]",
     "pytest",
     "respx",
 ]

--- a/tests/deid/test_deid_codebook.py
+++ b/tests/deid/test_deid_codebook.py
@@ -128,6 +128,9 @@ class TestCodebookDB(utils.AsyncTestCase):
             # Confirm that an empty book starts modified
             db = CodebookDB()
             self.assertTrue(db.save(tmpdir))
+            self.assertTrue(os.path.exists(f"{tmpdir}/codebook.json"))
+            self.assertFalse(os.path.exists(f"{tmpdir}/codebook-cached-mappings.json"))
+            codebook_mtime = os.path.getmtime(f"{tmpdir}/codebook.json")
 
             # But after a save, we are no longer modified
             self.assertFalse(db.save(tmpdir))
@@ -139,6 +142,9 @@ class TestCodebookDB(utils.AsyncTestCase):
             # Add a new patient, and we can save (because cached mapping changed)
             db.patient("1")
             self.assertTrue(db.save(tmpdir))
+            self.assertTrue(os.path.exists(f"{tmpdir}/codebook-cached-mappings.json"))
+            # main codebook shouldn't be written for just mappings changes
+            self.assertEqual(codebook_mtime, os.path.getmtime(f"{tmpdir}/codebook.json"))
 
             # But if we make a call that doesn't modify the db, don't save
             db.patient("1")

--- a/tests/deid/test_deid_scrubber.py
+++ b/tests/deid/test_deid_scrubber.py
@@ -5,6 +5,7 @@ from unittest import mock
 
 from ctakesclient import text2fhir, typesystem
 
+from cumulus_etl import common
 from cumulus_etl.deid import Scrubber
 from cumulus_etl.deid.codebook import CodebookDB
 from tests import i2b2_mock_data, utils
@@ -136,9 +137,7 @@ class TestScrubber(utils.AsyncTestCase):
             scrubber.scrub_resource(encounter_bad)
 
             # make sure that we raise an error on an unexpected cookbook version
-            db.settings["version"] = ".99"
-            db.modified = True
-            db.save(tmpdir)
+            common.write_json(f"{tmpdir}/codebook.json", {"version": ".99"})
             with self.assertRaises(Exception) as context:
                 Scrubber(tmpdir)
             self.assertIn(".99", str(context.exception))

--- a/tests/etl/test_etl_cli.py
+++ b/tests/etl/test_etl_cli.py
@@ -8,7 +8,6 @@ import tempfile
 from unittest import mock
 
 import pytest
-import s3fs
 from ctakesclient.typesystem import Polarity
 
 from cumulus_etl import cli, common, deid, errors, loaders, store
@@ -340,12 +339,9 @@ class TestEtlOnS3(S3Mixin, BaseEtlSimple):
     """Test case for our support of writing to S3"""
 
     async def test_etl_job_s3(self):
-        fs = s3fs.S3FileSystem()
-        fs.makedirs("s3://mockbucket/")
-
         await self.run_etl(output_path="s3://mockbucket/root")
 
-        all_files = {x for x in fs.find("mockbucket/root") if "/JobConfig/" not in x}
+        all_files = {x for x in self.s3fs.find("mockbucket/root") if "/JobConfig/" not in x}
         self.assertEqual(
             {
                 "mockbucket/root/condition/condition.000.ndjson",

--- a/tests/etl/test_etl_cli.py
+++ b/tests/etl/test_etl_cli.py
@@ -108,9 +108,9 @@ class TestEtlJobFlow(BaseEtlSimple):
 
             # Run a couple checks to ensure that we do indeed have PHI in this dir
             self.assertIn("Patient.ndjson", os.listdir(phi_dir))
-            with common.open_file(os.path.join(phi_dir, "Patient.ndjson"), "r") as f:
-                first = json.loads(f.readlines()[0])
-                self.assertEqual("02139", first["address"][0]["postalCode"])
+            patients = list(common.read_ndjson(os.path.join(phi_dir, "Patient.ndjson")))
+            first = patients[0]
+            self.assertEqual("02139", first["address"][0]["postalCode"])
 
             # Then raise an exception to interrupt the ETL flow before we normally would be able to clean up
             raise KeyboardInterrupt

--- a/tests/test_chart_cli.py
+++ b/tests/test_chart_cli.py
@@ -1,7 +1,6 @@
 """Tests for chart_review/cli.py"""
 
 import base64
-import json
 import os
 import shutil
 import tempfile
@@ -157,8 +156,8 @@ class TestChartReview(CtakesMixin, AsyncTestCase):
             f.write("\n".join(lines))
 
     def get_exported_ids(self) -> set[str]:
-        with common.open_file(os.path.join(self.export_path, "DocumentReference.ndjson"), "r") as f:
-            return {json.loads(line)["id"] for line in f}
+        rows = common.read_ndjson(f"{self.export_path}/DocumentReference.ndjson")
+        return {row["id"] for row in rows}
 
     def get_pushed_ids(self) -> set[str]:
         notes = self.ls_client.push_tasks.call_args[0][0]

--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -1,16 +1,15 @@
 """Tests for common.py"""
 import contextlib
-import io
-import os
+import itertools
 import tempfile
 from unittest import mock
 
 import ddt
 import fsspec
-from fsspec.implementations.local import LocalFileOpener
+import s3fs
 
 from cumulus_etl import common
-from tests import utils
+from tests import s3mock, utils
 
 
 @ddt.ddt
@@ -43,34 +42,79 @@ class TestLogging(utils.AsyncTestCase):
 
 
 @ddt.ddt
-class TestIOUtils(utils.AsyncTestCase):
-    """Tests for our read/write helper methods"""
+class TestIOUtils(s3mock.S3Mixin, utils.AsyncTestCase):
+    """
+    Tests for our read/write helper methods.
+
+    Mostly against S3 because that's such an important target FS and s3fs might have its own set of bugs/behavior.
+    """
 
     @contextlib.contextmanager
     def exploding_text(self):
         """Yields text data that when fed to S3 writes, will explode after some but not all data has been uploaded"""
-        orig_write = LocalFileOpener.write
+        orig_write = s3fs.core.S3File.write
 
         def exploding_write(*args, **kwargs):
             orig_write(*args, **kwargs)
             raise KeyboardInterrupt
 
-        with mock.patch("fsspec.implementations.local.LocalFileOpener.write", new=exploding_write):
+        with mock.patch("s3fs.core.S3File.write", new=exploding_write):
             with self.assertRaises(KeyboardInterrupt):
-                yield "1" * io.DEFAULT_BUFFER_SIZE
+                yield "1" * (fsspec.spec.AbstractBufferedFile.DEFAULT_BLOCK_SIZE + 1)
 
-    async def test_writes_are_atomic(self):
+    def test_writes_are_atomic(self):
         """Verify that our write utilities are atomic."""
-        with tempfile.TemporaryDirectory() as tmpdir:
-            # Try a couple of our write methods, confirm that nothing makes it through
-            with self.exploding_text() as text:
-                common.write_text(f"{tmpdir}/atomic.txt", text)
-            with self.exploding_text() as text:
-                common.write_json(f"{tmpdir}/atomic.json", {"hello": text})
-            self.assertEqual([], os.listdir(tmpdir))
+        # Try a couple of our write methods, confirm that nothing makes it through
+        with self.exploding_text() as text:
+            common.write_text(f"{self.bucket_url}/atomic.txt", text)
+        with self.exploding_text() as text:
+            common.write_json(f"{self.bucket_url}/atomic.json", {"hello": text})
+        self.assertEqual([], self.s3fs.ls(self.bucket_url, detail=False))
 
-            # By default, fsspec writes are not atomic - just sanity check that text _can_ get through exploding_text
-            with self.exploding_text() as text:
-                with fsspec.open(f"{tmpdir}/partial.txt", "w") as f:
-                    f.write(text)
-            self.assertEqual(["partial.txt"], os.listdir(tmpdir))
+        # By default, fsspec writes are not atomic - just sanity check that text _can_ get through exploding_text
+        with self.exploding_text() as text:
+            with fsspec.open(f"{self.bucket_url}/partial.txt", "w", endpoint_url=s3mock.S3Mixin.ENDPOINT_URL) as f:
+                f.write(text)
+        self.assertEqual([f"{self.bucket}/partial.txt"], self.s3fs.ls(self.bucket_url, detail=False))
+
+    @ddt.idata(
+        # Every combination of these sizes, backends, and data formats:
+        itertools.product(
+            [5, fsspec.spec.AbstractBufferedFile.DEFAULT_BLOCK_SIZE + 1],
+            ["local", "s3"],
+            ["json", "text"],
+        )
+    )
+    @ddt.unpack
+    def test_writes_happy_path(self, size, backend, data_format):
+        """
+        Verify that writes of various sizes and formats are written out correctly.
+
+        This may seem paranoid, but we've seen S3FS not write them out inside a transaction,
+        because we forgot to close or flush the file.
+        """
+        match data_format:
+            case "text":
+                write = common.write_text
+                read = common.read_text
+                data = "1" * size
+            case "json":
+                write = common.write_json
+                read = common.read_json
+                data = ["1" * size]
+            case _:
+                raise ValueError
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            match backend:
+                case "local":
+                    directory = tmpdir
+                case "s3":
+                    directory = self.bucket_url
+                case _:
+                    raise ValueError
+
+            write(f"{directory}/file.txt", data)
+            result = read(f"{directory}/file.txt")
+
+        self.assertEqual(data, result)

--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -1,13 +1,20 @@
 """Tests for common.py"""
+import contextlib
+import io
+import os
+import tempfile
+from unittest import mock
 
 import ddt
+import fsspec
+from fsspec.implementations.local import LocalFileOpener
 
 from cumulus_etl import common
-from tests.utils import AsyncTestCase
+from tests import utils
 
 
 @ddt.ddt
-class TestLogging(AsyncTestCase):
+class TestLogging(utils.AsyncTestCase):
     """
     Test case for common logging methods.
     """
@@ -33,3 +40,37 @@ class TestLogging(AsyncTestCase):
     def test_human_time_offset(self, seconds, expected_str):
         """Verify human_time_offset works correctly"""
         self.assertEqual(expected_str, common.human_time_offset(seconds))
+
+
+@ddt.ddt
+class TestIOUtils(utils.AsyncTestCase):
+    """Tests for our read/write helper methods"""
+
+    @contextlib.contextmanager
+    def exploding_text(self):
+        """Yields text data that when fed to S3 writes, will explode after some but not all data has been uploaded"""
+        orig_write = LocalFileOpener.write
+
+        def exploding_write(*args, **kwargs):
+            orig_write(*args, **kwargs)
+            raise KeyboardInterrupt
+
+        with mock.patch("fsspec.implementations.local.LocalFileOpener.write", new=exploding_write):
+            with self.assertRaises(KeyboardInterrupt):
+                yield "1" * io.DEFAULT_BUFFER_SIZE
+
+    async def test_writes_are_atomic(self):
+        """Verify that our write utilities are atomic."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            # Try a couple of our write methods, confirm that nothing makes it through
+            with self.exploding_text() as text:
+                common.write_text(f"{tmpdir}/atomic.txt", text)
+            with self.exploding_text() as text:
+                common.write_json(f"{tmpdir}/atomic.json", {"hello": text})
+            self.assertEqual([], os.listdir(tmpdir))
+
+            # By default, fsspec writes are not atomic - just sanity check that text _can_ get through exploding_text
+            with self.exploding_text() as text:
+                with fsspec.open(f"{tmpdir}/partial.txt", "w") as f:
+                    f.write(text)
+            self.assertEqual(["partial.txt"], os.listdir(tmpdir))

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -51,6 +51,18 @@ class AsyncTestCase(unittest.IsolatedAsyncioTestCase):
         self.addCleanup(patcher.stop)
         return patcher.start()
 
+    def patch_dict(self, *args, **kwargs) -> mock.Mock:
+        """Syntactic sugar to ease making a dictionary mock over a test's lifecycle, without decorators"""
+        patcher = mock.patch.dict(*args, **kwargs)
+        self.addCleanup(patcher.stop)
+        return patcher.start()
+
+    def patch_object(self, *args, **kwargs) -> mock.Mock:
+        """Syntactic sugar to ease making an object mock over a test's lifecycle, without decorators"""
+        patcher = mock.patch.object(*args, **kwargs)
+        self.addCleanup(patcher.stop)
+        return patcher.start()
+
     async def _catch_system_exit(self, method):
         try:
             ret = method()


### PR DESCRIPTION
This PR contains 3 commits:
- Old PR #243 (reviewed, reverted)
- Old PR #244 (not reviewed, reverted)
- New commit that fixes the remaining issue.

This new commit has the actual fix to a bug introduced in #243:
```
-        return root.fs.open(path, mode=mode, encoding="utf8")
+        with root.fs.open(path, mode=mode, encoding="utf8") as file:
+            yield file
```

The original commit changed `open_file` (a method that returns a file) to `_atomic_open` (a context manager that returns a file), inadvertently dropping the bit where we were actually using the file as a context manager itself, which means the file was not being closed and could have lingering data not committed to disk.

Easy to miss, hard to find.

I've also updated our testing to catch the several error cases that arise when you forget to close, so they are a bit paranoid now (confirm that small and large writes, to local and s3, using text or json all work correctly).

And I've done some manual testing to confirm everything seems to work.

### Checklist
- [x] Consider if documentation (like in `docs/`) needs to be updated
- [x] Consider if tests should be added