### PR TITLE
docker: stop launching llama2 for every profile

### DIFF
--- a/compose.yaml
+++ b/compose.yaml
@@ -109,6 +109,8 @@ services:
       start_period: 20m  # give plenty of time for startup, since we may be downloading a model
     volumes:
       - hf-data:/data
+    profiles:
+      - hf-test
     networks:
       - cumulus-etl
     ports:


### PR DESCRIPTION
The llama2 docker compose stanza was missing a profile, which meant it was launching for all profiles.

Setting an "hf-test" profile fixes that.


### Checklist
- [x] Consider if documentation (like in `docs/`) needs to be updated
- [x] Consider if tests should be added
