### PR TITLE
Added DB prefix to example template

### DIFF
--- a/docs/setup/cumulus-aws-template.yaml
+++ b/docs/setup/cumulus-aws-template.yaml
@@ -5,6 +5,10 @@ Parameters:
   BucketPrefix:
     Type: 'String'
     Description: 'Prefix for Cumulus bucket names (they will look like {BucketPrefix}-{purpose}-{AWS::AccountId}-{AWS::Region})'
+  DatabasePrefix:
+    Type: 'String'
+    Description: 'Prefix for Athena-related AWS resources (they will look like {BucketPrefix}-{service related suffix}. It can be left as default unless you need to run multiple instances of this stack.'
+    Default: 'cumulus-deid'
   EtlSubdir:
     Type: 'String'
     Description: 'Subdirectory on the Cumulus ETL output bucket where files will be placed. This should match the path you give when running Cumulus ETL. Using a subdirectory is recommended to allow for test runs of Cumulus ETL in different subdirectories and general future-proofing.'
@@ -116,7 +120,7 @@ Resources:
         S3Encryptions:
           - KmsKeyArn: !Ref KMSMasterKeyID
             S3EncryptionMode: SSE-KMS
-      Name: cumulus-deid-kms
+      Name: !Sub "${DatabasePrefix}-kms"
 
   CrawlerRole:
     Type: AWS::IAM::Role
@@ -148,12 +152,17 @@ Resources:
     Properties:
       CatalogId: !Ref AWS::AccountId
       DatabaseInput:
-        Name: cumulus_deid_db # use underscores for ease of SQL (hyphens are reserved)
+        Name: 
+          Fn::Join: # replace hyphens with underscores for ease of SQL (hyphens are reserved)
+          - '_'
+          - Fn::Split:
+            - '-'
+            - !Sub "${DatabasePrefix}_db"
 
   GlueCrawler:
     Type: AWS::Glue::Crawler
     Properties:
-      Name: cumulus-deid-crawler
+      Name: !Sub "${DatabasePrefix}-crawler"
       DatabaseName: !Ref GlueDB
       Role: !GetAtt CrawlerRole.Arn
       CrawlerSecurityConfiguration: !Ref GlueSecurity
@@ -222,7 +231,7 @@ Resources:
   AthenaWorkGroup:
     Type: AWS::Athena::WorkGroup
     Properties:
-      Name: cumulus-deid
+      Name: !Sub "${DatabasePrefix}"
       State: ENABLED
       WorkGroupConfiguration:
         EnforceWorkGroupConfiguration: True


### PR DESCRIPTION
This PR adds a new param to the example template to allow specifying a different prefix for database-related AWS infrastructure.

### Checklist
- [X] Consider if documentation (like in `docs/`) needs to be updated
- [X] Consider if tests should be added
