### PR TITLE
Added reminder about updating docker images

### DIFF
--- a/docs/setup/sample-runs.md
+++ b/docs/setup/sample-runs.md
@@ -12,6 +12,9 @@ nav_order: 2
 This guide will explain how to install and run Cumulus ETL inside your hospital's infrastructure.
 It assumes you are familiar with the command line.
 
+If you're coming back to these docs after an update to the ETL on a machine you've run it on before,
+run `docker pull smartonfhir/cumulus-etl` before you start to get the latest ETL image.
+
 ## On-Premises Runs
 
 But first, a word about on-premises vs in-cloud runs of Cumulus ETL.


### PR DESCRIPTION
This updates the docs with a reminder about needing to explicitly pull an image if you're trying to run a new version of the ETL.

### Checklist
- [X] Consider if documentation (like in `docs/`) needs to be updated
- [X] Consider if tests should be added
