### PR TITLE
fix: write "null match" NLP rows for DocRefs with no symptoms

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -22,3 +22,8 @@ ETL stands for "extract, transform, load."
 
 Read the [First Time Setup](setup) documentation to learn how to install & prepare Cumulus ETL
 at your institution.
+
+## Source Code
+Cumulus ETL is open source.
+If you'd like to browse its code or contribute changes yourself,
+the code is on [GitHub](https://github.com/smart-on-fhir/cumulus-etl).

--- a/tests/covid_symptom/test_covid_results.py
+++ b/tests/covid_symptom/test_covid_results.py
@@ -163,34 +163,52 @@ class TestCovidSymptomNlpResultsTask(CtakesMixin, TaskTestCase):
     async def test_group_values_noted(self):
         """Verify that the task does keep track of group values per batch"""
         docref = i2b2_mock_data.documentreference()
-        docref_no_text = i2b2_mock_data.documentreference()
-        docref_no_text["content"][0]["attachment"]["data"] = ""
-        self.make_json("DocumentReference.1", "has-symptoms", **docref)
+        self.make_json("DocumentReference.1", "first-doc", **docref)
         self.make_json("DocumentReference.2", "not-examined", **docref, docStatus="preliminary")
-        self.make_json("DocumentReference.3", "zero-symptoms", **docref_no_text)
-        self.make_json("DocumentReference.4", "second-batch", **docref)
+        self.make_json("DocumentReference.3", "second-doc", **docref)
+        self.make_json("DocumentReference.4", "third-doc", **docref)
 
-        self.job_config.batch_size = 2  # two symptoms for each doc that has them
+        self.job_config.batch_size = 4  # two symptoms for each doc that has them
         await covid_symptom.CovidSymptomNlpResultsTask(self.job_config, self.scrubber).run()
 
         self.assertEqual(2, self.format.write_records.call_count)
 
         # First batch
         first_batch = self.format.write_records.call_args_list[0][0][0]
-        expected_row_docs = {self.codebook.db.resource_hash("has-symptoms")}
+        expected_row_docs = {
+            self.codebook.db.resource_hash("first-doc"),
+            self.codebook.db.resource_hash("second-doc"),
+        }
         self.assertEqual(expected_row_docs, {row["docref_id"] for row in first_batch.rows})
         self.assertEqual(expected_row_docs, first_batch.groups)
 
         # Second batch
         second_batch = self.format.write_records.call_args_list[1][0][0]
-        expected_row_docs = {self.codebook.db.resource_hash("second-batch")}
+        expected_row_docs = {self.codebook.db.resource_hash("third-doc")}
         self.assertEqual(expected_row_docs, {row["docref_id"] for row in second_batch.rows})
-        expected_groups = {
-            # The task will have cleared the group list and the first batch should not be present
-            self.codebook.db.resource_hash("second-batch"),
-            self.codebook.db.resource_hash("zero-symptoms"),  # even without rows, it shows up in group list
-        }
-        self.assertEqual(expected_groups, second_batch.groups)
+        self.assertEqual(expected_row_docs, second_batch.groups)
+
+    async def test_zero_symptoms(self):
+        """Verify that we write out a marker for DocRefs we did examine, even if no symptoms appeared"""
+        docref = i2b2_mock_data.documentreference()
+        docref_no_text = i2b2_mock_data.documentreference()
+        docref_no_text["content"][0]["attachment"]["data"] = ""
+        self.make_json("DocumentReference.1", "zero-symptoms", **docref_no_text)
+        self.make_json("DocumentReference.2", "not-examined", **docref, docStatus="preliminary")
+
+        await covid_symptom.CovidSymptomNlpResultsTask(self.job_config, self.scrubber).run()
+
+        self.assertEqual(1, self.format.write_records.call_count)
+        batch = self.format.write_records.call_args_list[0][0][0]
+
+        rows = batch.rows
+        self.assertEqual(1, len(rows))
+
+        row = rows[0]
+        anon_docref_id = self.codebook.db.resource_hash("zero-symptoms")
+        self.assertEqual(f"{anon_docref_id}.0", row["id"])
+        self.assertEqual(anon_docref_id, row["docref_id"])
+        self.assertIsNone(row["match"])
 
 
 class TestCovidSymptomEtl(BaseEtlSimple):


### PR DESCRIPTION
Previously, there was no way to detect the difference between a DocRef that was not processed (not an ED DocRef or an error occurred etc) vs a DocRef that had no symptoms.

Both just had zero rows in the Athena db.

This commit starts adding a single row in the nlp_results table with a null "match" column for this case.

Existing SQL should be able to gracefully handle this change. If/when we want to update the SQL to handle these kinds of DocRefs, it can be updated to treat these new rows specially. But for now, they will be ignored.


### Checklist
- [x] Consider if documentation (like in `docs/`) needs to be updated
- [x] Consider if tests should be added
