### PR TITLE
fix: allow the progress bars for reading ndjson to finish

### DIFF
--- a/cumulus_etl/common.py
+++ b/cumulus_etl/common.py
@@ -153,14 +153,12 @@ def write_json(path: str, data: Any, indent: int = None) -> None:
 
 
 @contextlib.contextmanager
-# pylint: disable-next = contextmanager-generator-missing-cleanup
 def read_csv(path: str) -> csv.DictReader:
     # Python docs say to use newline="", to support quoted multi-line fields
     with _atomic_open(path, "r", newline="") as csvfile:
         yield csv.DictReader(csvfile)
 
 
-# pylint: disable-next = contextmanager-generator-missing-cleanup
 def read_ndjson(path: str) -> Iterator[dict]:
     """Yields parsed json from the input ndjson file, line-by-line."""
     with _atomic_open(path, "r") as f:
@@ -237,7 +235,7 @@ def read_local_line_count(path) -> int:
         bufgen = itertools.takewhile(lambda x: x, (f.raw.read(1024 * 1024) for _ in itertools.repeat(None)))
         for buf in bufgen:
             count += buf.count(b"\n")
-    if buf and buf[-1] != "\n":  # catch a final line without a trailing newline
+    if buf and buf[-1] != ord("\n"):  # catch a final line without a trailing newline
         count += 1
     return count
 

--- a/cumulus_etl/formats/deltalake.py
+++ b/cumulus_etl/formats/deltalake.py
@@ -77,6 +77,8 @@ class DeltaLakeFormat(Format):
             cls.spark = delta.configure_spark_with_delta_pip(
                 builder,
                 extra_packages=[
+                    # See https://docs.delta.io/latest/delta-storage.html for advice
+                    # on which version of hadoop-aws to use.
                     "org.apache.hadoop:hadoop-aws:3.3.4",
                 ],
             ).getOrCreate()

--- a/cumulus_etl/loaders/i2b2/extract.py
+++ b/cumulus_etl/loaders/i2b2/extract.py
@@ -7,7 +7,6 @@ from cumulus_etl import common
 from cumulus_etl.loaders.i2b2.schema import ObservationFact, PatientDimension, VisitDimension
 
 
-# pylint: disable-next = contextmanager-generator-missing-cleanup
 def extract_csv(path_csv: str) -> Iterator[dict]:
     """
     :param path_csv: /path/to/i2b2_formatted_file.csv

--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -152,3 +152,15 @@ class TestIOUtils(s3mock.S3Mixin, utils.AsyncTestCase):
             result = read(f"{directory}/file.txt")
 
         self.assertEqual(data, result)
+
+    @ddt.data(
+        ("1", 1),
+        ("1\n2\n", 2),
+        ("1\r\n2\r\n3\r\n", 3),
+    )
+    @ddt.unpack
+    def test_read_local_line_count(self, contents, expected_length):
+        with tempfile.NamedTemporaryFile() as tmpfile:
+            common.write_text(tmpfile.name, contents)
+            found_length = common.read_local_line_count(tmpfile.name)
+        self.assertEqual(expected_length, found_length)


### PR DESCRIPTION
There was an off by one error if the last character of the ndjson file was a newline. This prevented some "reading" progress bars from every appearing finished.

This was just cosmetic though - all data was read.


### Checklist
- [x] Consider if documentation (like in `docs/`) needs to be updated
- [x] Consider if tests should be added
