### PR TITLE
docker: depend on ctakes 1.1.1

### DIFF
--- a/compose.yaml
+++ b/compose.yaml
@@ -37,7 +37,7 @@ services:
       - etl-gpu
 
   ctakes-covid-base:
-    image: smartonfhir/ctakes-covid:1.1.0
+    image: smartonfhir/ctakes-covid:1.1.1
     environment:
       - ctakes_umlsuser=umls_api_key
       - ctakes_umlspw=$UMLS_API_KEY

--- a/cumulus_etl/__init__.py
+++ b/cumulus_etl/__init__.py
@@ -1,3 +1,3 @@
 """Cumulus public entry point"""
 
-__version__ = "1.1.0"
+__version__ = "1.1.1"

--- a/cumulus_etl/etl/studies/covid_symptom/covid_tasks.py
+++ b/cumulus_etl/etl/studies/covid_symptom/covid_tasks.py
@@ -83,7 +83,7 @@ class BaseCovidSymptomNlpResultsTask(tasks.BaseNlpTask):
     task_version = 4
     # Task Version History:
     # ** 4 (2024-01): Fixed bug preventing our cTAKES symptoms file from having any effect **
-    #   cTAKES: smartonfhir/ctakes-covid:1.1.0
+    #   cTAKES: smartonfhir/ctakes-covid:1.1.[01]
     #   cNLP: smartonfhir/cnlp-transformers:negation-0.6.1
     #   cNLP: smartonfhir/cnlp-transformers:termexists-0.6.1
     #   ctakesclient: 5.0


### PR DESCRIPTION
This hopefully fixes a race condition when restarting cTAKES as we feed it new bsv files.

Also bumped ETL's version to 1.1.1 (coincidentally the same :D)


### Checklist
- [x] Consider if documentation (like in `docs/`) needs to be updated
- [x] Consider if tests should be added
