### PR TITLE
fix: use separate reading/writing progress bars during tasks

### DIFF
--- a/cumulus_etl/etl/tasks/basic_tasks.py
+++ b/cumulus_etl/etl/tasks/basic_tasks.py
@@ -4,6 +4,8 @@ import copy
 import logging
 import os
 
+import rich.progress
+
 from cumulus_etl import common, fhir, store
 from cumulus_etl.etl import tasks
 
@@ -99,8 +101,8 @@ class MedicationRequestTask(tasks.EtlTask):
 
         return medication if self.scrub_medication(medication) else None
 
-    async def read_entries(self) -> tasks.EntryIterator:
-        for resource in self.read_ndjson():
+    async def read_entries(self, *, progress: rich.progress.Progress = None) -> tasks.EntryIterator:
+        for resource in self.read_ndjson(progress=progress):
             orig_resource = copy.deepcopy(resource)
             if not self.scrubber.scrub_resource(resource):
                 continue


### PR DESCRIPTION
This allows for tasks whose output is not 1:1 with their input. For example, medicationrequest or covid_symptom__nlp_results.

Before, their total batch count might be over or under counted. Now, the reading bar will always match the input progress, and the writing bar will be indeterminate or finished while taking a reading breather.

# Considerations
I could have just left off the `Writing` bar, and had the `Reading` bar have momentary-but-unexplained pauses. But then you have the issue of the last batch written. I didn't want 100% on the reading bar for 30 minutes with no explanation (or arguably worse, save a bit at the end and leave it at 99% for 30 minutes).

I also figured it was better to reset the existing `Writing` bar (rather than have a growing list of `Batch 1`, `Batch 2` etc bars) because that kept the Reading bar as the focus and seeing historical batch writes wouldn't be super interesting to the user, I figured. (though sometimes interesting to me for their timings -- now if I want to watch the timing, I have to notice it during a pause in the action... so some possible improvements there).

But I'm open to those thoughts ^ being wrong.

# Screencast of new bars in action:
[Screencast from 08-07-2023 02:53:19 PM.webm](https://github.com/smart-on-fhir/cumulus-etl/assets/1196901/7be0fcca-4a2b-49fb-a481-4d8917353c64)

### Checklist
- [x] Consider if documentation (like in `docs/`) needs to be updated
- [x] Consider if tests should be added
