### PR TITLE
feat: allow input ndjson files to have non-numeric filename parts

### DIFF
--- a/cumulus_etl/common.py
+++ b/cumulus_etl/common.py
@@ -75,7 +75,7 @@ def get_temp_dir(subdir: str) -> str:
 
 
 def ls_resources(root: store.Root, resource: str) -> list[str]:
-    pattern = re.compile(rf".*/([0-9]+.)?{resource}(.[0-9]+)?.ndjson")
+    pattern = re.compile(rf".*/([0-9]+\.)?{resource}(\.[^/]+)?\.ndjson")
     all_files = root.ls()
     return sorted(filter(pattern.match, all_files))
 


### PR DESCRIPTION
Before, we allowed files of this format:
1.Patient.ndjson
Patient.1.ndjson
1.Patient.1.ndjson
Patient.ndjson

But now we also allow files that look like:
Patient.string.here.ndjson
1.Patient.string.here.ndjson

This loosening is to help with organizing your files - maybe you have an export of Observation labs and want to denote that in the filename, like 1.Observation.labs.ndjson or something.


### Checklist
- [x] Consider if documentation (like in `docs/`) needs to be updated
- [x] Consider if tests should be added
