### PR TITLE
feat: use progress bars in a lot more places

### DIFF
--- a/cumulus_etl/common.py
+++ b/cumulus_etl/common.py
@@ -3,6 +3,7 @@
 import contextlib
 import csv
 import datetime
+import itertools
 import json
 import logging
 import re
@@ -39,7 +40,7 @@ class RealDirectory:
 ###############################################################################
 
 
-def ls_resources(root, resource: str) -> list[str]:
+def ls_resources(root: store.Root, resource: str) -> list[str]:
     pattern = re.compile(rf".*/([0-9]+.)?{resource}(.[0-9]+)?.ndjson")
     all_files = root.ls()
     return sorted(filter(pattern.match, all_files))
@@ -130,7 +131,7 @@ def read_ndjson(path: str) -> Iterator[dict]:
             yield json.loads(line)
 
 
-def read_resource_ndjson(root, resource: str) -> Iterator[dict]:
+def read_resource_ndjson(root: store.Root, resource: str) -> Iterator[dict]:
     """
     Grabs all ndjson files from a folder, of a particular resource type.
 
@@ -187,6 +188,15 @@ class NdjsonWriter:
 
         json.dump(obj, self._file)
         self._file.write("\n")
+
+
+def read_local_line_count(path) -> int:
+    """Reads a local file and provides the count of new line characters."""
+    # From https://stackoverflow.com/a/27517681/239668
+    # Copyright Michael Bacon, licensed CC-BY-SA 3.0
+    with open(path, "rb") as f:
+        bufgen = itertools.takewhile(lambda x: x, (f.raw.read(1024 * 1024) for _ in itertools.repeat(None)))
+        return sum(buf.count(b"\n") for buf in bufgen if buf)
 
 
 def sparse_dict(dictionary: dict) -> dict:

--- a/cumulus_etl/deid/mstool.py
+++ b/cumulus_etl/deid/mstool.py
@@ -48,7 +48,7 @@ async def _wait_for_completion(process: asyncio.subprocess.Process, input_dir: s
     stdout, stderr = None, None
 
     with cli_utils.make_progress_bar() as progress:
-        task = progress.add_task("De-identifying data…", total=1)
+        task = progress.add_task("De-identifying data", total=1)
         target = _count_file_sizes(f"{input_dir}/*.ndjson")
 
         while process.returncode is None:

--- a/cumulus_etl/etl/cli.py
+++ b/cumulus_etl/etl/cli.py
@@ -212,6 +212,7 @@ async def etl_main(args: argparse.Namespace) -> None:
 
     # Print configuration
     print_config(args, job_datetime, selected_tasks)
+    common.print_header()  # all "prep" comes in this next section, like connecting to server, bulk export, and de-id
 
     if args.errors_to:
         cli_utils.confirm_dir_is_empty(args.errors_to)
@@ -267,11 +268,14 @@ async def etl_main(args: argparse.Namespace) -> None:
     job_context.last_successful_output_dir = args.dir_output
     job_context.save()
 
-    # If any task had a failure, flag that for the user
+    # Flag final status to user
+    common.print_header()
     failed = any(s.success < s.attempt for s in summaries)
     if failed:
-        print("** One or more tasks above did not 100% complete! **", file=sys.stderr)
+        print("🚨 One or more tasks above did not 100% complete! 🚨", file=sys.stderr)
         raise SystemExit(errors.TASK_FAILED)
+    else:
+        print("⭐ All tasks completed successfully! ⭐", file=sys.stderr)
 
 
 async def run_etl(parser: argparse.ArgumentParser, argv: list[str]) -> None:

--- a/cumulus_etl/fhir/fhir_client.py
+++ b/cumulus_etl/fhir/fhir_client.py
@@ -154,6 +154,8 @@ class FhirClient:
         if not self._server_root:
             return
 
+        print("Connecting to server…")
+
         try:
             response = await self._session.get(
                 fhir_auth.urljoin(self._server_root, "metadata"),

--- a/cumulus_etl/loaders/fhir/ndjson_loader.py
+++ b/cumulus_etl/loaders/fhir/ndjson_loader.py
@@ -56,7 +56,7 @@ class FhirNdjsonLoader(base.Loader):
         #
         # This uses more disk space temporarily (copied files will get deleted once the MS tool is done and this
         # TemporaryDirectory gets discarded), but that seems reasonable.
-        common.print_header("Copying ndjson input files…")
+        print("Copying ndjson input files…")
         tmpdir = tempfile.TemporaryDirectory()  # pylint: disable=consider-using-with
         for resource in resources:
             filenames = common.ls_resources(self.root, resource)


### PR DESCRIPTION
- Bulk export gets a spinner
- Each task gets 3 progress bars (prep, batches, finalize)
- After the ETL run, print a final success message

# Old vs New
Old:
![Old](https://github.com/smart-on-fhir/cumulus-etl/assets/1196901/47e241e3-cebd-4c3c-986c-ef613b8eda5b)
New:
![New](https://github.com/smart-on-fhir/cumulus-etl/assets/1196901/b6c8277d-22a9-4d3a-9678-8148b87d2b4a)

# Multiple Output tables
![Screenshot from 2023-08-01 11-28-52](https://github.com/smart-on-fhir/cumulus-etl/assets/1196901/58b0808b-ebec-4639-8310-83d91640b1ac)

# Bulk Progress Spinner
![Screenshot from 2023-08-01 10-47-58](https://github.com/smart-on-fhir/cumulus-etl/assets/1196901/c9f7241f-a35f-4215-ab16-a09a569e31fe)

# Screencast of New
[Screencast](https://github.com/smart-on-fhir/cumulus-etl/assets/1196901/071f350d-b8f8-4ac8-87b6-971b932c3818)

### Checklist
- [x] Consider if documentation (like in `docs/`) needs to be updated
- [x] Consider if tests should be added
