### PR TITLE
Disable context generator cleanup pylint warning

### DIFF
--- a/cumulus_etl/common.py
+++ b/cumulus_etl/common.py
@@ -153,12 +153,14 @@ def write_json(path: str, data: Any, indent: int = None) -> None:
 
 
 @contextlib.contextmanager
+# pylint: disable-next = contextmanager-generator-missing-cleanup
 def read_csv(path: str) -> csv.DictReader:
     # Python docs say to use newline="", to support quoted multi-line fields
     with _atomic_open(path, "r", newline="") as csvfile:
         yield csv.DictReader(csvfile)
 
 
+# pylint: disable-next = contextmanager-generator-missing-cleanup
 def read_ndjson(path: str) -> Iterator[dict]:
     """Yields parsed json from the input ndjson file, line-by-line."""
     with _atomic_open(path, "r") as f:

--- a/cumulus_etl/loaders/i2b2/extract.py
+++ b/cumulus_etl/loaders/i2b2/extract.py
@@ -7,6 +7,7 @@ from cumulus_etl import common
 from cumulus_etl.loaders.i2b2.schema import ObservationFact, PatientDimension, VisitDimension
 
 
+# pylint: disable-next = contextmanager-generator-missing-cleanup
 def extract_csv(path_csv: str) -> Iterator[dict]:
     """
     :param path_csv: /path/to/i2b2_formatted_file.csv


### PR DESCRIPTION
This PR disables the warning about context manager usage for the time being.

### Checklist
- [X] Consider if documentation (like in `docs/`) needs to be updated
- [X] Consider if tests should be added
