### PR TITLE
chore(ms-config): replace fake json comments with C-style comments

### DIFF
--- a/cumulus_etl/deid/ms-config.json
+++ b/cumulus_etl/deid/ms-config.json
@@ -1,47 +1,47 @@
 {
-  "comment": [
-    "This config takes an allow-list approach (vs a deny-list).",
-    "The last rule denies everything not previously allowed.",
+  /*
+    This config takes an allow-list approach (vs a deny-list).
+    The last rule denies everything not previously allowed.
 
-    "== Style advice ==",
-    "In general, please do not blanket-include a BackboneElement, but reference each sub-element directly.",
-    "This helps avoid allow-listing too much at once and the awkwardness of redacting one element then keeping the parent node.",
-    "When you encounter a polymorphic element (like Condition.onset), beware of freeform string variants.",
-    "Please mark such text fields with a comment if kept, to flag that they will need a philter pass.",
-    "Each resource's fields are ordered as they appear in the FHIR spec for easier cross-referencing, rather than alphabetical.",
+    ** Style advice **
+    In general, please do not blanket-include a BackboneElement, but reference each sub-element directly.
+    This helps avoid allow-listing too much at once and the awkwardness of redacting one element then keeping the parent node.
+    When you encounter a polymorphic element (like Condition.onset), beware of freeform string variants.
+    Please mark such text fields with a comment if kept, to flag that they will need a philter pass.
+    Each resource's fields are ordered as they appear in the FHIR spec for easier cross-referencing, rather than alphabetical.
 
-    "== Why we choose to keep as much as we do ==",
-    "This config is very greedy as long as it is not grabbing PHI.",
-    "For example, we grab Encounter.classHistory and Observation.performer.",
-    "It's not clear how or if they will be used, but it's better to have them than not.",
-    "It's unrealistic to go back and get the data from the EHR if we decide we do actually want to use the data.",
-    "And some of this data may be interesting internally to a hospital for quality checks, aside from study potential."
-  ],
+    ** Why we choose to keep as much as we do **
+    This config is very greedy as long as it is not grabbing PHI.
+    For example, we grab Encounter.classHistory and Observation.performer.
+    It's not clear how or if they will be used, but it's better to have them than not.
+    It's unrealistic to go back and get the data from the EHR if we decide we do actually want to use the data.
+    And some of this data may be interesting internally to a hospital for quality checks, aside from study potential.
+  */
   "fhirVersion": "R4",
   "processingErrors": "raise",
   "fhirPathRules": [
-    {"comment": "** Only allow a few known extensions **", "path": "xxx", "method": "redact"},
-    {"path": "Patient.extension('http://hl7.org/fhir/Profile/us-core#ethnicity')", "method": "keep", "comment": "Old DSTU1 URL, still out there in the wild: https://www.hl7.org/fhir/DSTU1/us-core.html"},
-    {"path": "Patient.extension('http://hl7.org/fhir/Profile/us-core#race')", "method": "keep", "comment": "Old DSTU1 URL, still out there in the wild: https://www.hl7.org/fhir/DSTU1/us-core.html"},
+    // Only allow a few known extensions
+    {"path": "Patient.extension('http://hl7.org/fhir/Profile/us-core#ethnicity')", "method": "keep"}, // Old DSTU1 URL, still out there in the wild: https://www.hl7.org/fhir/DSTU1/us-core.html
+    {"path": "Patient.extension('http://hl7.org/fhir/Profile/us-core#race')", "method": "keep"}, // Old DSTU1 URL, still out there in the wild: https://www.hl7.org/fhir/DSTU1/us-core.html
     {"path": "Patient.extension('http://hl7.org/fhir/us/core/StructureDefinition/us-core-birthsex')", "method": "keep"},
     {"path": "Patient.extension('http://hl7.org/fhir/us/core/StructureDefinition/us-core-ethnicity')", "method": "keep"},
     {"path": "Patient.extension('http://hl7.org/fhir/us/core/StructureDefinition/us-core-genderIdentity')", "method": "keep"},
     {"path": "Patient.extension('http://hl7.org/fhir/us/core/StructureDefinition/us-core-race')", "method": "keep"},
     {"path": "Patient.extension('http://hl7.org/fhir/us/core/StructureDefinition/us-core-sex-for-clinical-use')", "method": "keep"},
-    {"path": "Patient.extension('http://open.epic.com/FHIR/StructureDefinition/extension/sex-for-clinical-use')", "method": "keep", "comment": "Epic has used this pre-final-spec URL"},
-    {"path": "nodesByName('modifierExtension')", "method": "keep", "comment": "keep these so we can ignore resources with modifiers we don't understand"},
-    {"path": "nodesByType('Extension')", "method": "redact", "comment": "drop all unknown extensions"},
+    {"path": "Patient.extension('http://open.epic.com/FHIR/StructureDefinition/extension/sex-for-clinical-use')", "method": "keep"}, // Epic has used this pre-final-spec URL
+    {"path": "nodesByName('modifierExtension')", "method": "keep"}, // keep these so we can ignore resources with modifiers we don't understand
+    {"path": "nodesByType('Extension')", "method": "redact"}, // drop all unknown extensions
 
-    {"comment": "** Elements that might be embedded and kept elsewhere -- redact pieces of the whole **", "path": "xxx", "method": "redact"},
+    // Elements that might be embedded and kept elsewhere -- redact pieces of the whole
     {"path": "nodesByType('Attachment').title", "method": "redact"},
     {"path": "nodesByType('Reference').display", "method": "redact"},
     {"path": "nodesByType('Reference').identifier", "method": "redact"},
 
-    {"comment": "** Elements that will be redacted, but we want to keep a small piece of **", "path": "xxx", "method": "redact"},
+    // Elements that will be redacted, but we want to keep a small piece of
     {"path": "nodesByType('Address').country", "method": "keep"},
     {"path": "nodesByType('Address').state", "method": "keep"},
 
-    {"comment": "** These PHI-risky elements shouldn't be allow-listed anyway -- but just as a safety measure, explicitly exclude them **", "path": "xxx", "method": "redact"},
+    // These PHI-risky elements shouldn't be allow-listed anyway -- but just as a safety measure, explicitly exclude them
     {"path": "nodesByType('Address')", "method": "redact"},
     {"path": "nodesByType('Annotation')", "method": "redact"},
     {"path": "nodesByType('ContactDetail')", "method": "redact"},
@@ -50,10 +50,11 @@
     {"path": "nodesByType('Narrative')", "method": "redact"},
 
 
-    {"comment": "** Shared backbone elements **", "path": "xxx", "method": "redact"},
+    // ** Shared backbone elements **
 
-    {"comment": "** https://www.hl7.org/fhir/R4/dosage.html **", "path": "xxx", "method": "redact"},
+    // ** Dosage: https://www.hl7.org/fhir/R4/dosage.html **
     {"path": "nodesByType('Dosage').sequence", "method": "keep"},
+    // Skip Dosage.text
     {"path": "nodesByType('Dosage').additionalInstruction", "method": "keep"},
     {"path": "nodesByType('Dosage').timing", "method": "keep"},
     {"path": "nodesByType('Dosage').asNeeded", "method": "keep"},
@@ -68,9 +69,10 @@
     {"path": "nodesByType('Dosage').maxDosePerLifetime", "method": "keep"},
 
 
-    {"comment": "** Top-level resources **", "path": "xxx", "method": "redact"},
+    // ** Top-level resources **
 
-    {"comment": "** https://www.hl7.org/fhir/R4/allergyintolerance.html **", "path": "xxx", "method": "redact"},
+    // ** AllergyIntolerance: https://www.hl7.org/fhir/R4/allergyintolerance.html **
+    // Skip AllergyIntolerance.identifier
     {"path": "AllergyIntolerance.clinicalStatus", "method": "keep"},
     {"path": "AllergyIntolerance.verificationStatus", "method": "keep"},
     {"path": "AllergyIntolerance.type", "method": "keep"},
@@ -79,19 +81,23 @@
     {"path": "AllergyIntolerance.code", "method": "keep"},
     {"path": "AllergyIntolerance.patient", "method": "keep"},
     {"path": "AllergyIntolerance.encounter", "method": "keep"},
-    {"path": "AllergyIntolerance.onset.ofType(string)", "method": "redact", "comment": "would run philter on it, but it would just remove anything useful we could parse"},
+    {"path": "AllergyIntolerance.onset.ofType(string)", "method": "redact"}, // would run philter on it, but it would just remove anything useful we could parse
     {"path": "AllergyIntolerance.onset", "method": "keep"},
     {"path": "AllergyIntolerance.recordedDate", "method": "keep"},
     {"path": "AllergyIntolerance.recorder", "method": "keep"},
     {"path": "AllergyIntolerance.asserter", "method": "keep"},
     {"path": "AllergyIntolerance.lastOccurrence", "method": "keep"},
+    // Skip AllergyIntolerance.note
     {"path": "AllergyIntolerance.reaction.substance", "method": "keep"},
     {"path": "AllergyIntolerance.reaction.manifestation", "method": "keep"},
+    // Skip AllergyIntolerance.reaction.description
     {"path": "AllergyIntolerance.reaction.onset", "method": "keep"},
     {"path": "AllergyIntolerance.reaction.severity", "method": "keep"},
     {"path": "AllergyIntolerance.reaction.exposureRoute", "method": "keep"},
+    // Skip AllergyIntolerance.reaction.note
 
-    {"comment": "** https://www.hl7.org/fhir/R4/condition.html **", "path": "xxx", "method": "redact"},
+    // ** Condition: https://www.hl7.org/fhir/R4/condition.html **
+    // Skip Condition.identifier
     {"path": "Condition.clinicalStatus", "method": "keep"},
     {"path": "Condition.verificationStatus", "method": "keep"},
     {"path": "Condition.category", "method": "keep"},
@@ -100,55 +106,61 @@
     {"path": "Condition.bodySite", "method": "keep"},
     {"path": "Condition.subject", "method": "keep"},
     {"path": "Condition.encounter", "method": "keep"},
-    {"path": "Condition.onset.ofType(string)", "method": "redact", "comment": "would run philter on it, but it would just remove anything useful we could parse"},
+    {"path": "Condition.onset.ofType(string)", "method": "redact"}, // would run philter on it, but it would just remove anything useful we could parse
     {"path": "Condition.onset", "method": "keep"},
-    {"path": "Condition.abatement.ofType(string)", "method": "redact", "comment": "would run philter on it, but it would just remove anything useful we could parse"},
+    {"path": "Condition.abatement.ofType(string)", "method": "redact"}, // would run philter on it, but it would just remove anything useful we could parse
     {"path": "Condition.abatement", "method": "keep"},
+    {"path": "Condition.recordedDate", "method": "keep"},
     {"path": "Condition.recorder", "method": "keep"},
     {"path": "Condition.asserter", "method": "keep"},
-    {"path": "Condition.recordedDate", "method": "keep"},
     {"path": "Condition.stage.summary", "method": "keep"},
     {"path": "Condition.stage.assessment", "method": "keep"},
     {"path": "Condition.stage.type", "method": "keep"},
     {"path": "Condition.evidence.code", "method": "keep"},
     {"path": "Condition.evidence.detail", "method": "keep"},
+    // Skip Condition.note
 
-    {"comment": "** https://www.hl7.org/fhir/R4/device.html **", "path": "xxx", "method": "redact"},
+    // ** Device: https://www.hl7.org/fhir/R4/device.html **
+    // Skip Device.identifier
     {"path": "Device.definition", "method": "keep"},
-    {"path": "Device.udiCarrier.deviceIdentifier", "method": "keep", "comment": "caution: non-PHI freeform string"},
+    {"path": "Device.udiCarrier.deviceIdentifier", "method": "keep"}, // caution: non-PHI freeform string
     {"path": "Device.udiCarrier.issuer", "method": "keep"},
     {"path": "Device.udiCarrier.jurisdiction", "method": "keep"},
-    {"path": "Device.udiCarrier.carrierAIDC", "method": "keep", "comment": "caution: non-PHI freeform string"},
-    {"path": "Device.udiCarrier.carrierHRF", "method": "keep", "comment": "caution: non-PHI freeform string"},
+    {"path": "Device.udiCarrier.carrierAIDC", "method": "keep"}, // caution: non-PHI freeform string
+    {"path": "Device.udiCarrier.carrierHRF", "method": "keep"}, // caution: non-PHI freeform string
     {"path": "Device.udiCarrier.entryType", "method": "keep"},
     {"path": "Device.status", "method": "keep"},
     {"path": "Device.statusReason", "method": "keep"},
-    {"path": "Device.distinctIdentifier", "method": "keep", "comment": "caution: non-PHI freeform string"},
-    {"path": "Device.manufacturer", "method": "keep", "comment": "caution: non-PHI freeform string"},
+    {"path": "Device.distinctIdentifier", "method": "keep"}, // caution: non-PHI freeform string
+    {"path": "Device.manufacturer", "method": "keep"}, // caution: non-PHI freeform string
     {"path": "Device.manufactureDate", "method": "keep"},
     {"path": "Device.expirationDate", "method": "keep"},
-    {"path": "Device.lotNumber", "method": "keep", "comment": "caution: non-PHI freeform string"},
-    {"path": "Device.serialNumber", "method": "keep", "comment": "caution: non-PHI freeform string"},
-    {"path": "Device.deviceName.name", "method": "keep", "comment": "caution: non-PHI freeform string"},
+    {"path": "Device.lotNumber", "method": "keep"}, // caution: non-PHI freeform string
+    {"path": "Device.serialNumber", "method": "keep"}, // caution: non-PHI freeform string
+    {"path": "Device.deviceName.name", "method": "keep"}, // caution: non-PHI freeform string
     {"path": "Device.deviceName.type", "method": "keep"},
-    {"path": "Device.modelNumber", "method": "keep", "comment": "caution: non-PHI freeform string"},
-    {"path": "Device.partNumber", "method": "keep", "comment": "caution: non-PHI freeform string"},
+    {"path": "Device.modelNumber", "method": "keep"}, // caution: non-PHI freeform string
+    {"path": "Device.partNumber", "method": "keep"}, // caution: non-PHI freeform string
     {"path": "Device.type", "method": "keep"},
     {"path": "Device.specialization.systemType", "method": "keep"},
-    {"path": "Device.specialization.version", "method": "keep", "comment": "caution: non-PHI freeform string"},
+    {"path": "Device.specialization.version", "method": "keep"}, // caution: non-PHI freeform string
     {"path": "Device.version.type", "method": "keep"},
-    {"path": "Device.version.component", "method": "keep", "comment": "caution: non-PHI identifier"},
-    {"path": "Device.version.value", "method": "keep", "comment": "caution: non-PHI freeform string"},
+    {"path": "Device.version.component", "method": "keep"}, // caution: non-PHI identifier
+    {"path": "Device.version.value", "method": "keep"}, // caution: non-PHI freeform string
     {"path": "Device.property.type", "method": "keep"},
     {"path": "Device.property.valueQuantity", "method": "keep"},
     {"path": "Device.property.valueCode", "method": "keep"},
     {"path": "Device.patient", "method": "keep"},
     {"path": "Device.owner", "method": "keep"},
+    // Skip Device.contact
     {"path": "Device.location", "method": "keep"},
+    // Skip Device.url
+    // Skip Device.note
     {"path": "Device.safety", "method": "keep"},
     {"path": "Device.parent", "method": "keep"},
 
-    {"comment": "** https://www.hl7.org/fhir/R4/diagnosticreport.html **", "path": "xxx", "method": "redact"},
+    // ** DiagnosticReport: https://www.hl7.org/fhir/R4/diagnosticreport.html **
+    // Skip DiagnosticReport.identifier
     {"path": "DiagnosticReport.basedOn", "method": "keep"},
     {"path": "DiagnosticReport.status", "method": "keep"},
     {"path": "DiagnosticReport.category", "method": "keep"},
@@ -162,10 +174,15 @@
     {"path": "DiagnosticReport.specimen", "method": "keep"},
     {"path": "DiagnosticReport.result", "method": "keep"},
     {"path": "DiagnosticReport.imagingStudy", "method": "keep"},
+    // Skip DiagnosticReport.media.comment
     {"path": "DiagnosticReport.media.link", "method": "keep"},
+    // Skip DiagnosticReport.conclusion
     {"path": "DiagnosticReport.conclusionCode", "method": "keep"},
+    // Skip DiagnosticReport.presentedForm (can add back later when/if we want to run NLP on it)
 
-    {"comment": "** https://www.hl7.org/fhir/R4/documentreference.html **", "path": "xxx", "method": "redact"},
+    // ** DocumentReference: https://www.hl7.org/fhir/R4/documentreference.html **
+    // Skip DocumentReference.masterIdentifier
+    // Skip DocumentReference.identifier
     {"path": "DocumentReference.status", "method": "keep"},
     {"path": "DocumentReference.docStatus", "method": "keep"},
     {"path": "DocumentReference.type", "method": "keep"},
@@ -177,8 +194,9 @@
     {"path": "DocumentReference.custodian", "method": "keep"},
     {"path": "DocumentReference.relatesTo.code", "method": "keep"},
     {"path": "DocumentReference.relatesTo.target", "method": "keep"},
+    // Skip DocumentReference.description
     {"path": "DocumentReference.securityLabel", "method": "keep"},
-    {"path": "DocumentReference.content.attachment", "method": "keep", "comment": "attachments will be dropped later after running NLP on them"},
+    {"path": "DocumentReference.content.attachment", "method": "keep"}, // attachments will be dropped later after running NLP on them
     {"path": "DocumentReference.content.format", "method": "keep"},
     {"path": "DocumentReference.context.encounter", "method": "keep"},
     {"path": "DocumentReference.context.event", "method": "keep"},
@@ -188,7 +206,8 @@
     {"path": "DocumentReference.context.sourcePatientInfo", "method": "keep"},
     {"path": "DocumentReference.context.related", "method": "keep"},
 
-    {"comment": "** https://www.hl7.org/fhir/R4/encounter.html **", "path": "xxx", "method": "redact"},
+    // ** Encounter: https://www.hl7.org/fhir/R4/encounter.html **
+    // Skip Encounter.identifier
     {"path": "Encounter.status", "method": "keep"},
     {"path": "Encounter.statusHistory.status", "method": "keep"},
     {"path": "Encounter.statusHistory.period", "method": "keep"},
@@ -213,6 +232,7 @@
     {"path": "Encounter.diagnosis.use", "method": "keep"},
     {"path": "Encounter.diagnosis.rank", "method": "keep"},
     {"path": "Encounter.account", "method": "keep"},
+    // Skip Encounter.hospitalization.preAdmissionIdentifier
     {"path": "Encounter.hospitalization.origin", "method": "keep"},
     {"path": "Encounter.hospitalization.admitSource", "method": "keep"},
     {"path": "Encounter.hospitalization.reAdmission", "method": "keep"},
@@ -228,45 +248,49 @@
     {"path": "Encounter.serviceProvider", "method": "keep"},
     {"path": "Encounter.partOf", "method": "keep"},
 
-    {"comment": "** https://www.hl7.org/fhir/R4/immunization.html **", "path": "xxx", "method": "redact"},
+    // ** Immunization: https://www.hl7.org/fhir/R4/immunization.html **
+    // Skip Immunization.identifier
     {"path": "Immunization.status", "method": "keep"},
     {"path": "Immunization.statusReason", "method": "keep"},
     {"path": "Immunization.vaccineCode", "method": "keep"},
     {"path": "Immunization.patient", "method": "keep"},
     {"path": "Immunization.encounter", "method": "keep"},
-    {"path": "Immunization.occurrence.ofType(string)", "method": "redact", "comment": "would run philter on it, but it would just remove anything useful we could parse"},
+    {"path": "Immunization.occurrence.ofType(string)", "method": "redact"}, // would run philter on it, but it would just remove anything useful we could parse
     {"path": "Immunization.occurrence", "method": "keep"},
     {"path": "Immunization.recorded", "method": "keep"},
     {"path": "Immunization.primarySource", "method": "keep"},
     {"path": "Immunization.reportOrigin", "method": "keep"},
     {"path": "Immunization.location", "method": "keep"},
     {"path": "Immunization.manufacturer", "method": "keep"},
-    {"path": "Immunization.lotNumber", "method": "keep", "comment": "caution: non-PHI freeform string"},
+    {"path": "Immunization.lotNumber", "method": "keep"}, // caution: non-PHI freeform string
     {"path": "Immunization.expirationDate", "method": "keep"},
     {"path": "Immunization.site", "method": "keep"},
     {"path": "Immunization.route", "method": "keep"},
     {"path": "Immunization.doseQuantity", "method": "keep"},
     {"path": "Immunization.performer.function", "method": "keep"},
     {"path": "Immunization.performer.actor", "method": "keep"},
+    // Skip Immunization.note
     {"path": "Immunization.reasonCode", "method": "keep"},
     {"path": "Immunization.reasonReference", "method": "keep"},
     {"path": "Immunization.isSubpotent", "method": "keep"},
     {"path": "Immunization.subpotentReason", "method": "keep"},
     {"path": "Immunization.education.documentType", "method": "keep"},
-    {"path": "Immunization.education.publicationDate", "method": "keep", "comment": "we aren't keeping uri for fear of any (institutional) PHI slipping in, so maybe these two dates aren't very useful, but better more data than less"},
+    // Skip Immunization.education.reference (institutional info might slip in, and it's not likely to be useful)
+    {"path": "Immunization.education.publicationDate", "method": "keep"},
     {"path": "Immunization.education.presentationDate", "method": "keep"},
     {"path": "Immunization.programEligibility", "method": "keep"},
     {"path": "Immunization.fundingSource", "method": "keep"},
     {"path": "Immunization.reaction.date", "method": "keep"},
     {"path": "Immunization.reaction.detail", "method": "keep"},
     {"path": "Immunization.reaction.reported", "method": "keep"},
-    {"path": "Immunization.protocolApplied.series", "method": "keep", "comment": "caution: non-PHI freeform string"},
+    {"path": "Immunization.protocolApplied.series", "method": "keep"}, // caution: non-PHI freeform string
     {"path": "Immunization.protocolApplied.authority", "method": "keep"},
     {"path": "Immunization.protocolApplied.targetDisease", "method": "keep"},
-    {"path": "Immunization.protocolApplied.doseNumber", "method": "keep", "comment": "caution: non-PHI freeform string"},
-    {"path": "Immunization.protocolApplied.seriesDoses", "method": "keep", "comment": "caution: non-PHI freeform string"},
+    {"path": "Immunization.protocolApplied.doseNumber", "method": "keep"}, // caution: non-PHI freeform string
+    {"path": "Immunization.protocolApplied.seriesDoses", "method": "keep"}, // caution: non-PHI freeform string
 
-    {"comment": "** https://www.hl7.org/fhir/R4/medication.html **", "path": "xxx", "method": "redact"},
+    // ** Medication: https://www.hl7.org/fhir/R4/medication.html **
+    // Skip Medication.identifier
     {"path": "Medication.code", "method": "keep"},
     {"path": "Medication.status", "method": "keep"},
     {"path": "Medication.manufacturer", "method": "keep"},
@@ -278,7 +302,8 @@
     {"path": "Medication.batch.lotNumber", "method": "keep"},
     {"path": "Medication.batch.expirationDate", "method": "keep"},
 
-    {"comment": "** https://www.hl7.org/fhir/R4/medicationrequest.html **", "path": "xxx", "method": "redact"},
+    // ** MedicationRequest: https://www.hl7.org/fhir/R4/medicationrequest.html **
+    // Skip MedicationRequest.identifier
     {"path": "MedicationRequest.status", "method": "keep"},
     {"path": "MedicationRequest.statusReason", "method": "keep"},
     {"path": "MedicationRequest.intent", "method": "keep"},
@@ -300,9 +325,11 @@
     {"path": "MedicationRequest.instantiatesCanonical", "method": "keep"},
     {"path": "MedicationRequest.instantiatesUri", "method": "keep"},
     {"path": "MedicationRequest.basedOn", "method": "keep"},
+    // Skip MedicationRequest.groupIdentifier
     {"path": "MedicationRequest.courseOfTherapyType", "method": "keep"},
     {"path": "MedicationRequest.insurance", "method": "keep"},
-    {"comment": "MedicationRequest.dosageInstruction is automatically kept/handled by Dosage block above", "path": "xxx", "method": "redact"},
+    // Skip MedicationRequest.note
+    // MedicationRequest.dosageInstruction is automatically kept/handled by Dosage block above
     {"path": "MedicationRequest.dispenseRequest.initialFill.quantity", "method": "keep"},
     {"path": "MedicationRequest.dispenseRequest.initialFill.duration", "method": "keep"},
     {"path": "MedicationRequest.dispenseRequest.dispenseInterval", "method": "keep"},
@@ -317,42 +344,54 @@
     {"path": "MedicationRequest.detectedIssue", "method": "keep"},
     {"path": "MedicationRequest.eventHistory", "method": "keep"},
 
-    {"comment": "** https://www.hl7.org/fhir/R4/observation.html **", "path": "xxx", "method": "redact"},
+    // ** Observation: https://www.hl7.org/fhir/R4/observation.html **
+    // Skip Observation.identifier
     {"path": "Observation.basedOn", "method": "keep"},
     {"path": "Observation.partOf", "method": "keep"},
     {"path": "Observation.status", "method": "keep"},
-    {"path": "Observation.code", "method": "keep"},
     {"path": "Observation.category", "method": "keep"},
+    {"path": "Observation.code", "method": "keep"},
     {"path": "Observation.subject", "method": "keep"},
     {"path": "Observation.focus", "method": "keep"},
     {"path": "Observation.encounter", "method": "keep"},
     {"path": "Observation.effective", "method": "keep"},
     {"path": "Observation.issued", "method": "keep"},
     {"path": "Observation.performer", "method": "keep"},
-    {"path": "Observation.value", "method": "keep", "comment": "should run philter on valueString"},
+    {"path": "Observation.value", "method": "keep"}, // should run philter on valueString
     {"path": "Observation.dataAbsentReason", "method": "keep"},
     {"path": "Observation.interpretation", "method": "keep"},
+    // Skip Observation.note
     {"path": "Observation.bodySite", "method": "keep"},
     {"path": "Observation.method", "method": "keep"},
     {"path": "Observation.specimen", "method": "keep"},
     {"path": "Observation.device", "method": "keep"},
+    // Skip Observation.referenceRange
     {"path": "Observation.hasMember", "method": "keep"},
     {"path": "Observation.derivedFrom", "method": "keep"},
     {"path": "Observation.component.code", "method": "keep"},
-    {"path": "Observation.component.value", "method": "keep", "comment": "should run philter on valueString"},
+    {"path": "Observation.component.value", "method": "keep"}, // should run philter on valueString
     {"path": "Observation.component.dataAbsentReason", "method": "keep"},
     {"path": "Observation.component.interpretation", "method": "keep"},
+    // Skip Observation.component.referenceRange
 
-    {"comment": "** https://www.hl7.org/fhir/R4/patient.html **", "path": "xxx", "method": "redact"},
+    // ** Patient: https://www.hl7.org/fhir/R4/patient.html **
+    // Skip Patient.identifier
     {"path": "Patient.active", "method": "keep"},
+    // Skip Patient.name
+    // Skip Patient.telecom
     {"path": "Patient.gender", "method": "keep"},
     {"path": "Patient.birthDate", "method": "generalize",
-     "comment": "keep just the year for privacy (note: 90+ HIPAA grouping is done downstream in SQL)",
+     // keep just the year for privacy (note: 90+ HIPAA grouping is done downstream in SQL
      "cases": {"true": "$this.toString().replaceMatches('^(?<year>\\\\d+).*', '${year}')"}},
     {"path": "Patient.deceased", "method": "keep"},
+    // Skip Patient.address
     {"path": "Patient.maritalStatus", "method": "keep"},
     {"path": "Patient.multipleBirth", "method": "keep"},
+    // Skip Patient.photo
     {"path": "Patient.contact.relationship", "method": "keep"},
+    // Skip Patient.contact.name
+    // Skip Patient.contact.telecom
+    // Skip Patient.contact.address
     {"path": "Patient.contact.gender", "method": "keep"},
     {"path": "Patient.contact.organization", "method": "keep"},
     {"path": "Patient.contact.period", "method": "keep"},
@@ -363,7 +402,8 @@
     {"path": "Patient.link.other", "method": "keep"},
     {"path": "Patient.link.type", "method": "keep"},
 
-    {"comment": "** https://www.hl7.org/fhir/R4/procedure.html **", "path": "xxx", "method": "redact"},
+    // ** Procedure: https://www.hl7.org/fhir/R4/procedure.html **
+    // Skip Procedure.identifier
     {"path": "Procedure.instantiatesCanonical", "method": "keep"},
     {"path": "Procedure.instantiatesUri", "method": "keep"},
     {"path": "Procedure.basedOn", "method": "keep"},
@@ -374,7 +414,7 @@
     {"path": "Procedure.code", "method": "keep"},
     {"path": "Procedure.subject", "method": "keep"},
     {"path": "Procedure.encounter", "method": "keep"},
-    {"path": "Procedure.performed.ofType(string)", "method": "redact", "comment": "not usefully machine readable"},
+    {"path": "Procedure.performed.ofType(string)", "method": "redact"}, // not usefully machine readable
     {"path": "Procedure.performed", "method": "keep"},
     {"path": "Procedure.recorder", "method": "keep"},
     {"path": "Procedure.asserter", "method": "keep"},
@@ -390,16 +430,19 @@
     {"path": "Procedure.complication", "method": "keep"},
     {"path": "Procedure.complicationDetail", "method": "keep"},
     {"path": "Procedure.followUp", "method": "keep"},
+    // Skip Procedure.note
     {"path": "Procedure.focalDevice.action", "method": "keep"},
     {"path": "Procedure.focalDevice.manipulated", "method": "keep"},
     {"path": "Procedure.usedReference", "method": "keep"},
     {"path": "Procedure.usedCode", "method": "keep"},
 
-    {"comment": "** https://www.hl7.org/fhir/R4/servicerequest.html **", "path": "xxx", "method": "redact"},
+    // ** ServiceRequest: https://www.hl7.org/fhir/R4/servicerequest.html **
+    // Skip ServiceRequest.identifier
     {"path": "ServiceRequest.instantiatesCanonical", "method": "keep"},
     {"path": "ServiceRequest.instantiatesUri", "method": "keep"},
     {"path": "ServiceRequest.basedOn", "method": "keep"},
     {"path": "ServiceRequest.replaces", "method": "keep"},
+    // Skip ServiceRequest.requisition
     {"path": "ServiceRequest.status", "method": "keep"},
     {"path": "ServiceRequest.intent", "method": "keep"},
     {"path": "ServiceRequest.category", "method": "keep"},
@@ -424,15 +467,17 @@
     {"path": "ServiceRequest.supportingInfo", "method": "keep"},
     {"path": "ServiceRequest.specimen", "method": "keep"},
     {"path": "ServiceRequest.bodySite", "method": "keep"},
+    // Skip ServiceRequest.note
+    // Skip ServiceRequest.patientInstruction
     {"path": "ServiceRequest.relevantHistory", "method": "keep"},
 
-    {"comment": "** https://www.hl7.org/fhir/R4/resource.html **", "path": "xxx", "method": "redact"},
+    // ** Resource: https://www.hl7.org/fhir/R4/resource.html **
     {"path": "Resource.id", "method": "keep"},
+    {"path": "Resource.meta", "method": "keep"},
     {"path": "Resource.implicitRules", "method": "keep"},
     {"path": "Resource.language", "method": "keep"},
-    {"path": "Resource.meta", "method": "keep"},
 
-    {"path": "Resource", "method": "redact", "comment": "Catch-all removal of anything not specifically allowed above"}
+    {"path": "Resource", "method": "redact"} // Catch-all removal of anything not specifically allowed above
   ],
   "parameters": {
     "enablePartialZipCodesForRedact": true,


### PR DESCRIPTION
Turns out that the MS Anonymizer tool actually does support json comments, using C-style /* */ and // syntax.

I really thought I had tested that at some point.

So this commit just converts all the fake {"comment": "my text"} lines into real comments. And adds a comment for every field skipped (i.e. adds a comment for every field you wouldn't otherwise see because we use an allow-list)

No functionality changes. (Except de-id might be faster now that it has less fake rules to attempt to apply.)


### Checklist
- [x] Consider if documentation (like in `docs/`) needs to be updated
- [x] Consider if tests should be added
