### PR TITLE
A couple small fixes

### DIFF
--- a/cumulus_etl/formats/batched_files.py
+++ b/cumulus_etl/formats/batched_files.py
@@ -61,7 +61,7 @@ class BatchedFileFormat(Format):
         except FileNotFoundError:
             return  # folder doesn't exist, we're good!
 
-        allowed_pattern = re.compile(rf"{self.dbname}\.[0-9]+\.{self.suffix}")
+        allowed_pattern = re.compile(rf"{self.dbname}\.[0-9]+\.({self.suffix}|meta)")
         if not all(map(allowed_pattern.fullmatch, filenames)):
             errors.fatal(
                 f"There are unexpected files in the output folder '{folder}'.\n"

--- a/docs/deid.md
+++ b/docs/deid.md
@@ -74,7 +74,7 @@ But the devil is in the details, because it can be configured to do nothing at a
 or redact everything.
 
 Cumulus ETL uses a
-[custom configuration](https://github.com/smart-on-fhir/cumulus-etl/blob/main/cumulus/deid/ms-config.json),
+[custom configuration](https://github.com/smart-on-fhir/cumulus-etl/blob/main/cumulus_etl/deid/ms-config.json),
 designed to remove everything by default, and only allow specifically mentioned fields
 (i.e. an allow-list or whitelist).
 

--- a/tests/formats/test_ndjson.py
+++ b/tests/formats/test_ndjson.py
@@ -49,6 +49,7 @@ class TestNdjsonFormat(utils.AsyncTestCase):
         (None, True),
         ([], True),
         (["condition.1234.ndjson", "condition.22.ndjson"], True),
+        (["condition.000.meta"], True),
         (["condition.ndjson"], False),
         (["condition.000.parquet"], False),
         (["patient.000.ndjson"], False),


### PR DESCRIPTION
Two commits:
- One is a doc broken link fix
- The other adjusts the "ndjson format overwrite detection" code to allow for `.meta` files which NLP jobs also write out in addition to .ndjson

### Checklist
- [x] Consider if documentation (like in `docs/`) needs to be updated
- [x] Consider if tests should be added
