### PR TITLE
feat(chart-review): push internal docref spans to Label Studio

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -69,8 +69,11 @@ jobs:
           pip install bandit[toml] pycodestyle pylint black==22.12.0
 
       - name: Run pycodestyle
+        # E203: pycodestyle is a little too rigid about slices & whitespace
+        #  See https://black.readthedocs.io/en/stable/the_black_code_style/current_style.html#slices
+        # W503: a default ignore that we are restoring
         run: |
-          pycodestyle --max-line-length=120 .
+          pycodestyle --max-line-length=120 --ignore=E203,W503 .
 
       - name: Run pylint
         if: success() || failure() # still run pylint if above checks fail

--- a/compose.yaml
+++ b/compose.yaml
@@ -51,12 +51,15 @@ services:
   ctakes-covid:
     extends: ctakes-covid-base
     profiles:
+      - chart-review
+      - chart-review-gpu
       - covid-symptom
       - covid-symptom-gpu
 
   cnlpt-negation:
     image: smartonfhir/cnlp-transformers:negation-0.6.1-cpu
     profiles:
+      - chart-review
       - covid-symptom
     networks:
       - cumulus-etl
@@ -64,6 +67,7 @@ services:
   cnlpt-negation-gpu:
     image: smartonfhir/cnlp-transformers:negation-0.6.1-gpu
     profiles:
+      - chart-review-gpu
       - covid-symptom-gpu
     networks:
       - cumulus-etl

--- a/cumulus_etl/chart_review/downloader.py
+++ b/cumulus_etl/chart_review/downloader.py
@@ -68,7 +68,7 @@ async def _download_docrefs_from_real_ids(
 
     # Grab identifiers for which specific docrefs we need
     with common.read_csv(docref_csv) as reader:
-        docref_ids = {row["docref_id"] for row in reader}
+        docref_ids = sorted({row["docref_id"] for row in reader})
 
     # Kick off a bunch of requests to the FHIR server for these documents
     coroutines = [_request_docref(client, docref_id) for docref_id in docref_ids]

--- a/cumulus_etl/nlp/__init__.py
+++ b/cumulus_etl/nlp/__init__.py
@@ -1,6 +1,6 @@
 """Support code for NLP servers"""
 
-from .extract import ctakes_extract, ctakes_httpx_client, list_polarity
+from .extract import TransformerModel, ctakes_extract, ctakes_httpx_client, list_polarity
 from .huggingface import hf_prompt, hf_info, llama2_prompt
 from .utils import cache_wrapper, is_docref_valid
 from .watcher import check_negation_cnlpt, check_term_exists_cnlpt, check_ctakes, restart_ctakes_with_bsv

--- a/docs/chart-review.md
+++ b/docs/chart-review.md
@@ -17,7 +17,9 @@ Along the way, it can mark the note with NLP results and/or anonymize the note w
 This is useful for not just actual chart reviews, but also for developing a custom NLP dictionary.
 You can feed Cumulus ETL a custom NLP dictionary, review how it performs, and iterate upon it.
 
-## Preliminary Label Studio Setup
+## Preliminaries
+
+### Label Studio Setup
 
 This guide assumes you already have a local instance of Label Studio running.
 They offer Docker images and reasonable
@@ -26,6 +28,19 @@ If you haven't set that up yet, go do that and come back.
 
 The Cumulus team can help you with setting it up if you come talk to us,
 but the rest of this guide will mostly deal with chart review mode itself.
+
+### Dependent Services
+
+Some features of chart review mode need external services (like cTAKES to run NLP).
+Launch those before you begin using chart review:
+
+```shell
+export UMLS_API_KEY=your-umls-api-key
+docker compose --profile chart-review up -d
+```
+
+Or if you have access to a GPU,
+you can speed up the NLP by launching the GPU profile instead with `--profile chart-review-gpu`.
 
 ## Basic Operation
 

--- a/tests/chart_review/test_chart_labelstudio.py
+++ b/tests/chart_review/test_chart_labelstudio.py
@@ -26,7 +26,14 @@ class TestChartLabelStudio(AsyncTestCase):
 
     @staticmethod
     def make_note(*, enc_id: str = "enc", matches: bool = True) -> LabelStudioNote:
-        note = LabelStudioNote(enc_id, "enc-anon", {"doc": "doc-anon"}, "Ignored Title", "Normal note text")
+        text = "Normal note text"
+        note = LabelStudioNote(
+            enc_id,
+            "enc-anon",
+            doc_mappings={"doc": "doc-anon"},
+            doc_spans={"doc": (0, len(text))},
+            text=text,
+        )
         if matches:
             note.matches = ctakesmock.fake_ctakes_extract(note.text).list_match(polarity=Polarity.pos)
         return note
@@ -61,6 +68,7 @@ class TestChartLabelStudio(AsyncTestCase):
                     "enc_id": "enc",
                     "anon_id": "enc-anon",
                     "docref_mappings": {"doc": "doc-anon"},
+                    "docref_spans": {"doc": [0, 16]},
                 },
                 "predictions": [
                     {
@@ -109,6 +117,7 @@ class TestChartLabelStudio(AsyncTestCase):
                     "enc_id": "enc",
                     "anon_id": "enc-anon",
                     "docref_mappings": {"doc": "doc-anon"},
+                    "docref_spans": {"doc": [0, 16]},
                 },
                 "predictions": [
                     {
@@ -132,6 +141,7 @@ class TestChartLabelStudio(AsyncTestCase):
                 "enc_id": "enc",
                 "anon_id": "enc-anon",
                 "docref_mappings": {"doc": "doc-anon"},
+                "docref_spans": {"doc": [0, 16]},
                 "mylabel": [
                     {"value": "Itch"},
                     {"value": "Nausea"},
@@ -151,6 +161,7 @@ class TestChartLabelStudio(AsyncTestCase):
                 "enc_id": "enc",
                 "anon_id": "enc-anon",
                 "docref_mappings": {"doc": "doc-anon"},
+                "docref_spans": {"doc": [0, 16]},
                 "mylabel": [],  # this needs to be sent, or the server will complain
             },
             self.get_pushed_task()["data"],


### PR DESCRIPTION
In case we need to know the internal placing of doc notes, when we gather multiple notes into one note, push up the start & end of those texts.

No planned use for this right now, but I want to get this in so when we do want it, the metadata already exists.


### Checklist
- [x] Consider if documentation (like in `docs/`) needs to be updated
- [x] Consider if tests should be added
