### PR TITLE
deltalake: refactor a bit for cleaner update flow

### DIFF
--- a/tests/etl/test_etl_cli.py
+++ b/tests/etl/test_etl_cli.py
@@ -308,7 +308,8 @@ class TestEtlFormats(BaseEtlSimple):
         self.assert_output_equal()
 
     async def test_etl_job_deltalake(self):
-        await self.run_etl(output_format=None)  # deltalake should be default output format
+        # deltalake should be default output format, so pass in None to test that
+        await self.run_etl(output_format=None, tasks=["condition"])
 
         # Just test that the files got created, for a single table.
 
@@ -329,12 +330,14 @@ class TestEtlFormats(BaseEtlSimple):
         # Check metadata files (these have consistent names)
         self.assertEqual(
             {
-                "_delta_log/00000000000000000000.json",  # write
+                "_delta_log/00000000000000000000.json",  # create
                 "_delta_log/.00000000000000000000.json.crc",
-                "_delta_log/00000000000000000001.json",  # vacuum start
+                "_delta_log/00000000000000000001.json",  # merge
                 "_delta_log/.00000000000000000001.json.crc",
-                "_delta_log/00000000000000000002.json",  # vacuum end
+                "_delta_log/00000000000000000002.json",  # vacuum start
                 "_delta_log/.00000000000000000002.json.crc",
+                "_delta_log/00000000000000000003.json",  # vacuum end
+                "_delta_log/.00000000000000000003.json.crc",
                 "_symlink_format_manifest/manifest",
                 "_symlink_format_manifest/.manifest.crc",
             },


### PR DESCRIPTION
This should have no functional change right now.

Just goes from a flow like "try to update and if we get a missing table error, create the table (using spark code)" to a flow like "create table if missing (using delta lake code), then update that table"

I'm only interested in this little refactor because it will make future changes to table creation easier if we are already using the DeltaTable class to create the table (changes like adding cluster-by columns for liquid clustering).

### Checklist
- [ ] Consider if documentation (like in `docs/`) needs to be updated
- [ ] Consider if tests should be added