### PR TITLE
feat(deltalake): don't overwrite newer rows if we can avoid it

### DIFF
--- a/cumulus_etl/chart_review/cli.py
+++ b/cumulus_etl/chart_review/cli.py
@@ -8,7 +8,7 @@ from collections.abc import Collection
 import ctakesclient
 from ctakesclient.typesystem import Polarity
 
-from cumulus_etl import cli_utils, common, deid, errors, fhir, loaders, nlp, store
+from cumulus_etl import cli_utils, common, deid, errors, fhir, nlp, store
 from cumulus_etl.chart_review import downloader, selector
 from cumulus_etl.chart_review.labelstudio import LabelStudioClient, LabelStudioNote
 
@@ -30,7 +30,7 @@ def init_checks(args: argparse.Namespace):
 
 async def gather_docrefs(
     client: fhir.FhirClient, root_input: store.Root, root_phi: store.Root, args: argparse.Namespace
-) -> loaders.Directory:
+) -> common.Directory:
     """Selects and downloads just the docrefs we need to an export folder."""
     common.print_header("Gathering documents...")
 

--- a/cumulus_etl/chart_review/downloader.py
+++ b/cumulus_etl/chart_review/downloader.py
@@ -33,7 +33,7 @@ async def _download_docrefs_from_fake_ids(
     dir_phi: str,
     docref_csv: str,
     export_to: str = None,
-) -> loaders.Directory:
+) -> common.Directory:
     """Download DocumentReference resources for the given patient and docref identifiers"""
     output_folder = cli_utils.make_export_dir(export_to)
 
@@ -63,7 +63,7 @@ async def _download_docrefs_from_real_ids(
     client: fhir.FhirClient,
     docref_csv: str,
     export_to: str = None,
-) -> loaders.Directory:
+) -> common.Directory:
     """Download DocumentReference resources for the given patient and docref identifiers"""
     output_folder = cli_utils.make_export_dir(export_to)
 

--- a/cumulus_etl/chart_review/selector.py
+++ b/cumulus_etl/chart_review/selector.py
@@ -4,12 +4,12 @@ import functools
 import os
 from collections.abc import Callable, Iterable, Iterator
 
-from cumulus_etl import cli_utils, common, deid, loaders, store
+from cumulus_etl import cli_utils, common, deid, store
 
 
 def select_docrefs_from_files(
     root_input: store.Root, root_phi: store.Root, docrefs: str = None, anon_docrefs: str = None, export_to: str = None
-) -> loaders.Directory:
+) -> common.Directory:
     """Takes an input folder of ndjson and exports just the chosen docrefs to a new ndjson folder"""
     # Get an appropriate filter method, for the given docrefs
     docref_filter = _create_docref_filter(root_phi, docrefs, anon_docrefs)

--- a/cumulus_etl/cli_utils.py
+++ b/cumulus_etl/cli_utils.py
@@ -9,7 +9,7 @@ import urllib.parse
 
 import rich.progress
 
-from cumulus_etl import errors, loaders
+from cumulus_etl import common, errors
 
 
 def add_auth(parser: argparse.ArgumentParser) -> None:
@@ -47,7 +47,7 @@ def add_debugging(parser: argparse.ArgumentParser):
     return group
 
 
-def make_export_dir(export_to: str = None) -> loaders.Directory:
+def make_export_dir(export_to: str = None) -> common.Directory:
     """Makes a temporary directory to drop exported ndjson files into"""
     # Handle the easy case -- just a random temp dir
     if not export_to:
@@ -62,7 +62,7 @@ def make_export_dir(export_to: str = None) -> loaders.Directory:
 
     confirm_dir_is_empty(export_to)
 
-    return loaders.RealDirectory(export_to)
+    return common.RealDirectory(export_to)
 
 
 def confirm_dir_is_empty(path: str) -> None:

--- a/cumulus_etl/common.py
+++ b/cumulus_etl/common.py
@@ -7,9 +7,29 @@ import json
 import logging
 import re
 from collections.abc import Iterator
-from typing import Any, TextIO
+from typing import Any, Protocol, TextIO
+
+import rich
 
 from cumulus_etl import store
+
+
+###############################################################################
+#
+# Types
+#
+###############################################################################
+
+# We often want the ability to provide a TemporaryDirectory _or_ an actual real folder that isn't temporary.
+# So for that use case, we define a Directory protocol for typing purposes, which looks like a TemporaryDirectory.
+# And then a RealDirectory class that does not delete its folder.
+class Directory(Protocol):
+    name: str
+
+
+class RealDirectory:
+    def __init__(self, path: str):
+        self.name = path
 
 
 ###############################################################################
@@ -247,15 +267,9 @@ def warn_mode():
     logging.getLogger().setLevel(logging.WARN)
 
 
-_first_header = True
-
-
 def print_header(name: str | None = None) -> None:
     """Prints a section break to the console, with a name for the user"""
-    global _first_header
-    if not _first_header:
-        print("###############################################################")
-    _first_header = False
+    rich.get_console().rule()
     if name:
         print(name)
 

--- a/cumulus_etl/deid/mstool.py
+++ b/cumulus_etl/deid/mstool.py
@@ -9,7 +9,7 @@ import glob
 import os
 import sys
 
-from cumulus_etl import cli_utils, common, errors
+from cumulus_etl import cli_utils, errors
 
 MSTOOL_CMD = "Microsoft.Health.Fhir.Anonymizer.R4.CommandLineTool"
 
@@ -24,8 +24,6 @@ async def run_mstool(input_dir: str, output_dir: str) -> None:
 
     The input must be in ndjson format. And the output will be as well.
     """
-    common.print_header()
-
     process = await asyncio.create_subprocess_exec(
         MSTOOL_CMD,
         "--bulkData",

--- a/cumulus_etl/loaders/__init__.py
+++ b/cumulus_etl/loaders/__init__.py
@@ -1,5 +1,5 @@
 """Public API for loaders"""
 
-from .base import Directory, Loader, RealDirectory
+from .base import Loader
 from .fhir.ndjson_loader import FhirNdjsonLoader
 from .i2b2.loader import I2b2Loader

--- a/cumulus_etl/loaders/base.py
+++ b/cumulus_etl/loaders/base.py
@@ -1,22 +1,8 @@
 """Base abstract loader"""
 
 import abc
-from typing import Protocol
 
-from cumulus_etl.store import Root
-
-
-# Loaders often want the ability to provide callers with a TemporaryDirectory -- a folder that will be deleted as soon
-# as the caller is done using it. However, some code flows may instead require returning a folder that already exists.
-# So for that use case, we define a Directory protocol for typing purposes, which looks like a TemporaryDirectory.
-# And then a RealDirectory class that does not delete its folder.
-class Directory(Protocol):
-    name: str
-
-
-class RealDirectory:
-    def __init__(self, path: str):
-        self.name = path
+from cumulus_etl import common, store
 
 
 class Loader(abc.ABC):
@@ -28,7 +14,7 @@ class Loader(abc.ABC):
     All methods return an iterator over FHIR resources.
     """
 
-    def __init__(self, root: Root):
+    def __init__(self, root: store.Root):
         """
         Initialize a new Loader class
         :param root: the base location to read data from
@@ -36,7 +22,7 @@ class Loader(abc.ABC):
         self.root = root
 
     @abc.abstractmethod
-    async def load_all(self, resources: list[str]) -> Directory:
+    async def load_all(self, resources: list[str]) -> common.Directory:
         """
         Loads the listed remote resources and places them into a local folder as FHIR ndjson
 

--- a/cumulus_etl/loaders/fhir/ndjson_loader.py
+++ b/cumulus_etl/loaders/fhir/ndjson_loader.py
@@ -37,7 +37,7 @@ class FhirNdjsonLoader(base.Loader):
         self.since = since
         self.until = until
 
-    async def load_all(self, resources: list[str]) -> base.Directory:
+    async def load_all(self, resources: list[str]) -> common.Directory:
         # Are we doing a bulk FHIR export from a server?
         if self.root.protocol in ["http", "https"]:
             return await self._load_from_bulk_export(resources)
@@ -56,7 +56,7 @@ class FhirNdjsonLoader(base.Loader):
         #
         # This uses more disk space temporarily (copied files will get deleted once the MS tool is done and this
         # TemporaryDirectory gets discarded), but that seems reasonable.
-        common.print_header("Copying ndjson input files...")
+        common.print_header("Copying ndjson input files…")
         tmpdir = tempfile.TemporaryDirectory()  # pylint: disable=consider-using-with
         for resource in resources:
             filenames = common.ls_resources(self.root, resource)
@@ -66,7 +66,7 @@ class FhirNdjsonLoader(base.Loader):
                 logging.warning("No resources found for %s", resource)
         return tmpdir
 
-    async def _load_from_bulk_export(self, resources: list[str]) -> base.Directory:
+    async def _load_from_bulk_export(self, resources: list[str]) -> common.Directory:
         target_dir = cli_utils.make_export_dir(self.export_to)
 
         try:

--- a/cumulus_etl/loaders/i2b2/loader.py
+++ b/cumulus_etl/loaders/i2b2/loader.py
@@ -8,7 +8,7 @@ from pathlib import Path
 from typing import TypeVar
 
 from cumulus_etl import cli_utils, common, store
-from cumulus_etl.loaders.base import Directory, Loader
+from cumulus_etl.loaders.base import Loader
 from cumulus_etl.loaders.i2b2 import extract, schema, transform
 from cumulus_etl.loaders.i2b2.oracle import extract as oracle_extract
 
@@ -34,7 +34,7 @@ class I2b2Loader(Loader):
         super().__init__(root)
         self.export_to = export_to
 
-    async def load_all(self, resources: list[str]) -> Directory:
+    async def load_all(self, resources: list[str]) -> common.Directory:
         if self.root.protocol in ["tcp"]:
             return self._load_all_from_oracle(resources)
 
@@ -50,7 +50,7 @@ class I2b2Loader(Loader):
         documentreferences: I2b2ExtractorCallable,
         patients: I2b2ExtractorCallable,
         encounters: I2b2ExtractorCallable,
-    ) -> Directory:
+    ) -> common.Directory:
         """
         Load i2b2 content into a local folder as ndjson
 
@@ -130,7 +130,7 @@ class I2b2Loader(Loader):
     #
     ###################################################################################################################
 
-    def _load_all_from_csv(self, resources: list[str]) -> Directory:
+    def _load_all_from_csv(self, resources: list[str]) -> common.Directory:
         path = self.root.path
         return self._load_all_with_extractors(
             resources,
@@ -163,7 +163,7 @@ class I2b2Loader(Loader):
     #
     ###################################################################################################################
 
-    def _load_all_from_oracle(self, resources: list[str]) -> Directory:
+    def _load_all_from_oracle(self, resources: list[str]) -> common.Directory:
         path = self.root.path
         return self._load_all_with_extractors(
             resources,

--- a/docs/vendors/epic.md
+++ b/docs/vendors/epic.md
@@ -44,6 +44,21 @@ Rinse and repeat until you have imported all your data.
 When running Cumulus on a regular ongoing basis,
 make sure you update your registry to slide your date range forward before running Cumulus ETL.
 
+### Versioning of Updates
+
+Epic does not provide metadata about when each records was last updated
+(i.e. does not populate the `meta.lastUpdated` FHIR field).
+
+Which means that Cumulus ETL has no way of knowing when one batch of data is more up-to-date than
+another.
+This is fine, it just means that **you should run the ETL on the results of exports in the order
+that you exported them**.
+
+That is, if you exported patients both last week and today,
+you should run the ETL first on last week's batch, and then on today's.
+Otherwise, the ETL will accidentally overwrite today's patient data with last week's patient data
+(for any patients in both exports).
+
 ## API Access
 
 Epic will ask you for a list of APIs / resources to enable.

--- a/tests/test_chart_cli.py
+++ b/tests/test_chart_cli.py
@@ -10,7 +10,7 @@ from unittest import mock
 import ddt
 import respx
 
-from cumulus_etl import cli, common, errors, loaders
+from cumulus_etl import cli, common, errors
 from cumulus_etl.chart_review.labelstudio import LabelStudioNote
 
 from tests.ctakesmock import CtakesMixin
@@ -210,7 +210,7 @@ class TestChartReview(CtakesMixin, AsyncTestCase):
         # Mock out the bulk export loading, as that's well tested elsewhere
         async def load_all(*args):
             del args
-            return loaders.RealDirectory(self.input_path)
+            return common.RealDirectory(self.input_path)
 
         load_all_mock = mock_loader.return_value.load_all
         load_all_mock.side_effect = load_all


### PR DESCRIPTION
If both the lake table and the update rows have `meta.lastUpdated`, only push the update row if it is actually a newer version.

This should let folks with `meta.lastUpdated` support more safely mix and match batches of ndjson without having to stress about when each batch was exported from the EHR.

Unfortunately Epic doesn't provide this field, so this benefit is limited to other EHRs.

### Checklist
- [x] Consider if documentation (like in `docs/`) needs to be updated
- [x] Consider if tests should be added
