### PR TITLE
feat(covid-symptom): add BCH/Cerner-specific ED codes

### DIFF
--- a/cumulus_etl/etl/studies/covid_symptom/covid_tasks.py
+++ b/cumulus_etl/etl/studies/covid_symptom/covid_tasks.py
@@ -14,18 +14,6 @@ from cumulus_etl.etl.studies.covid_symptom import covid_ctakes
 
 # List of recognized emergency department note types. We'll add more as we discover them in use.
 ED_CODES = {
-    "http://cumulus.smarthealthit.org/i2b2": {
-        "NOTE:3710480",
-        "NOTE:3807712",
-        "NOTE:149798455",
-        "NOTE:159552404",
-        "NOTE:189094576",
-        "NOTE:189094619",
-        "NOTE:189094644",
-        "NOTE:318198107",
-        "NOTE:318198110",
-        "NOTE:318198113",
-    },
     "http://loinc.org": {
         "18842-5",  # Discharge Summary
         "28568-4",  # Physician Emergency department Note
@@ -40,6 +28,33 @@ ED_CODES = {
         "68552-9",  # Emergency medicine Emergency department Admission evaluation note
         "74187-6",  # InterRAI Emergency Screener for Psychiatry (ESP) Document
         "74211-4",  # Summary of episode note Emergency department+Hospital
+    },
+    # The above _should_ be enough if everything is coded well.
+    # But sometimes not every document has a LOINC coding included.
+    # Below are some site-specific coding systems and their ED codes, to help fill in those gaps.
+    "http://cumulus.smarthealthit.org/i2b2": {  # BCH i2b2
+        "NOTE:3710480",  # ED Consultation
+        "NOTE:3807712",  # ED Note
+        "NOTE:149798455",  # Emergency MD
+        "NOTE:159552404",  # ED Note Scanned
+        "NOTE:189094576",  # ED Scanned
+        "NOTE:189094619",  # SANE Report
+        "NOTE:189094644",  # Emergency Dept Scanned Forms
+        "NOTE:318198107",  # ED Social Work Assessment
+        "NOTE:318198110",  # ED Social Work Brief Screening
+        "NOTE:318198113",  # ED Social Work
+    },
+    "https://fhir.cerner.com/96976f07-eccb-424c-9825-e0d0b887148b/codeSet/72": {  # BCH Cerner
+        "3710480",  # ED Consultation
+        "3807712",  # ED Note
+        "149798455",  # Emergency MD
+        "159552404",  # ED Note Scanned
+        "189094576",  # ED Scanned
+        "189094619",  # SANE Report
+        "189094644",  # Emergency Dept Scanned Forms
+        "318198107",  # ED Social Work Assessment
+        "318198110",  # ED Social Work Brief Screening
+        "318198113",  # ED Social Work
     },
 }
 

--- a/tests/covid_symptom/test_nlp_results.py
+++ b/tests/covid_symptom/test_nlp_results.py
@@ -44,10 +44,15 @@ class TestCovidSymptomNlpResultsTask(CtakesMixin, TaskTestCase):
         # Invalid codes
         ([], False),
         ([{"system": "http://cumulus.smarthealthit.org/i2b2", "code": "NOTE:0"}], False),
+        ([{"system": "https://fhir.cerner.com/96976f07-eccb-424c-9825-e0d0b887148b/codeSet/72", "code": "0"}], False),
         ([{"system": "http://loinc.org", "code": "00000-0"}], False),
         ([{"system": "http://example.org", "code": "nope"}], False),
         # Valid codes
         ([{"system": "http://cumulus.smarthealthit.org/i2b2", "code": "NOTE:3710480"}], True),
+        (
+            [{"system": "https://fhir.cerner.com/96976f07-eccb-424c-9825-e0d0b887148b/codeSet/72", "code": "3710480"}],
+            True,
+        ),
         ([{"system": "http://loinc.org", "code": "57053-1"}], True),
         ([{"system": "nope", "code": "nope"}, {"system": "http://loinc.org", "code": "57053-1"}], True),
     )


### PR DESCRIPTION
Previously, we had some BCH/i2b2-specific ED codes for BCH's i2b2 data. And the LOINC codes were supposed to be sufficient for the properly coded data coming from Cerner.

But it turns out that not all DocRefs in Cerner have proper LOINC codes, so this commit adds the same site-specific i2b2 codes but with a Cerner "system".

This should be harmless, study-wise since all these NLP symptoms are filtered down on the Library side - worst case is that we run NLP on docs we don't need to. But this now allows the Library side to expand what it looks for, if it wants.


### Checklist
- [x] Consider if documentation (like in `docs/`) needs to be updated
- [x] Consider if tests should be added
