### PR TITLE
feat: add GitHub workflow to build and push to Docker Hub

### DIFF
--- a/.github/workflows/docker-hub.yaml
+++ b/.github/workflows/docker-hub.yaml
@@ -1,0 +1,39 @@
+name: Docker Hub
+
+# Currently, we publish every commit to main into Docker hub.
+# In the future, we may to trigger off of actual release tags.
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  push_to_docker_hub:
+    name: Build and push image
+    runs-on: ubuntu-latest
+    steps:
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+
+      - name: Get Docker metadata
+        id: meta
+        uses: docker/metadata-action@v4
+        with:
+          flavor: latest=true
+          images: smartonfhir/cumulus-etl
+
+      - name: Log in to Docker Hub
+        uses: docker/login-action@v2
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Build and push image to Docker Hub
+        uses: docker/build-push-action@v4
+        with:
+          push: true
+          platforms: |
+            linux/amd64
+            linux/arm64
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}

--- a/compose.yaml
+++ b/compose.yaml
@@ -1,9 +1,7 @@
 services:
 
   cumulus-etl-base:
-    build: 
-      context: .
-      target: cumulus-etl
+    image: smartonfhir/cumulus-etl:latest
     environment:
       - AWS_ACCESS_KEY_ID
       - AWS_SECRET_ACCESS_KEY

--- a/docs/performance.md
+++ b/docs/performance.md
@@ -84,19 +84,16 @@ If that that describes you, there are further instructions below.)
 Cumulus ETL is deployed with Docker images.
 And because of the way Docker interacts with the GPU, we define a whole second set of profiles for GPU usage.
 
-Normally, you specify profile & image names in three places:
-1. When building the ETL tool:<br>
-`docker compose --profile etl build`
-2. When starting the support tools (cTAKES etc):<br>
+Normally, you specify profile & image names in a couple places:
+1. When starting the support tools (cTAKES etc):<br>
 `docker compose --profile etl-support up`
-3. When running the ETL tool:<br>
+1. When running the ETL tool:<br>
 `docker compose run cumulus-etl`
 
 To work with the GPU version of Cumulus ETL, just add `-gpu` to each of those names
 wherever they appear in [instructions](sample-runs.md):
-1. <code>docker compose --profile etl<b>-gpu</b> build</code>
-2. <code>docker compose --profile etl-support<b>-gpu</b> up</code>
-3. <code>docker compose run cumulus-etl<b>-gpu</b></code>
+1. <code>docker compose --profile etl-support<b>-gpu</b> up</code>
+1. <code>docker compose run cumulus-etl<b>-gpu</b></code>
 
 ### Cloud Access to a GPU
 

--- a/docs/setup/sample-runs.md
+++ b/docs/setup/sample-runs.md
@@ -55,6 +55,15 @@ Simply clone the Cumulus ETL repository:
 git clone https://github.com/smart-on-fhir/cumulus-etl.git
 ```
 
+Further instructions below will pass Docker the argument `-f $CUMULUS_REPO_PATH/compose.yaml`.
+You can set that variable like so:
+```shell
+CUMULUS_REPO_PATH=/path-to-cloned-cumulus-etl-repo
+```
+
+Or if you run Docker commands directly from inside the cloned path,
+you can drop that `-f` argument entirely.
+
 ## Docker
 
 The next few steps will require Docker.
@@ -87,23 +96,6 @@ The `compose.yaml` file, which defines the network, adds the following container
   server, to run a second-pass negation of cTAKES results.
 
 ## Cumulus ETL
-
-### Building a Docker Image
-We plan to eventually offer a turnkey docker image.
-But for now you have to build a docker image yourself.
-
-You _could_ run Cumulus ETL directly from your cloned repository, but rather than worrying about
-all the dependencies it needs (including a whole
-[C# app from Microsoft](https://github.com/microsoft/Tools-for-Health-Data-Anonymization)
-that does some of the de-identification for us), we'll just build the docker image, using
-the Docker Compose network definition.
-
-```sh
-CUMULUS_REPO_PATH=/path-to-cloned-cumulus-etl-repo
-COMPOSE_DOCKER_CLI_BUILD=1 DOCKER_BUILDKIT=1 docker compose -f $CUMULUS_REPO_PATH/compose.yaml --profile etl build
-```
-
-And now you have Cumulus ETL installed!
 
 ### Running Cumulus ETL
 


### PR DESCRIPTION
This adds a new docker-hub.yaml workflow that builds and pushes any commit to main into Docker Hub directly.
    
And uses that built image in the compose file.

You can see the results of test runs here: https://hub.docker.com/r/smartonfhir/cumulus-etl/tags

### Checklist
- [x] Consider if documentation (like in `docs/`) needs to be updated
- [x] Consider if tests should be added
