### PR TITLE
Chart review doc gathering status

### DIFF
--- a/cumulus_etl/common.py
+++ b/cumulus_etl/common.py
@@ -12,6 +12,7 @@ from collections.abc import Iterator
 from typing import Any, Protocol, TextIO
 
 import rich
+from rich import progress
 
 from cumulus_etl import store
 
@@ -317,6 +318,13 @@ def print_header(name: str | None = None) -> None:
     rich.get_console().rule()
     if name:
         print(name)
+
+def get_transient_progress()-> (progress.Progress):
+    progress_bar = progress.Progress(
+        progress.TextColumn("[progress.description]{task.description}"),
+        refresh_per_second=0.1)
+    return progress_bar
+    
 
 
 ###############################################################################

--- a/cumulus_etl/fhir/fhir_utils.py
+++ b/cumulus_etl/fhir/fhir_utils.py
@@ -201,10 +201,13 @@ async def get_docref_note(client: FhirClient, docref: dict) -> str:
     if best_attachment_index < 0:
         # We didn't find _any_ of our target text content types.
         # A content type isn't required by the spec with external URLs, so it's possible an unmarked link could be good.
-        # But let's optimistically enforce the need for a content type ourselves by bailing here.
-        # If we find a real-world need to be more permissive, we can change this later.
+        # We've found a real world case where we've found missing data preventing note download; for now,
+        # we are just notifying about it and returning an empty string object.
+        # If we find a actually need this data, we can change this later.
         # But note that if we do, we'll need to handle downloading Binary FHIR objects, in addition to arbitrary URLs.
-        raise ValueError("No textual mimetype found")
+        
+        print(f"Found unexpected mime type '{mimetype}', skipping.")
+        return ""
 
     note = await _get_docref_note_from_attachment(client, attachments[best_attachment_index])
 


### PR DESCRIPTION
This PR makes the following changes:
- Adds a status indicator for gathering documents
- Backs off the strict type enforcement for documents in favor of skipping and reporting an error.

### Checklist
- [X] Consider if documentation (like in `docs/`) needs to be updated
- [X] Consider if tests should be added
