### PR TITLE
feat: initial completeness-tracking work

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -27,6 +27,26 @@ pre-commit install
 
 This will install the pre-commit hooks for the repo (which automatically enforce styling for you).
 
+### Running unit tests
+
+1. First, you'll want to install the
+[Microsoft Anonymizer tool](https://github.com/microsoft/Tools-for-Health-Data-Anonymization/).
+Here's an example install command for a Debian-based Linux system,
+once you've checked out the repo:
+
+```shell
+sudo apt-get install dotnet6
+dotnet publish \
+  --runtime=linux-x64 \
+  --configuration=Release \
+  -p:PublishSingleFile=true \
+  --output=$HOME/.local/bin \
+  mstool/FHIR/src/Microsoft.Health.Fhir.Anonymizer.R4.CommandLineTool
+```
+
+2. Then just run `pytest`.
+All dependencies should have been installed by the `pip install .[dev]` above.
+
 ### How to show us the patch
 
 Open a new GitHub PR and one of the maintainers will notice it and comment.

--- a/cumulus_etl/completion/__init__.py
+++ b/cumulus_etl/completion/__init__.py
@@ -1,0 +1,21 @@
+"""
+Helpers for implementing completion-tracking.
+
+Completion tracking allows downstream consumers to know when ETL runs are
+"complete enough" for their purposes.
+
+For example, the `core` study may want to not expose Encounters whose
+Conditions have not yet been loaded. These metadata tables allow that.
+
+Although these metadata tables aren't themselves tasks, they need a
+lot of the same information that tasks need. This module provides that.
+"""
+
+from .schema import (
+    COMPLETION_TABLE,
+    COMPLETION_ENCOUNTERS_TABLE,
+    completion_encounters_output_args,
+    completion_encounters_schema,
+    completion_format_args,
+    completion_schema,
+)

--- a/cumulus_etl/completion/schema.py
+++ b/cumulus_etl/completion/schema.py
@@ -1,0 +1,62 @@
+"""Schemas and Format helpers for writing completion tables."""
+
+import pyarrow
+
+
+COMPLETION_TABLE = "etl__completion"
+COMPLETION_ENCOUNTERS_TABLE = "etl__completion_encounters"
+
+
+# FORMATTERS
+
+
+def completion_format_args() -> dict:
+    """Returns kwargs to pass to the Format class initializer of your choice"""
+    return {
+        "dbname": COMPLETION_TABLE,
+        "uniqueness_fields": {"table_name", "group_name"},
+    }
+
+
+# OUTPUT TABLES
+
+
+def completion_encounters_output_args() -> dict:
+    """Returns output table kwargs for the etl__completion_encounters table"""
+    return {
+        "name": COMPLETION_ENCOUNTERS_TABLE,
+        "uniqueness_fields": {"encounter_id", "group_name"},
+        "update_existing": False,  # we want to keep the first export time we make for a group
+        "resource_type": None,
+        "visible": False,
+    }
+
+
+# SCHEMAS
+
+
+def completion_schema() -> pyarrow.Schema:
+    """Returns a schema for the etl__completion table"""
+    return pyarrow.schema(
+        [
+            pyarrow.field("table_name", pyarrow.string()),
+            pyarrow.field("group_name", pyarrow.string()),
+            # You might think this is an opportunity to use pyarrow.timestamp(),
+            # but because ndjson output formats (which can't natively represent a
+            # datetime) would then require conversion to and fro, it's easier to
+            # just mirror our FHIR tables and use strings for timestamps.
+            pyarrow.field("export_time", pyarrow.string()),
+        ]
+    )
+
+
+def completion_encounters_schema() -> pyarrow.Schema:
+    """Returns a schema for the etl__completion_encounters table"""
+    return pyarrow.schema(
+        [
+            pyarrow.field("encounter_id", pyarrow.string()),
+            pyarrow.field("group_name", pyarrow.string()),
+            # See note above for why this isn't a pyarrow.timestamp() field.
+            pyarrow.field("export_time", pyarrow.string()),
+        ]
+    )

--- a/cumulus_etl/errors.py
+++ b/cumulus_etl/errors.py
@@ -32,6 +32,7 @@ LABEL_STUDIO_CONFIG_INVALID = 30
 LABEL_STUDIO_MISSING = 31
 FHIR_AUTH_FAILED = 32
 SERVICE_MISSING = 33  # generic init-check service is missing
+COMPLETION_ARG_MISSING = 34
 
 
 class FhirConnectionError(Exception):

--- a/cumulus_etl/etl/config.py
+++ b/cumulus_etl/etl/config.py
@@ -31,6 +31,8 @@ class JobConfig:
         ctakes_overrides: str = None,
         dir_errors: str = None,
         tasks: list[str] = None,
+        export_group_name: str = None,
+        export_datetime: datetime.datetime = None,
     ):
         self._dir_input_orig = dir_input_orig
         self.dir_input = dir_input_deid
@@ -46,14 +48,16 @@ class JobConfig:
         self.batch_size = batch_size
         self.ctakes_overrides = ctakes_overrides
         self.tasks = tasks or []
+        self.export_group_name = export_group_name
+        self.export_datetime = export_datetime
 
         # initialize format class
         self._output_root = store.Root(self._dir_output, create=True)
         self._format_class = formats.get_format_class(self._output_format)
         self._format_class.initialize_class(self._output_root)
 
-    def create_formatter(self, dbname: str, group_field: str = None, resource_type: str = None) -> formats.Format:
-        return self._format_class(self._output_root, dbname, group_field=group_field, resource_type=resource_type)
+    def create_formatter(self, dbname: str, **kwargs) -> formats.Format:
+        return self._format_class(self._output_root, dbname, **kwargs)
 
     def path_config(self) -> str:
         return os.path.join(self.dir_job_config(), "job_config.json")
@@ -74,6 +78,8 @@ class JobConfig:
             "comment": self.comment,
             "batch_size": self.batch_size,
             "tasks": ",".join(self.tasks),
+            "export_group_name": self.export_group_name,
+            "export_timestamp": self.export_datetime and self.export_datetime.isoformat(),
         }
 
 

--- a/cumulus_etl/etl/studies/covid_symptom/covid_tasks.py
+++ b/cumulus_etl/etl/studies/covid_symptom/covid_tasks.py
@@ -7,7 +7,7 @@ import pyarrow
 import rich.progress
 from ctakesclient.transformer import TransformerModel
 
-from cumulus_etl import formats, nlp, store
+from cumulus_etl import nlp, store
 from cumulus_etl.etl import tasks
 from cumulus_etl.etl.studies.covid_symptom import covid_ctakes
 
@@ -109,7 +109,7 @@ class BaseCovidSymptomNlpResultsTask(tasks.BaseNlpTask):
     #   cNLP: smartonfhir/cnlp-transformers:negation-0.4.0
     #   ctakesclient: 3.0
 
-    outputs = [tasks.OutputTable(schema=None, group_field="docref_id")]
+    outputs = [tasks.OutputTable(resource_type=None, group_field="docref_id")]
 
     async def prepare_task(self) -> bool:
         bsv_path = ctakesclient.filesystem.covid_symptoms_path()
@@ -155,7 +155,7 @@ class BaseCovidSymptomNlpResultsTask(tasks.BaseNlpTask):
             yield symptoms
 
     @classmethod
-    def get_schema(cls, formatter: formats.Format, rows: list[dict]) -> pyarrow.Schema:
+    def get_schema(cls, resource_type: str | None, rows: list[dict]) -> pyarrow.Schema:
         return pyarrow.schema(
             [
                 pyarrow.field("id", pyarrow.string()),

--- a/cumulus_etl/etl/studies/hftest/hf_tasks.py
+++ b/cumulus_etl/etl/studies/hftest/hf_tasks.py
@@ -4,7 +4,7 @@ import httpx
 import pyarrow
 import rich.progress
 
-from cumulus_etl import common, errors, formats, nlp
+from cumulus_etl import common, errors, nlp
 from cumulus_etl.etl import tasks
 
 
@@ -86,7 +86,7 @@ class HuggingFaceTestTask(tasks.BaseNlpTask):
             }
 
     @classmethod
-    def get_schema(cls, formatter: formats.Format, rows: list[dict]) -> pyarrow.Schema:
+    def get_schema(cls, resource_type: str | None, rows: list[dict]) -> pyarrow.Schema:
         return pyarrow.schema(
             [
                 pyarrow.field("id", pyarrow.string()),

--- a/cumulus_etl/etl/tasks/nlp_task.py
+++ b/cumulus_etl/etl/tasks/nlp_task.py
@@ -19,7 +19,7 @@ class BaseNlpTask(EtlTask):
     needs_bulk_deid = False
 
     # You may want to override these in your subclass
-    outputs = [OutputTable(schema=None)]  # maybe a group_field? (remember to call self.seen_docrefs.add() if so)
+    outputs = [OutputTable(resource_type=None)]  # maybe a group_field? (remember to call self.seen_docrefs.add() if so)
     tags = {"gpu"}  # maybe a study identifier?
 
     # Task Version

--- a/cumulus_etl/formats/batch.py
+++ b/cumulus_etl/formats/batch.py
@@ -15,11 +15,10 @@ class Batch:
     - Written to the target location as one piece (e.g. one ndjson file or one Delta Lake update chunk)
     """
 
-    def __init__(self, rows: list[dict], groups: set[str] = None, schema: pyarrow.Schema = None, index: int = 0):
+    def __init__(self, rows: list[dict], groups: set[str] = None, schema: pyarrow.Schema = None):
         self.rows = rows
         # `groups` is the set of the values of the format's `group_field` represented by `rows`.
         # We can't just get this from rows directly because there might be groups that now have zero entries.
         # And those won't be in rows, but should still be removed from the database.
         self.groups = groups
         self.schema = schema
-        self.index = index

--- a/cumulus_etl/loaders/base.py
+++ b/cumulus_etl/loaders/base.py
@@ -21,6 +21,10 @@ class Loader(abc.ABC):
         """
         self.root = root
 
+        # Public properties (potentially set when loading) for reporting back to caller
+        self.group_name = None
+        self.export_datetime = None
+
     @abc.abstractmethod
     async def load_all(self, resources: list[str]) -> common.Directory:
         """

--- a/cumulus_etl/loaders/fhir/ndjson_loader.py
+++ b/cumulus_etl/loaders/fhir/ndjson_loader.py
@@ -74,6 +74,11 @@ class FhirNdjsonLoader(base.Loader):
                 self.client, resources, self.root.path, target_dir.name, self.since, self.until
             )
             await bulk_exporter.export()
+
+            # Copy back these settings from the export
+            self.group_name = bulk_exporter.group_name
+            self.export_datetime = bulk_exporter.export_datetime
+
         except errors.FatalError as exc:
             errors.fatal(str(exc), errors.BULK_EXPORT_FAILED)
 

--- a/docs/setup/cumulus-aws-template.yaml
+++ b/docs/setup/cumulus-aws-template.yaml
@@ -198,6 +198,8 @@ Resources:
               - !Sub "s3://${S3Bucket}/${EtlSubdir}/servicerequest"
               - !Sub "s3://${S3Bucket}/${EtlSubdir}/covid_symptom__nlp_results"
               - !Sub "s3://${S3Bucket}/${EtlSubdir}/covid_symptom__nlp_results_term_exists"
+              - !Sub "s3://${S3Bucket}/${EtlSubdir}/etl__completion"
+              - !Sub "s3://${S3Bucket}/${EtlSubdir}/etl__completion_encounters"
             CreateNativeDeltaTable: True
             WriteManifest: False
 

--- a/tests/data/covid/output/etl__completion/etl__completion.000.ndjson
+++ b/tests/data/covid/output/etl__completion/etl__completion.000.ndjson
@@ -1,0 +1,1 @@
+{"table_name": "covid_symptom__nlp_results", "group_name": "test-group", "export_time": "2020-10-13T12:00:20-05:00"}

--- a/tests/data/covid/term-exists/etl__completion/etl__completion.000.ndjson
+++ b/tests/data/covid/term-exists/etl__completion/etl__completion.000.ndjson
@@ -1,0 +1,1 @@
+{"table_name": "covid_symptom__nlp_results_term_exists", "group_name": "test-group", "export_time": "2020-10-13T12:00:20-05:00"}

--- a/tests/data/i2b2/output/etl__completion/etl__completion.000.ndjson
+++ b/tests/data/i2b2/output/etl__completion/etl__completion.000.ndjson
@@ -1,0 +1,1 @@
+{"table_name": "encounter", "group_name": "test-group", "export_time": "2020-10-13T12:00:20-05:00"}

--- a/tests/data/i2b2/output/etl__completion/etl__completion.001.ndjson
+++ b/tests/data/i2b2/output/etl__completion/etl__completion.001.ndjson
@@ -1,0 +1,1 @@
+{"table_name": "patient", "group_name": "test-group", "export_time": "2020-10-13T12:00:20-05:00"}

--- a/tests/data/i2b2/output/etl__completion/etl__completion.002.ndjson
+++ b/tests/data/i2b2/output/etl__completion/etl__completion.002.ndjson
@@ -1,0 +1,1 @@
+{"table_name": "condition", "group_name": "test-group", "export_time": "2020-10-13T12:00:20-05:00"}

--- a/tests/data/i2b2/output/etl__completion/etl__completion.003.ndjson
+++ b/tests/data/i2b2/output/etl__completion/etl__completion.003.ndjson
@@ -1,0 +1,1 @@
+{"table_name": "documentreference", "group_name": "test-group", "export_time": "2020-10-13T12:00:20-05:00"}

--- a/tests/data/i2b2/output/etl__completion/etl__completion.004.ndjson
+++ b/tests/data/i2b2/output/etl__completion/etl__completion.004.ndjson
@@ -1,0 +1,2 @@
+{"table_name": "medication", "group_name": "test-group", "export_time": "2020-10-13T12:00:20-05:00"}
+{"table_name": "medicationrequest", "group_name": "test-group", "export_time": "2020-10-13T12:00:20-05:00"}

--- a/tests/data/i2b2/output/etl__completion/etl__completion.005.ndjson
+++ b/tests/data/i2b2/output/etl__completion/etl__completion.005.ndjson
@@ -1,0 +1,1 @@
+{"table_name": "observation", "group_name": "test-group", "export_time": "2020-10-13T12:00:20-05:00"}

--- a/tests/data/i2b2/output/etl__completion_encounters/etl__completion_encounters.000.ndjson
+++ b/tests/data/i2b2/output/etl__completion_encounters/etl__completion_encounters.000.ndjson
@@ -1,0 +1,2 @@
+{"encounter_id": "82ebb5bb976239c0a7c3b37f50362b58b9c210b35753bb82fbb477f93c43b423", "export_time": "2020-10-13T12:00:20-05:00", "group_name": "test-group"}
+{"encounter_id": "fb29ea2a68ca2e1e4bbe22bdeedf021d94ec89f7e3d38ecbe908a8f2b3d89687", "export_time": "2020-10-13T12:00:20-05:00", "group_name": "test-group"}

--- a/tests/data/simple/batched-output/etl__completion/etl__completion.000.ndjson
+++ b/tests/data/simple/batched-output/etl__completion/etl__completion.000.ndjson
@@ -1,0 +1,1 @@
+{"table_name": "encounter", "group_name": "test-group", "export_time": "2020-10-13T12:00:20-05:00"}

--- a/tests/data/simple/batched-output/etl__completion/etl__completion.001.ndjson
+++ b/tests/data/simple/batched-output/etl__completion/etl__completion.001.ndjson
@@ -1,0 +1,1 @@
+{"table_name": "patient", "group_name": "test-group", "export_time": "2020-10-13T12:00:20-05:00"}

--- a/tests/data/simple/batched-output/etl__completion/etl__completion.002.ndjson
+++ b/tests/data/simple/batched-output/etl__completion/etl__completion.002.ndjson
@@ -1,0 +1,1 @@
+{"table_name": "condition", "group_name": "test-group", "export_time": "2020-10-13T12:00:20-05:00"}

--- a/tests/data/simple/batched-output/etl__completion/etl__completion.003.ndjson
+++ b/tests/data/simple/batched-output/etl__completion/etl__completion.003.ndjson
@@ -1,0 +1,1 @@
+{"table_name": "documentreference", "group_name": "test-group", "export_time": "2020-10-13T12:00:20-05:00"}

--- a/tests/data/simple/batched-output/etl__completion/etl__completion.004.ndjson
+++ b/tests/data/simple/batched-output/etl__completion/etl__completion.004.ndjson
@@ -1,0 +1,2 @@
+{"table_name": "medication", "group_name": "test-group", "export_time": "2020-10-13T12:00:20-05:00"}
+{"table_name": "medicationrequest", "group_name": "test-group", "export_time": "2020-10-13T12:00:20-05:00"}

--- a/tests/data/simple/batched-output/etl__completion/etl__completion.005.ndjson
+++ b/tests/data/simple/batched-output/etl__completion/etl__completion.005.ndjson
@@ -1,0 +1,1 @@
+{"table_name": "observation", "group_name": "test-group", "export_time": "2020-10-13T12:00:20-05:00"}

--- a/tests/data/simple/batched-output/etl__completion/etl__completion.006.ndjson
+++ b/tests/data/simple/batched-output/etl__completion/etl__completion.006.ndjson
@@ -1,0 +1,1 @@
+{"table_name": "procedure", "group_name": "test-group", "export_time": "2020-10-13T12:00:20-05:00"}

--- a/tests/data/simple/batched-output/etl__completion/etl__completion.007.ndjson
+++ b/tests/data/simple/batched-output/etl__completion/etl__completion.007.ndjson
@@ -1,0 +1,1 @@
+{"table_name": "servicerequest", "group_name": "test-group", "export_time": "2020-10-13T12:00:20-05:00"}

--- a/tests/data/simple/batched-output/etl__completion_encounters/etl__completion_encounters.000.ndjson
+++ b/tests/data/simple/batched-output/etl__completion_encounters/etl__completion_encounters.000.ndjson
@@ -1,0 +1,1 @@
+{"encounter_id": "08f0ebd4-950c-ddd9-ce97-b5bdf073eed1", "export_time": "2020-10-13T12:00:20-05:00", "group_name": "test-group"}

--- a/tests/data/simple/batched-output/etl__completion_encounters/etl__completion_encounters.001.ndjson
+++ b/tests/data/simple/batched-output/etl__completion_encounters/etl__completion_encounters.001.ndjson
@@ -1,0 +1,1 @@
+{"encounter_id": "af1e6186-3f9a-1fa9-3c73-cfa56c84a056", "export_time": "2020-10-13T12:00:20-05:00", "group_name": "test-group"}

--- a/tests/data/simple/output/etl__completion/etl__completion.000.ndjson
+++ b/tests/data/simple/output/etl__completion/etl__completion.000.ndjson
@@ -1,0 +1,1 @@
+{"table_name": "encounter", "group_name": "test-group", "export_time": "2020-10-13T12:00:20-05:00"}

--- a/tests/data/simple/output/etl__completion/etl__completion.001.ndjson
+++ b/tests/data/simple/output/etl__completion/etl__completion.001.ndjson
@@ -1,0 +1,1 @@
+{"table_name": "patient", "group_name": "test-group", "export_time": "2020-10-13T12:00:20-05:00"}

--- a/tests/data/simple/output/etl__completion/etl__completion.002.ndjson
+++ b/tests/data/simple/output/etl__completion/etl__completion.002.ndjson
@@ -1,0 +1,1 @@
+{"table_name": "allergyintolerance", "group_name": "test-group", "export_time": "2020-10-13T12:00:20-05:00"}

--- a/tests/data/simple/output/etl__completion/etl__completion.003.ndjson
+++ b/tests/data/simple/output/etl__completion/etl__completion.003.ndjson
@@ -1,0 +1,1 @@
+{"table_name": "condition", "group_name": "test-group", "export_time": "2020-10-13T12:00:20-05:00"}

--- a/tests/data/simple/output/etl__completion/etl__completion.004.ndjson
+++ b/tests/data/simple/output/etl__completion/etl__completion.004.ndjson
@@ -1,0 +1,1 @@
+{"table_name": "device", "group_name": "test-group", "export_time": "2020-10-13T12:00:20-05:00"}

--- a/tests/data/simple/output/etl__completion/etl__completion.005.ndjson
+++ b/tests/data/simple/output/etl__completion/etl__completion.005.ndjson
@@ -1,0 +1,1 @@
+{"table_name": "diagnosticreport", "group_name": "test-group", "export_time": "2020-10-13T12:00:20-05:00"}

--- a/tests/data/simple/output/etl__completion/etl__completion.006.ndjson
+++ b/tests/data/simple/output/etl__completion/etl__completion.006.ndjson
@@ -1,0 +1,1 @@
+{"table_name": "documentreference", "group_name": "test-group", "export_time": "2020-10-13T12:00:20-05:00"}

--- a/tests/data/simple/output/etl__completion/etl__completion.007.ndjson
+++ b/tests/data/simple/output/etl__completion/etl__completion.007.ndjson
@@ -1,0 +1,1 @@
+{"table_name": "immunization", "group_name": "test-group", "export_time": "2020-10-13T12:00:20-05:00"}

--- a/tests/data/simple/output/etl__completion/etl__completion.008.ndjson
+++ b/tests/data/simple/output/etl__completion/etl__completion.008.ndjson
@@ -1,0 +1,2 @@
+{"table_name": "medication", "group_name": "test-group", "export_time": "2020-10-13T12:00:20-05:00"}
+{"table_name": "medicationrequest", "group_name": "test-group", "export_time": "2020-10-13T12:00:20-05:00"}

--- a/tests/data/simple/output/etl__completion/etl__completion.009.ndjson
+++ b/tests/data/simple/output/etl__completion/etl__completion.009.ndjson
@@ -1,0 +1,1 @@
+{"table_name": "observation", "group_name": "test-group", "export_time": "2020-10-13T12:00:20-05:00"}

--- a/tests/data/simple/output/etl__completion/etl__completion.010.ndjson
+++ b/tests/data/simple/output/etl__completion/etl__completion.010.ndjson
@@ -1,0 +1,1 @@
+{"table_name": "procedure", "group_name": "test-group", "export_time": "2020-10-13T12:00:20-05:00"}

--- a/tests/data/simple/output/etl__completion/etl__completion.011.ndjson
+++ b/tests/data/simple/output/etl__completion/etl__completion.011.ndjson
@@ -1,0 +1,1 @@
+{"table_name": "servicerequest", "group_name": "test-group", "export_time": "2020-10-13T12:00:20-05:00"}

--- a/tests/data/simple/output/etl__completion_encounters/etl__completion_encounters.000.ndjson
+++ b/tests/data/simple/output/etl__completion_encounters/etl__completion_encounters.000.ndjson
@@ -1,0 +1,2 @@
+{"encounter_id": "08f0ebd4-950c-ddd9-ce97-b5bdf073eed1", "export_time": "2020-10-13T12:00:20-05:00", "group_name": "test-group"}
+{"encounter_id": "af1e6186-3f9a-1fa9-3c73-cfa56c84a056", "export_time": "2020-10-13T12:00:20-05:00", "group_name": "test-group"}

--- a/tests/formats/test_ndjson.py
+++ b/tests/formats/test_ndjson.py
@@ -4,7 +4,7 @@ import os
 
 import ddt
 
-from cumulus_etl import formats, store
+from cumulus_etl import common, store
 from cumulus_etl.formats.ndjson import NdjsonFormat
 from tests import utils
 
@@ -15,59 +15,44 @@ class TestNdjsonFormat(utils.AsyncTestCase):
     Test case for the ndjson format writer.
 
     i.e. tests for ndjson.py
+
+    Note that a lot of the basics of that formatter gets tested in other unit tests.
+    This class is mostly just for the less typical edge cases.
     """
 
     def setUp(self):
         super().setUp()
         self.output_tempdir = self.make_tempdir()
         self.root = store.Root(self.output_tempdir)
-        NdjsonFormat.initialize_class(self.root)
-
-    @staticmethod
-    def df(**kwargs) -> list[dict]:
-        """
-        Creates a dummy Table with ids & values equal to each kwarg provided.
-        """
-        return [{"id": k, "value": v} for k, v in kwargs.items()]
-
-    def store(
-        self,
-        rows: list[dict],
-        batch_index: int = 10,
-    ) -> bool:
-        """
-        Writes a single batch of data to the output dir.
-
-        :param rows: the data to insert
-        :param batch_index: which batch number this is, defaulting to 10 to avoid triggering any first/last batch logic
-        """
-        ndjson = NdjsonFormat(self.root, "condition")
-        batch = formats.Batch(rows, index=batch_index)
-        return ndjson.write_records(batch)
 
     @ddt.data(
         (None, True),
         ([], True),
-        (["condition.1234.ndjson", "condition.22.ndjson"], True),
-        (["condition.000.meta"], True),
-        (["condition.ndjson"], False),
-        (["condition.000.parquet"], False),
-        (["patient.000.ndjson"], False),
+        (["condition/condition.000.ndjson", "condition/condition.111.ndjson"], False),
+        (["condition/readme.txt"], False),
+        (["my-novel.txt"], False),
     )
     @ddt.unpack
-    def test_handles_existing_files(self, files: None | list[str], is_ok: bool):
-        """Verify that we bail out if any weird files already exist in the output"""
-        dbpath = self.root.joinpath("condition")
-        if files is not None:
-            os.makedirs(dbpath)
+    def test_disallows_existing_files(self, files: None | list[str], is_ok: bool):
+        """Verify that we bail out if any files already exist in the output"""
+        if files is None:
+            # This means we don't want any folder at all for the test
+            os.rmdir(self.root.path)
+        else:
             for file in files:
-                with open(f"{dbpath}/{file}", "w", encoding="utf8") as f:
-                    f.write('{"id": "A"}')
+                pieces = file.split("/")
+                if len(pieces) > 1:
+                    os.makedirs(self.root.joinpath(pieces[0]), exist_ok=True)
+                # write any old content in there, we just want to create the file.
+                common.write_text(self.root.joinpath(file), "Hello!")
 
         if is_ok:
-            self.store([{"id": "B"}], batch_index=0)
-            self.assertEqual(["condition.000.ndjson"], os.listdir(dbpath))
+            NdjsonFormat.initialize_class(self.root)
+            # Test that we didn't adjust/remove/create any of the files on disk
+            if files is None:
+                self.assertFalse(os.path.exists(self.root.path))
+            else:
+                self.assertEqual(files or [], os.listdir(self.root.path))
         else:
             with self.assertRaises(SystemExit):
-                self.store([{"id": "B"}])
-            self.assertEqual(files or [], os.listdir(dbpath))
+                NdjsonFormat.initialize_class(self.root)


### PR DESCRIPTION
This is early support for completeness-tracking (the ability to mark which groups & resources have been loaded by the ETL and are thus ready for studies to use).

- Adds some new (secret) CLI arguments: `--export-group`, `--export-timestamp`, and `--write-completion`
- Adds a new `etl__completion` table which holds:
  - table
  - group
  - export_time
- Adds a new `etl__completion_encounters` table which holds:
  - encounter_id
  - group
  - export_time
- This table is automatically written to, using the CLI values
- Currently, those arguments are optional. A future change will make them required. (though hopefully usually automatically inferred from export logs)
- When using the ndjson output format, you can no longer have any files in the output folder. This is to safeguard against accidents (and to make some code paths simpler)

This PR starts to address https://github.com/smart-on-fhir/cumulus-etl/issues/296 (Library side [here](https://github.com/smart-on-fhir/cumulus-library/pull/203))

**Future Plans**
This PR is just an preparatory, disabled-by-default step 1. These are bits of work that still have to be done to make this feature real (and required) across Cumulus.
- Parse export logs to autodetect arg values
- Require the new ETL args (from user, from log, or from our own export)
- Prevent overwriting new group data with old, to solve Epic use cases (check dates before deltalake write)
- Generate export logs from our own bulk export implementation, allowing us to parse it back later
- Backfill/migration support (maybe as simple as running `--group-name legacy --timestamp 2020` for all current encounters)
- Handle empty input sets - may require patching the bulk exporter to leave an empty file in those cases
- User docs

### Checklist
- [x] Consider if documentation (like in `docs/`) needs to be updated
- [x] Consider if tests should be added
