### PR TITLE
feat(chart-review): group notes by encounter, show real & anon IDs

### DIFF
--- a/cumulus_etl/chart_review/selector.py
+++ b/cumulus_etl/chart_review/selector.py
@@ -8,11 +8,15 @@ from cumulus_etl import cli_utils, common, deid, store
 
 
 def select_docrefs_from_files(
-    root_input: store.Root, root_phi: store.Root, docrefs: str = None, anon_docrefs: str = None, export_to: str = None
+    root_input: store.Root,
+    codebook: deid.Codebook,
+    docrefs: str = None,
+    anon_docrefs: str = None,
+    export_to: str = None,
 ) -> common.Directory:
     """Takes an input folder of ndjson and exports just the chosen docrefs to a new ndjson folder"""
     # Get an appropriate filter method, for the given docrefs
-    docref_filter = _create_docref_filter(root_phi, docrefs, anon_docrefs)
+    docref_filter = _create_docref_filter(codebook, docrefs, anon_docrefs)
 
     # Set up export folder
     output_folder = cli_utils.make_export_dir(export_to=export_to)
@@ -28,14 +32,14 @@ def select_docrefs_from_files(
 
 
 def _create_docref_filter(
-    root_phi: store.Root, docrefs: str = None, anon_docrefs: str = None
+    codebook: deid.Codebook, docrefs: str = None, anon_docrefs: str = None
 ) -> Callable[[Iterable[dict]], Iterator[dict]]:
     """This returns a method that will can an iterator of docrefs and returns an iterator of fewer docrefs"""
     # Decide how we're filtering the input files (by real or fake ID, or no filtering at all!)
     if docrefs:
         return functools.partial(_filter_real_docrefs, docrefs)
     elif anon_docrefs:
-        return functools.partial(_filter_fake_docrefs, root_phi, anon_docrefs)
+        return functools.partial(_filter_fake_docrefs, codebook, anon_docrefs)
     else:
         # Just accept everything (we still want to read them though, to copy them to a possible export folder).
         # So this lambda just returns an iterator over its input.
@@ -56,12 +60,10 @@ def _filter_real_docrefs(docrefs_csv: str, docrefs: Iterable[dict]) -> Iterator[
                 break
 
 
-def _filter_fake_docrefs(root_phi: store.Root, anon_docrefs_csv: str, docrefs: Iterable[dict]) -> Iterator[dict]:
+def _filter_fake_docrefs(codebook: deid.Codebook, anon_docrefs_csv: str, docrefs: Iterable[dict]) -> Iterator[dict]:
     """Calculates the fake ID for all docrefs found, and keeps any that match the csv list"""
     with common.read_csv(anon_docrefs_csv) as reader:
         fake_docref_ids = {row["docref_id"] for row in reader}  # ignore the patient_id column, not needed
-
-    codebook = deid.Codebook(root_phi.path)
 
     for docref in docrefs:
         fake_id = codebook.fake_id("DocumentReference", docref["id"], caching_allowed=False)

--- a/docs/chart-review.md
+++ b/docs/chart-review.md
@@ -63,6 +63,15 @@ mark the notes with the default NLP dictionary,
 anonymize the notes with `philter`,
 and then push the results to your Label Studio project number `3`.
 
+### Grouping by Encounter
+
+Chart review mode will group all notes by encounter and present them together as a single
+Label Studio artifact.
+
+Each clinical note will have a little header describing what type of note it is ("Admission MD"),
+as well as its real & anonymized DocumentReference identifiers,
+to make it easier to reference back to your EHR or Athena data.
+
 ## Bulk Export Options
 
 You can point chart review mode at either a folder with DocumentReference ndjson files
@@ -240,7 +249,8 @@ But just briefly, a setup like this with hard-coded labels will work:
 </View>
 ```
 
-Or you can use dynamic labels, and chart review mode will define them from your symptoms file:
+Or you can use dynamic labels, and chart review mode will define them from your symptoms file.
+Note that the `value` argument must match the `name` argument in your config, like so:
 ```
 <View>
   <Labels name="label" toName="text" value="$label" />

--- a/tests/fhir/test_fhir_client.py
+++ b/tests/fhir/test_fhir_client.py
@@ -227,7 +227,7 @@ class TestFhirClient(AsyncTestCase):
             {},
             (
                 "Client error '400 Bad Request' for url 'https://auth.example.com/token'\n"
-                "For more information check: https://httpstatuses.com/400"
+                "For more information check: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/400"
             ),
         ),
     )


### PR DESCRIPTION
This adds a couple quality-of-life improvements to chart-review mode:
- Notes are now grouped by encounter, with each note clearly demarked inside a larger text document.
- Notes now have a header with their note type label (e.g. "Admission MD") plus their real & anonymized IDs
- The encounter ID (real+anon) plus all the contained DocRef IDs (real+anon) are also pushed as Label Studio metadata, which will show up in exports if folks want to do some post-processing.

This should land along with an announcement.

### Checklist
- [x] Consider if documentation (like in `docs/`) needs to be updated
- [x] Consider if tests should be added
