### PR TITLE
feat(upload-notes): add datetimes to each DocRef header

### DIFF
--- a/cumulus_etl/fhir/__init__.py
+++ b/cumulus_etl/fhir/__init__.py
@@ -1,4 +1,4 @@
 """Support for talking to FHIR servers & handling the FHIR spec"""
 
 from .fhir_client import FhirClient, create_fhir_client_for_cli
-from .fhir_utils import download_reference, get_docref_note, ref_resource, unref_resource
+from .fhir_utils import download_reference, get_docref_note, parse_datetime, ref_resource, unref_resource

--- a/cumulus_etl/upload_notes/labelstudio.py
+++ b/cumulus_etl/upload_notes/labelstudio.py
@@ -1,6 +1,7 @@
 """LabelStudio document annotation"""
 
 import dataclasses
+import datetime
 from collections.abc import Collection, Iterable
 
 import ctakesclient.typesystem
@@ -25,6 +26,7 @@ class LabelStudioNote:
     enc_id: str  # real Encounter ID
     anon_id: str  # anonymized Encounter ID
     text: str = ""  # text of the note, sent to Label Studio
+    date: datetime.datetime | None = None  # date of the note
 
     # A title is only used when combining notes into one big encounter note. It's not sent to Label Studio.
     title: str = ""

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -69,10 +69,10 @@ line-length = 120
 tests = [
     "coverage",
     "ddt",
-    "freezegun",
     "moto[server,s3] >= 5.0",
     "pytest",
     "respx",
+    "time-machine",
 ]
 dev = [
     "black == 23.11.0",

--- a/tests/fhir/test_fhir_client.py
+++ b/tests/fhir/test_fhir_client.py
@@ -43,7 +43,7 @@ class TestFhirClient(AsyncTestCase):
                 "iss": self.client_id,
                 "sub": self.client_id,
                 "aud": self.token_url,
-                "exp": int(time.time()) + 299,  # aided by freezegun not changing time under us
+                "exp": int(time.time()) + 299,  # aided by time-machine not changing time under us
                 "jti": "1234",
             },
         )

--- a/tests/fhir/test_fhir_utils.py
+++ b/tests/fhir/test_fhir_utils.py
@@ -1,5 +1,7 @@
 """Tests for fhir_utils.py"""
+
 import base64
+import datetime
 import shutil
 from unittest import mock
 
@@ -43,6 +45,31 @@ class TestReferenceHandlers(utils.AsyncTestCase):
     @ddt.unpack
     def test_ref_resource(self, resource_type, resource_id, expected):
         self.assertEqual({"reference": expected}, fhir.ref_resource(resource_type, resource_id))
+
+
+@ddt.ddt
+class TestDateParsing(utils.AsyncTestCase):
+    """Tests for the parse_datetime method"""
+
+    @ddt.data(
+        (None, None),
+        ("", None),
+        ("abc", None),
+        ("abc-de", None),
+        ("abc-de-fg", None),
+        ("2018", datetime.datetime(2018, 1, 1)),  # naive
+        ("2021-07", datetime.datetime(2021, 7, 1)),  # naive
+        ("1992-11-06", datetime.datetime(1992, 11, 6)),  # naive
+        (
+            "1992-11-06T13:28:17.239+02:00",
+            datetime.datetime(1992, 11, 6, 13, 28, 17, 239000, tzinfo=datetime.timezone(datetime.timedelta(hours=2))),
+        ),
+        ("1992-11-06T13:28:17.239Z", datetime.datetime(1992, 11, 6, 13, 28, 17, 239000, tzinfo=datetime.timezone.utc)),
+    )
+    @ddt.unpack
+    def test_parse_datetime(self, input_value, expected_value):
+        parsed = fhir.parse_datetime(input_value)
+        self.assertEqual(expected_value, parsed)
 
 
 @ddt.ddt

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -13,21 +13,20 @@ import tracemalloc
 import unittest
 from unittest import mock
 
-import freezegun
 import httpx
 import respx
+import time_machine
 
 from cumulus_etl.formats.deltalake import DeltaLakeFormat
 
-# Pass a non-UTC time to freezegun to help notice any bad timezone handling.
+# Pass a non-UTC time to time-machine to help notice any bad timezone handling.
 # But only bother exposing the UTC version to other test code, since that's what will be most useful/common.
 _FROZEN_TIME = datetime.datetime(2021, 9, 15, 1, 23, 45, tzinfo=datetime.timezone(datetime.timedelta(hours=4)))
 FROZEN_TIME_UTC = _FROZEN_TIME.astimezone(datetime.timezone.utc)
 
 
 # Several tests involve timestamps in some form, so just pick a standard time for all tests.
-# We ignore socketserver because it checks the result of time() when evaluating timeouts.
-@freezegun.freeze_time(_FROZEN_TIME, ignore=["socketserver"])
+@time_machine.travel(_FROZEN_TIME, tick=False)
 class AsyncTestCase(unittest.IsolatedAsyncioTestCase):
     """
     Test case to hold some common code (suitable for async *OR* sync tests)


### PR DESCRIPTION
Also:
- Order the DocRefs in an encounter by datetime
- Switch from freezegun to time-machine

Unrelatedly:
- Switch from deprecated cgi module to email module for mimetype parsing.

Fixes https://github.com/smart-on-fhir/cumulus-etl/issues/298


### Checklist
- [x] Consider if documentation (like in `docs/`) needs to be updated
- [x] Consider if tests should be added
