### PR TITLE
docs: fix AWS template to avoid confusing syntax

### DIFF
--- a/docs/setup/cumulus-aws-template.yaml
+++ b/docs/setup/cumulus-aws-template.yaml
@@ -152,8 +152,8 @@ Resources:
     Properties:
       CatalogId: !Ref AWS::AccountId
       DatabaseInput:
-        Name: 
-          Fn::Join: # replace hyphens with underscores for ease of SQL (hyphens are reserved)
+        # replace hyphens with underscores for ease of SQL (hyphens are reserved)
+        Name: !Join
           - '_'
           - Fn::Split:
             - '-'


### PR DESCRIPTION
Amazon's latest visual template editor doesn't like Fn::Join but does like !Join. So give it what it wants.

I tested this in the editor (no errors) and tested a deploy, to confirm it does the split and join.

### Checklist
- [x] Consider if documentation (like in `docs/`) needs to be updated
- [x] Consider if tests should be added
