### PR TITLE
feat: add new llama2 NLP test task

### DIFF
--- a/compose.yaml
+++ b/compose.yaml
@@ -70,6 +70,31 @@ services:
           devices:
             - capabilities: [gpu]
 
+  llama2:
+    image: ghcr.io/huggingface/text-generation-inference:1.0.0
+    environment:
+      # If you update anything here that could affect NLP results, consider updating the
+      # task_version of any tasks that use this docker.
+      - HUGGING_FACE_HUB_TOKEN
+      - MAX_BATCH_PREFILL_TOKENS=2048  # default of 4096 overwhelms a 16GB machine
+      - MODEL_ID=meta-llama/Llama-2-7b-chat-hf
+      - REVISION=08751db2aca9bf2f7f80d2e516117a53d7450235
+    healthcheck:
+      # There's no curl or wget inside this container, but there is python3!
+      test: ["CMD", "python3", "-c", "import socket; socket.create_connection(('localhost', 80))"]
+      start_period: 20m  # give plenty of time for startup, since we may be downloading a model
+    volumes:
+      - hf-data:/data
+    networks:
+      - cumulus-etl
+    ports:
+      - 8086:80
+    deploy:
+      resources:
+        reservations:
+          devices:
+            - capabilities: [gpu]
+
   # these images are intended specifically for development work
   cumulus-etl-test:
     extends:
@@ -156,3 +181,4 @@ networks:
 
 volumes:
   ctakes-overrides:
+  hf-data:

--- a/cumulus_etl/etl/studies/covid_symptom/covid_tasks.py
+++ b/cumulus_etl/etl/studies/covid_symptom/covid_tasks.py
@@ -95,10 +95,7 @@ class CovidSymptomNlpResultsTask(tasks.EtlTask):
         http_client = nlp.ctakes_httpx_client()
 
         for docref in self.read_ndjson(progress=progress):
-            # Only bother running NLP on docs that are current & finalized
-            bad_ref_status = docref.get("status") in ("superseded", "entered-in-error")  # status of DocRef itself
-            bad_doc_status = docref.get("docStatus") in ("preliminary", "entered-in-error")  # status of clinical note
-            if bad_ref_status or bad_doc_status:
+            if not nlp.is_docref_valid(docref):
                 continue
 
             # Check that the note is one of our special allow-listed types (we do this here rather than on the output

--- a/cumulus_etl/etl/studies/hftest/__init__.py
+++ b/cumulus_etl/etl/studies/hftest/__init__.py
@@ -1,0 +1,3 @@
+"""Test study for hugging face integration"""
+
+from .hf_tasks import HuggingFaceTestTask

--- a/cumulus_etl/etl/studies/hftest/hf_tasks.py
+++ b/cumulus_etl/etl/studies/hftest/hf_tasks.py
@@ -1,0 +1,121 @@
+"""Define tasks for the hftest study"""
+
+import logging
+
+import httpx
+import pyarrow
+import rich.progress
+
+from cumulus_etl import common, fhir, formats, nlp
+from cumulus_etl.etl import tasks
+
+
+class HuggingFaceTestTask(tasks.EtlTask):
+    """Hugging Face Test study task, to generate a summary from text"""
+
+    name = "hftest__summary"
+    resource = "DocumentReference"
+    outputs = [tasks.OutputTable(schema=None)]
+
+    # Task Version
+    # The "task_version" field is a simple integer that gets incremented any time an NLP-relevant parameter is changed.
+    # This is a reference to a bundle of metadata (model revision, container revision, prompt string).
+    # We could combine all that info into a field we save with the results. But it's more human-friendly to have a
+    # simple version to refer to. So anytime these properties get changed, bump the version and record the old bundle
+    # of metadata too. Also update the safety checks in prepare_task()
+    task_version = 0
+
+    # Task Version History:
+    # ** 0 **
+    #   This is fluid until we actually promote this to a real task - feel free to update without bumping the version.
+    #   container: ghcr.io/huggingface/text-generation-inference
+    #   container reversion: 3ef5ffbc6400370ff2e1546550a6bad3ac61b079
+    #   container properties:
+    #     MAX_BATCH_PREFILL_TOKENS=2048
+    #   model: meta-llama/Llama-2-7b-chat-hf
+    #   model revision: 08751db2aca9bf2f7f80d2e516117a53d7450235
+    #   system prompt:
+    #     "You will be given a clinical note, and you should reply with a short summary of that note."
+    #   user prompt: a clinical note
+
+    async def prepare_task(self) -> bool:
+        try:
+            raw_info = await nlp.hf_info()
+        except httpx.HTTPError:
+            logging.warning(
+                " Skipping task: NLP server is unreachable.\n Try running 'docker compose up llama2 --wait'."
+            )
+            self.summaries[0].had_errors = True
+            return False
+
+        # Sanity check a few of the properties, to make sure we don't accidentally get pointed at an unexpected model.
+        expected_info_present = (
+            raw_info.get("model_id") == "meta-llama/Llama-2-7b-chat-hf"
+            and raw_info.get("model_sha") == "08751db2aca9bf2f7f80d2e516117a53d7450235"
+            and raw_info.get("sha") == "3ef5ffbc6400370ff2e1546550a6bad3ac61b079"
+        )
+        if not expected_info_present:
+            logging.warning(" Skipping task: NLP server is using an unexpected model setup.")
+            self.summaries[0].had_errors = True
+            return False
+
+        return True
+
+    async def read_entries(self, *, progress: rich.progress.Progress = None) -> tasks.EntryIterator:
+        """Passes clinical notes through HF and returns any symptoms found"""
+        http_client = httpx.AsyncClient()
+
+        for docref in self.read_ndjson(progress=progress):
+            can_process = nlp.is_docref_valid(docref) and self.scrubber.scrub_resource(docref, scrub_attachments=False)
+            if not can_process:
+                continue
+
+            try:
+                clinical_note = await fhir.get_docref_note(self.task_config.client, docref)
+            except Exception as exc:  # pylint: disable=broad-except
+                logging.warning("Error getting text for docref %s: %s", docref["id"], exc)
+                self.summaries[0].had_errors = True
+                continue
+
+            timestamp = common.datetime_now().isoformat()
+
+            # If you change this prompt, consider updating task_version.
+            system_prompt = "You will be given a clinical note, and you should reply with a short summary of that note."
+            user_prompt = clinical_note
+
+            summary = await nlp.cache_wrapper(
+                self.task_config.dir_phi,
+                f"{self.name}_v{self.task_version}",
+                user_prompt,
+                nlp.llama2_prompt,
+                system_prompt,
+                user_prompt,
+                client=http_client,
+            )
+
+            # Debugging
+            # logging.warning("\n\n\n\n" "**********************************************************")
+            # logging.warning(user_prompt)
+            # logging.warning("==========================================================")
+            # logging.warning(summary)
+            # logging.warning("**********************************************************")
+
+            yield {
+                "id": docref["id"],  # just copy the docref
+                "docref_id": docref["id"],
+                "summary": summary,
+                "generated_on": timestamp,
+                "task_version": self.task_version,
+            }
+
+    @classmethod
+    def get_schema(cls, formatter: formats.Format, rows: list[dict]) -> pyarrow.Schema:
+        return pyarrow.schema(
+            [
+                pyarrow.field("id", pyarrow.string()),
+                pyarrow.field("docref_id", pyarrow.string()),
+                pyarrow.field("generated_on", pyarrow.string()),
+                pyarrow.field("task_version", pyarrow.int32()),
+                pyarrow.field("summary", pyarrow.string()),
+            ]
+        )

--- a/cumulus_etl/etl/tasks/__init__.py
+++ b/cumulus_etl/etl/tasks/__init__.py
@@ -1,4 +1,4 @@
 """Task support for the ETL workflow"""
 
 from .base import EntryIterator, EtlTask, OutputTable
-from .factory import get_all_tasks, get_selected_tasks
+from .factory import get_all_tasks, get_default_tasks, get_selected_tasks

--- a/cumulus_etl/nlp/__init__.py
+++ b/cumulus_etl/nlp/__init__.py
@@ -1,4 +1,6 @@
 """Support code for NLP servers"""
 
 from .extract import ctakes_extract, ctakes_httpx_client, list_polarity
+from .huggingface import hf_prompt, hf_info, llama2_prompt
+from .utils import cache_wrapper, is_docref_valid
 from .watcher import check_cnlpt, check_ctakes, restart_ctakes_with_bsv

--- a/cumulus_etl/nlp/huggingface.py
+++ b/cumulus_etl/nlp/huggingface.py
@@ -1,0 +1,82 @@
+"""Abstraction layer for Hugging Face's inference API"""
+
+import os
+import urllib.parse
+
+import httpx
+
+
+def get_hugging_face_url() -> str:
+    # 8000 and 8080 are both used as defaults in ctakesclient (cnlp & ctakes respectively). So let's use 86 for H.F.
+    return os.environ.get("CUMULUS_HUGGING_FACE_URL") or "http://localhost:8086/"
+
+
+async def llama2_prompt(system_prompt: str, user_prompt: str, *, client: httpx.AsyncClient = None) -> str:
+    """
+    Prompts a llama2 chat model and provides its response.
+
+    :param system_prompt: this is the instruction to the model ("You are a ...")
+    :param user_prompt: this is the question / input ("How big is the sun?")
+    :param client: the httpx client to use (optional)
+    :returns: the llama2 response
+    """
+    # From Llama2 docs (https://huggingface.co/meta-llama/Llama-2-7b-hf):
+    #   To get the expected features and performance for the chat versions, a specific formatting needs to be followed,
+    #   including the INST and <<SYS>> tags, BOS and EOS tokens, and the whitespaces and breaklines in between
+    #   (we recommend calling strip() on inputs to avoid double-spaces). See our reference code in github for details:
+    #   https://github.com/facebookresearch/llama/blob/main/llama/generation.py#L212.
+    #
+    # Also see https://huggingface.co/blog/llama2#how-to-prompt-llama-2
+    whole_prompt = f"""<s>[INST] <<SYS>>
+{system_prompt.strip()}
+<</SYS>>
+
+{user_prompt.strip()} [/INST]"""
+
+    response = await hf_prompt(whole_prompt, client=client)
+    text = response[0]["generated_text"]
+    text = text.removeprefix(whole_prompt).strip()  # llama2 gives back the prompt too, but we don't need it
+    return text
+
+
+async def hf_prompt(prompt: str | dict, *, client: httpx.AsyncClient = None) -> list | dict:
+    """
+    Prompts a Hugging Face model and provides its response.
+
+    :param prompt: this is the raw input to the model
+    :param client: the httpx client to use (optional)
+    :returns: the raw model response
+    """
+    headers = {}
+    # Check for a token using the same env name as the huggingface/text-generation-inference docker
+    # TODO: disabled for now to prevent accidentally sending PHI - do we even want the ability to hit the cloud?
+    # if hf_token := os.environ.get("HUGGING_FACE_HUB_TOKEN"):
+    #     headers["Authorization"] = f"Bearer {hf_token}"
+
+    # Prompt and answer format will be model-specific - don't assume too much here
+    client = client or httpx.AsyncClient()
+    response = await client.post(
+        get_hugging_face_url(),
+        headers=headers,
+        json={
+            "inputs": prompt,
+            "options": {
+                "wait_for_model": True,
+            },
+        },
+    )
+    response.raise_for_status()
+    return response.json()
+
+
+async def hf_info(*, client: httpx.AsyncClient = None) -> dict:
+    """
+    Returns a Hugging Face model info dictionary.
+
+    This is suitable for logging along with generated results, to identify provenance.
+    """
+    url = urllib.parse.urljoin(get_hugging_face_url(), "info")
+    client = client or httpx.AsyncClient()
+    response = await client.get(url)
+    response.raise_for_status()
+    return response.json()

--- a/cumulus_etl/nlp/utils.py
+++ b/cumulus_etl/nlp/utils.py
@@ -1,0 +1,33 @@
+"""Misc NLP functions"""
+
+import hashlib
+import os
+from typing import Callable
+
+from cumulus_etl import common, store
+
+
+def is_docref_valid(docref: dict) -> bool:
+    """Returns True if this docref is not a draft or entered-in-error resource and could be considered for NLP"""
+    good_status = docref.get("status") in ("current", None)  # status of DocRef itself
+    good_doc_status = docref.get("docStatus") in ("final", "amended", None)  # status of clinical note
+    return good_status and good_doc_status
+
+
+async def cache_wrapper(cache_dir: str, namespace: str, content: str, method: Callable, *args, **kwargs) -> str:
+    """Looks up an NLP result in the cache first, falling back to actually calling NLP."""
+    # First, what is our target path for a possible cache file
+    cache_dir = store.Root(cache_dir, create=True)
+    checksum = hashlib.sha256(content.encode("utf8")).hexdigest()
+    path = f"ctakes-cache/{namespace}/{checksum[0:4]}/sha256-{checksum}.json"  # "ctakes-cache" is historical
+    cache_filename = cache_dir.joinpath(path)
+
+    # And try to read that file, falling back to calling the given method if a cache is not available
+    try:
+        result = common.read_text(cache_filename)
+    except (FileNotFoundError, PermissionError):
+        result = await method(*args, **kwargs)
+        cache_dir.makedirs(os.path.dirname(cache_filename))
+        common.write_text(cache_filename, result)
+
+    return result

--- a/tests/convert/test_convert_cli.py
+++ b/tests/convert/test_convert_cli.py
@@ -72,7 +72,7 @@ class TestConvert(utils.AsyncTestCase):
         await self.run_convert()
 
         # Test first conversion results
-        expected_tables = {output.get_name(t) for t in tasks.get_all_tasks() for output in t.outputs}
+        expected_tables = {output.get_name(t) for t in tasks.get_default_tasks() for output in t.outputs}
         self.assertEqual(expected_tables | {"JobConfig"}, set(os.listdir(self.target_path)))
         self.assertEqual(
             {"test": True}, common.read_json(f"{self.target_path}/JobConfig/{job_timestamp}/job_config.json")

--- a/tests/etl/test_tasks.py
+++ b/tests/etl/test_tasks.py
@@ -124,9 +124,9 @@ class TestTasks(TaskTestCase):
         self.assertEqual(errors.TASK_FILTERED_OUT, cm.exception.code)
 
     @ddt.data(
-        (None, "all"),
-        ([], "all"),
-        (filter(None, []), "all"),  # iterable, not list
+        (None, "default"),
+        ([], "default"),
+        (filter(None, []), "default"),  # iterable, not list
         (["observation", "condition", "procedure"], ["condition", "observation", "procedure"]),  # re-ordered
         (["condition", "patient", "encounter"], ["encounter", "patient", "condition"]),  # encounter and patient first
     )
@@ -134,8 +134,8 @@ class TestTasks(TaskTestCase):
     def test_task_selection_ordering(self, user_tasks, expected_tasks):
         """Verify we define the order, not the user, and that encounter & patient are early"""
         names = [t.name for t in tasks.get_selected_tasks(names=user_tasks)]
-        if expected_tasks == "all":
-            expected_tasks = [t.name for t in tasks.get_all_tasks()]
+        if expected_tasks == "default":
+            expected_tasks = [t.name for t in tasks.get_default_tasks()]
         self.assertEqual(expected_tasks, names)
 
     async def test_drop_duplicates(self):


### PR DESCRIPTION
This task is not run by default, and it is more of a toy than a production-ready task right now.

It just asks Llama2 to summarize clinical notes.
There was no prompt engineering to improve results, yet.

Here's how you run it:
```
export HUGGING_FACE_HUB_TOKEN=xxx
docker compose up llama2 --wait  # this will take several minutes
docker compose run cumulus-etl --task hftest__summary ...
```

Note that Llama2 requires a GPU to run.


### Checklist
- [x] Consider if documentation (like in `docs/`) needs to be updated
- [x] Consider if tests should be added
