### PR TITLE
A couple tweaks: bump pyarrow and give nicer error ctakes hostname error message

### DIFF
--- a/cumulus_etl/cli_utils.py
+++ b/cumulus_etl/cli_utils.py
@@ -87,7 +87,9 @@ def is_url_available(url: str, retry: bool = True) -> bool:
         try:
             socket.create_connection((url_parsed.hostname, url_parsed.port))
             return True
-        except ConnectionRefusedError:
+        except socket.gaierror:  # hostname didn't resolve
+            return False
+        except ConnectionRefusedError:  # service is not ready yet
             if i < num_tries - 1:
                 time.sleep(3)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,7 @@ dependencies = [
     "label-studio-sdk < 1",
     "oracledb < 3",
     "philter-lite < 1",
-    "pyarrow < 15",
+    "pyarrow < 16",
     "rich < 14",
     "s3fs",
 ]


### PR DESCRIPTION
pyarrow 15: https://arrow.apache.org/blog/2024/01/21/15.0.0-release/
(seems like they just removed some deprecated API - seems to work fine)

The hostname thing happens during `compose run` when we try to use network hostnames but you haven't started the service, or some other similar cases - catching that error will go down the "print a nice message" path.

### Checklist
- [x] Consider if documentation (like in `docs/`) needs to be updated
- [x] Consider if tests should be added
