### PR TITLE
feat: downgrade some fatal connection errors to warnings

### DIFF
--- a/cumulus_etl/errors.py
+++ b/cumulus_etl/errors.py
@@ -20,7 +20,7 @@ TASK_FILTERED_OUT = 20
 TASK_SET_EMPTY = 21
 ARGS_CONFLICT = 22
 ARGS_INVALID = 23
-FHIR_URL_MISSING = 24
+# FHIR_URL_MISSING = 24 # Obsolete, it's no longer fatal
 BASIC_CREDENTIALS_MISSING = 25
 FOLDER_NOT_EMPTY = 26
 BULK_EXPORT_FOLDER_NOT_LOCAL = 27
@@ -30,6 +30,24 @@ LABEL_STUDIO_CONFIG_INVALID = 30
 LABEL_STUDIO_MISSING = 31
 FHIR_AUTH_FAILED = 32
 SERVICE_MISSING = 33  # generic init-check service is missing
+
+
+class FhirConnectionError(Exception):
+    """We needed to connect to a FHIR server but failed"""
+
+
+class FhirUrlMissing(FhirConnectionError):
+    """We needed to connect to a FHIR server but no URL was provided"""
+
+    def __init__(self):
+        super().__init__("Could not download some files without a FHIR server URL (use --fhir-url)")
+
+
+class FhirAuthMissing(FhirConnectionError):
+    """We needed to connect to a FHIR server but no authentication config was provided"""
+
+    def __init__(self):
+        super().__init__("Could not download some files without authentication parameters (see --help)")
 
 
 class FatalError(Exception):

--- a/cumulus_etl/fhir/fhir_auth.py
+++ b/cumulus_etl/fhir/fhir_auth.py
@@ -21,8 +21,7 @@ def urljoin(base: str, path: str) -> str:
         return path
 
     if not base:
-        print("You must provide a base FHIR server URL with --fhir-url", file=sys.stderr)
-        raise SystemExit(errors.FHIR_URL_MISSING)
+        raise errors.FhirUrlMissing()
     return urllib.parse.urljoin(base, path)
 
 
@@ -34,12 +33,8 @@ class Auth:
         del session
 
         if reauthorize:
-            # Abort because we clearly need authentication tokens, but have not been given any parameters for them.
-            print(
-                "You must provide some authentication parameters (like --smart-client-id) to connect to a server.",
-                file=sys.stderr,
-            )
-            raise SystemExit(errors.SMART_CREDENTIALS_MISSING)
+            # We clearly need auth tokens, but have not been given any parameters for them.
+            raise errors.FhirAuthMissing()
 
     def sign_headers(self, headers: dict) -> dict:
         """Add signature token to request headers"""

--- a/cumulus_etl/loaders/fhir/bulk_export.py
+++ b/cumulus_etl/loaders/fhir/bulk_export.py
@@ -81,11 +81,14 @@ class BulkExporter:
             # But some servers do support it, and it is a possible future addition to the spec.
             params["_until"] = self._until
 
-        response = await self._request_with_delay(
-            urllib.parse.urljoin(self._url, f"$export?{urllib.parse.urlencode(params)}"),
-            headers={"Prefer": "respond-async"},
-            target_status_code=202,
-        )
+        try:
+            response = await self._request_with_delay(
+                urllib.parse.urljoin(self._url, f"$export?{urllib.parse.urlencode(params)}"),
+                headers={"Prefer": "respond-async"},
+                target_status_code=202,
+            )
+        except errors.FhirConnectionError as exc:
+            errors.fatal(str(exc), errors.FHIR_AUTH_FAILED)
 
         # Grab the poll location URL for status updates
         poll_location = response.headers["Content-Location"]

--- a/tests/fhir/test_fhir_client.py
+++ b/tests/fhir/test_fhir_client.py
@@ -96,10 +96,12 @@ class TestFhirClient(AsyncTestCase):
         await use_client()
 
         # No SMART args at all will raise though if we do make a call
-        await use_client(code=errors.SMART_CREDENTIALS_MISSING, request=True)
+        with self.assertRaises(errors.FhirAuthMissing):
+            await use_client(request=True)
 
-        # No client ID
-        await use_client(code=errors.FHIR_URL_MISSING, request=True, url=None)
+        # No base URL
+        with self.assertRaises(errors.FhirUrlMissing):
+            await use_client(request=True, url=None)
 
         # No JWKS
         await use_client(code=errors.SMART_CREDENTIALS_MISSING, smart_client_id="foo")


### PR DESCRIPTION
Previously, if you were running an NLP task and we needed to download a clinical note but couldn't, we'd early-exit with an error and say "please provide the auth flags, kthx"

Now, we merely warn about it once but keep processing DocRefs.

This is designed to more gracefully handle some cases like BCH has, where their DocRefs contain some URLs that always error out, but the other DocRefs have been nicely inlined.

So we want to be able to run in a "no-network" context where we don't need to talk to the FHIR server at all. We just want to process the already-inlined notes.

In other contexts, where the user genuinely made a mistake and should re-run with auth parameters, this should still be plenty of notice. There is an error printed to the console, and the job is marked as failing, so the ETL as a whole will fail with a status code and error message at the end.


### Checklist
- [x] Consider if documentation (like in `docs/`) needs to be updated
- [x] Consider if tests should be added
