### PR TITLE
feat(upload-notes): add ability to tag philter spans, not redact them

### DIFF
--- a/cumulus_etl/deid/philter.py
+++ b/cumulus_etl/deid/philter.py
@@ -22,6 +22,16 @@ class Philter:
         filter_config = os.path.join(os.path.dirname(__file__), "philter-config.toml")
         self.filters = philter_lite.load_filters(filter_config)
 
+    def detect_phi(self, text: str) -> philter_lite.CoordinateMap:
+        """
+        Find PHI spans using Philter.
+
+        :param text: the text to scrub
+        :returns: a map of where the spans to scrub are
+        """
+        include_map, _, _ = philter_lite.detect_phi(text, self.filters)
+        return include_map
+
     def scrub_text(self, text: str) -> str:
         """
         Scrub text of PHI using Philter.
@@ -29,5 +39,5 @@ class Philter:
         :param text: the text to scrub
         :returns: the scrubbed text, with PHI replaced by asterisks ("*")
         """
-        include_map, _, _ = philter_lite.detect_phi(text, self.filters)
+        include_map = self.detect_phi(text)
         return philter_lite.transform_text_asterisk(text, include_map)

--- a/docs/chart-review.md
+++ b/docs/chart-review.md
@@ -233,7 +233,7 @@ But you may get better results by adding extra terms and variations in your symp
 ## Disabling Features
 
 You may not need NLP or `philter` processing.
-Simply pass `--no-nlp` or `--no-philter` and those steps will be skipped.
+Simply pass `--no-nlp` or `--philter=disable` and those steps will be skipped.
 
 ## Label Studio
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -70,7 +70,7 @@ tests = [
     "coverage",
     "ddt",
     "freezegun",
-    "moto[server,s3]",
+    "moto[server,s3] >= 5.0",
     "pytest",
     "respx",
 ]

--- a/tests/s3mock.py
+++ b/tests/s3mock.py
@@ -39,7 +39,7 @@ class S3Mixin(utils.AsyncTestCase):
         self.server = ThreadedMotoServer()
         self.server.start()
 
-        s3mock = moto.mock_s3()
+        s3mock = moto.mock_aws()
         self.addCleanup(s3mock.stop)
         s3mock.start()
 


### PR DESCRIPTION
This commit deprecates --no-philter in favor of --philter=disable and adds --philter=label (and the default --philter=redact).

When --philter=label is requested, we send a prediction layer to Label Studio that highlights all the detected PHI spans for you.

This is helpful when doing manual de-identification, since philter can do some of the grunt work for you.

Example (synthea note, no PHI here):
![image](https://github.com/smart-on-fhir/cumulus-etl/assets/1196901/a1848c25-4ef6-4694-ab1a-f6f81edc43b7)

### Checklist
- [x] Consider if documentation (like in `docs/`) needs to be updated
- [x] Consider if tests should be added
