### PR TITLE
Enable liquid clustering for delta lakes

### DIFF
--- a/cumulus_etl/__init__.py
+++ b/cumulus_etl/__init__.py
@@ -1,3 +1,3 @@
 """Turns FHIR data into de-identified & aggregated records"""
 
-__version__ = "1.3.0"
+__version__ = "1.4.0"

--- a/cumulus_etl/formats/deltalake.py
+++ b/cumulus_etl/formats/deltalake.py
@@ -101,6 +101,7 @@ class DeltaLakeFormat(Format):
         table = (
             delta.DeltaTable.createIfNotExists(self.spark)
             .addColumns(updates.schema)
+            .clusterBy(*self.uniqueness_fields)
             .location(self._table_path(self.dbname))
             .execute()
         )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,7 @@ requires-python = ">= 3.10"
 dependencies = [
     "ctakesclient >= 5.1, < 6",
     "cumulus-fhir-support >= 1.2, < 2",
-    "delta-spark >= 3, < 4",
+    "delta-spark >= 3.2.1, < 4",
     "httpx < 1",
     "inscriptis < 3",
     "jwcrypto < 2",

--- a/tests/etl/test_etl_cli.py
+++ b/tests/etl/test_etl_cli.py
@@ -410,20 +410,24 @@ class TestEtlFormats(BaseEtlSimple):
                 "_delta_log/.00000000000000000000.json.crc",
                 "_delta_log/00000000000000000001.json",  # merge
                 "_delta_log/.00000000000000000001.json.crc",
-                "_delta_log/00000000000000000002.json",  # vacuum start
+                "_delta_log/00000000000000000002.json",  # optimize
                 "_delta_log/.00000000000000000002.json.crc",
-                "_delta_log/00000000000000000003.json",  # vacuum end
+                "_delta_log/00000000000000000003.json",  # vacuum start
                 "_delta_log/.00000000000000000003.json.crc",
+                "_delta_log/00000000000000000004.json",  # vacuum end
+                "_delta_log/.00000000000000000004.json.crc",
                 "_symlink_format_manifest/manifest",
                 "_symlink_format_manifest/.manifest.crc",
             },
             metadata_files,
         )
 
-        self.assertEqual(1, len(data_files))
+        # Expect two data files - one will be original (now marked as deleted from optimize call)
+        # and the other will be the new optimized file.
+        self.assertEqual(2, len(data_files))
         self.assertRegex(data_files.pop(), r"part-00000-.*-c000.snappy.parquet")
 
-        self.assertEqual(1, len(data_crc_files))
+        self.assertEqual(2, len(data_crc_files))
         self.assertRegex(data_crc_files.pop(), r".part-00000-.*-c000.snappy.parquet.crc")
 
 


### PR DESCRIPTION
In practice, for most of our big raw tables, this will involve clustering on a single column: `id`, in which case Delta Lake falls back to a very simple ZORDER algorithm (making sure that the data files are ordered by `id`, to make looking up via `id` easy) -- which is still good, just not as sleek and cool as the full "liquid clustering" algorithm.

But it's still good to do for two reasons:
- This new paradigm is apparently the future of Delta Lake optimization, replacing normal ZORDER and partitioning. And you can't convert an existing table to it. So if we start creating clustered tables now, even if it's secretly just a ZORDER, we can benefit from future improvements to the algorithm and/or add more clustering columns if we want to.
- There are a few tables that *do* cluster by multiple columns and thus benefit from the cool liquid clustering logic - namely the completion tables. Those tables don't get crazy large anyway, but still - one of them scales with the number of encounters, so that's not chump change.

Delta Lake Protocol Notes:
- This bumps the delta lake writer protocol to 7 but keeps the reader protocol at 1 - this means Athena can keep reading these tables (I tested that). But it does mean that _very_ old versions of the ETL might not be able to write to these tables. Since we don't expect multiple ETL installations to be pointing at the same delta lakes often (usually just one engineer is doing that), because you have to create a table first before this becomes a problem, and because you'd need a truly ancient ETL, I'm not worried about this.

### Checklist
- [x] Consider if documentation (like in `docs/`) needs to be updated
- [x] Consider if tests should be added
