### PR TITLE
fix: fix parsing of server timestamps when bulk exporting

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,7 +17,7 @@ RUN arch=$(arch | sed s/aarch64/arm64/ | sed s/x86_64/x64/) && \
   --output=/bin \
   /app/FHIR/src/Microsoft.Health.Fhir.Anonymizer.R4.CommandLineTool
 
-FROM python:3.10 AS cumulus-etl-test
+FROM python:3.11 AS cumulus-etl-test
 COPY --from=eclipse-temurin:17-jre /opt/java/openjdk /opt/java/openjdk
 COPY --from=ms-tool /bin/Microsoft.Health.Fhir.Anonymizer.R4.CommandLineTool /bin
 COPY . /app
@@ -29,7 +29,7 @@ ENV JAVA_HOME /opt/java/openjdk
 
 ENTRYPOINT ["cumulus-etl"]
 
-FROM python:3.10 AS cumulus-etl
+FROM python:3.11 AS cumulus-etl
 COPY --from=eclipse-temurin:17-jre /opt/java/openjdk /opt/java/openjdk
 COPY --from=ms-tool /bin/Microsoft.Health.Fhir.Anonymizer.R4.CommandLineTool /bin
 


### PR DESCRIPTION
By bumping the python in our docker images to 3.11, which has better fromisoformat() logic that can handle a "Z" suffix.

This does not yet bump our minimum Python version for the code itself, but most folks run the ETL via the docker image.


### Checklist
- [x] Consider if documentation (like in `docs/`) needs to be updated
- [x] Consider if tests should be added
