### PR TITLE
fix: allow building the docker image via compose.yaml again

### DIFF
--- a/compose.yaml
+++ b/compose.yaml
@@ -2,6 +2,9 @@ services:
 
   cumulus-etl-base:
     image: smartonfhir/cumulus-etl:latest
+    build:
+      context: .
+      target: cumulus-etl
     environment:
       - AWS_ACCESS_KEY_ID
       - AWS_SECRET_ACCESS_KEY


### PR DESCRIPTION
I was overzealous when adding support for the pre-built ETL image. I removed the flag that let you build it via docker compose build.

So let's put that back.


### Checklist
- [x] Consider if documentation (like in `docs/`) needs to be updated
- [x] Consider if tests should be added
