### PR TITLE
feat: switch to cumulus-fhir-support's ndjson reading code

### DIFF
--- a/cumulus_etl/etl/convert/cli.py
+++ b/cumulus_etl/etl/convert/cli.py
@@ -19,6 +19,7 @@ from cumulus_etl.etl.tasks import task_factory
 
 
 def make_batch(
+    root: store.Root,
     path: str,
     schema_func: Callable[[list[dict]], pyarrow.Schema],
 ) -> formats.Batch:
@@ -28,7 +29,7 @@ def make_batch(
     except FileNotFoundError:
         metadata = {}
 
-    rows = list(common.read_ndjson(path))
+    rows = list(common.read_ndjson(root, path))
     groups = set(metadata.get("groups", []))
     schema = schema_func(rows)
 
@@ -61,7 +62,7 @@ def convert_folder(
     progress_task = progress.add_task(table_name, total=count)
 
     for ndjson_path in ndjson_paths:
-        batch = make_batch(ndjson_path, schema_func)
+        batch = make_batch(input_root, ndjson_path, schema_func)
         formatter.write_records(batch)
         progress.update(progress_task, advance=1)
 

--- a/cumulus_etl/etl/tasks/base.py
+++ b/cumulus_etl/etl/tasks/base.py
@@ -324,8 +324,6 @@ class EtlTask:
     def read_ndjson(self, *, progress: rich.progress.Progress = None) -> Iterator[dict]:
         """
         Grabs all ndjson files from a folder, of a particular resource type.
-
-        Supports filenames like Condition.ndjson, Condition.000.ndjson, or 1.Condition.ndjson.
         """
         input_root = store.Root(self.task_config.dir_input)
 
@@ -334,7 +332,7 @@ class EtlTask:
             row_task = progress.add_task("Reading", total=None)
 
             # Find total number of lines
-            filenames = common.ls_resources(input_root, self.resource)
+            filenames = common.ls_resources(input_root, {self.resource})
             total = sum(common.read_local_line_count(filename) for filename in filenames)
             progress.update(row_task, total=total, visible=bool(total))
 

--- a/cumulus_etl/loaders/fhir/export_log.py
+++ b/cumulus_etl/loaders/fhir/export_log.py
@@ -42,21 +42,21 @@ class BulkExportLogParser:
         self.group_name: str = None
         self.export_datetime: datetime.datetime = None
 
-        self._parse(self._find(root))
+        self._parse(root, self._find(root))
 
-    def _parse(self, path: str) -> None:
+    def _parse(self, root: store.Root, path: str) -> None:
         # Go through every row, looking for the events we care about.
         # Note that we parse every kickoff event we hit, for example.
         # So we'll end up with the latest one (which works for single-export
         # log files with maybe a false start at the beginning).
         try:
-            for row in common.read_ndjson(path):
+            for row in common.read_ndjson(root, path):
                 match row.get("eventId"):
                     case "kickoff":
                         self._parse_kickoff(row)
                     case "status_complete":
                         self._parse_status_complete(row)
-        except (KeyError, json.JSONDecodeError) as exc:
+        except KeyError as exc:
             raise self.IncompleteLog(f"Error parsing '{path}'") from exc
 
         if self.group_name is None:

--- a/cumulus_etl/loaders/fhir/ndjson_loader.py
+++ b/cumulus_etl/loaders/fhir/ndjson_loader.py
@@ -11,9 +11,6 @@ from cumulus_etl.loaders.fhir.export_log import BulkExportLogParser
 class FhirNdjsonLoader(base.Loader):
     """
     Loader for fhir ndjson data, either locally or from a FHIR server.
-
-    Expected local-folder format is a folder with ndjson files labeled by resource type.
-    (i.e. Condition.000.ndjson or Condition.ndjson)
     """
 
     def __init__(
@@ -70,10 +67,9 @@ class FhirNdjsonLoader(base.Loader):
         # TemporaryDirectory gets discarded), but that seems reasonable.
         print("Copying ndjson input files…")
         tmpdir = tempfile.TemporaryDirectory()  # pylint: disable=consider-using-with
-        for resource in resources:
-            filenames = common.ls_resources(input_root, resource, warn_if_empty=True)
-            for filename in filenames:
-                input_root.get(filename, f"{tmpdir.name}/")
+        filenames = common.ls_resources(input_root, set(resources), warn_if_empty=True)
+        for filename in filenames:
+            input_root.get(filename, f"{tmpdir.name}/")
         return tmpdir
 
     async def _load_from_bulk_export(self, resources: list[str]) -> common.Directory:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ requires-python = ">= 3.10"
 # to fix any breakages since users won't immediately see the problem).
 dependencies = [
     "ctakesclient >= 5.1, < 6",
-    "cumulus-fhir-support >= 1, < 2",
+    "cumulus-fhir-support >= 1.2, < 2",
     "delta-spark >= 3, < 4",
     "httpx < 1",
     "inscriptis < 3",

--- a/tests/etl/base.py
+++ b/tests/etl/base.py
@@ -118,6 +118,7 @@ class TaskTestCase(utils.AsyncTestCase):
         self.errors_dir = os.path.join(self.tmpdir, "errors")
         os.makedirs(self.input_dir)
         os.makedirs(self.phi_dir)
+        self.json_file_count = 0
 
         self.job_config = JobConfig(
             self.input_dir,
@@ -161,7 +162,9 @@ class TaskTestCase(utils.AsyncTestCase):
         # Keeps consistent IDs
         shutil.copy(os.path.join(self.datadir, "simple/codebook.json"), self.phi_dir)
 
-    def make_json(self, filename, resource_id, **kwargs):
+    def make_json(self, resource_type, resource_id, **kwargs):
+        self.json_file_count += 1
+        filename = f"{self.json_file_count}.ndjson"
         common.write_json(
-            os.path.join(self.input_dir, f"{filename}.ndjson"), {"resourceType": "Test", **kwargs, "id": resource_id}
+            os.path.join(self.input_dir, filename), {"resourceType": resource_type, **kwargs, "id": resource_id}
         )

--- a/tests/etl/test_etl_cli.py
+++ b/tests/etl/test_etl_cli.py
@@ -8,6 +8,7 @@ import shutil
 import tempfile
 from unittest import mock
 
+import cumulus_fhir_support
 import ddt
 import respx
 from ctakesclient.typesystem import Polarity
@@ -66,7 +67,7 @@ class TestEtlJobFlow(BaseEtlSimple):
 
             # Run a couple checks to ensure that we do indeed have PHI in this dir
             self.assertIn("Patient.ndjson", os.listdir(phi_dir))
-            patients = list(common.read_ndjson(os.path.join(phi_dir, "Patient.ndjson")))
+            patients = list(cumulus_fhir_support.read_multiline_json(os.path.join(phi_dir, "Patient.ndjson")))
             first = patients[0]
             self.assertEqual("02139", first["address"][0]["postalCode"])
 

--- a/tests/loaders/ndjson/test_bulk_export.py
+++ b/tests/loaders/ndjson/test_bulk_export.py
@@ -6,6 +6,7 @@ import io
 import tempfile
 from unittest import mock
 
+import cumulus_fhir_support
 import ddt
 import respx
 
@@ -35,7 +36,7 @@ class TestBulkExporter(utils.AsyncTestCase, utils.FhirClientMixin):
             await self.exporter.export()
 
     def assert_log_equals(self, *rows) -> None:
-        found_rows = list(common.read_ndjson(f"{self.tmpdir}/log.ndjson"))
+        found_rows = list(cumulus_fhir_support.read_multiline_json(f"{self.tmpdir}/log.ndjson"))
 
         # Do we use the same export ID throughout?
         all_export_ids = {x["exportId"] for x in found_rows}

--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -9,7 +9,7 @@ import ddt
 import fsspec
 import s3fs
 
-from cumulus_etl import common, store
+from cumulus_etl import common
 from tests import s3mock, utils
 
 
@@ -40,39 +40,6 @@ class TestLogging(utils.AsyncTestCase):
     def test_human_time_offset(self, seconds, expected_str):
         """Verify human_time_offset works correctly"""
         self.assertEqual(expected_str, common.human_time_offset(seconds))
-
-
-class TestListingUtils(utils.AsyncTestCase):
-    """Tests for our resource listing methods."""
-
-    def test_ls_resources_pattern(self):
-        included = [
-            "1.Patient.ndjson",  # bulk-data-client format
-            "Patient.1.ndjson",  # cumulus-etl format
-            "Patient.ndjson",
-            "1.Patient.2.ndjson",
-            "1.Patient.since.2020.10.02.ndjson",  # we ignore anything between resource name and file type
-        ]
-        excluded = [
-            "Condition.1.ndjson",  # wrong resource
-            "MyPatient.ndjson",
-            "1-Patient.ndjson",
-            "Patient-ndjson",
-            "Patient.json",
-            "My.Patient.ndjson",  # only numeric prefixes allowed (not a necessary restriction, but not onerous)
-        ]
-        all_paths = included + excluded
-
-        # Just create each file as an empty one
-        with tempfile.TemporaryDirectory() as tmpdir:
-            for path in all_paths:
-                with open(f"{tmpdir}/{path}", "w", encoding="utf8"):
-                    pass
-
-            resource_paths = common.ls_resources(store.Root(tmpdir), "Patient")
-
-        expected_paths = [f"{tmpdir}/{x}" for x in sorted(included)]
-        self.assertListEqual(expected_paths, resource_paths)
 
 
 @ddt.ddt

--- a/tests/test_store.py
+++ b/tests/test_store.py
@@ -14,15 +14,6 @@ class TestRoot(AsyncTestCase):
         super().setUp()
         self.fs_mock = self.patch("cumulus_etl.store.fsspec.filesystem")()
 
-    @ddt.data(
-        # root, ls return, expected value
-        ("s3://bucket", ["bucket/file.txt"], ["s3://bucket/file.txt"]),  # standard prefixing
-        ("s3://bucket", ["s3://bucket/file.txt"], ["s3://bucket/file.txt"]),  # we won't double-prefix
-        ("/local/path", ["bucket/file.txt"], ["bucket/file.txt"]),  # we'll leave local paths alone
-        ("s3://bucket", [], []),  # we'll gracefully handle empty lists
-    )
-    @ddt.unpack
-    def test_ls_guaranteed_prefix(self, root_path, ls_return, expected):
-        """Verify that we correctly guarantee that ls() filenames will have a protocol prefix"""
-        self.fs_mock.ls.return_value = ls_return
-        self.assertEqual(expected, store.Root(root_path).ls())
+    def test_file_protocol(self):
+        """Verify that we set a protocol of file:// for local paths"""
+        self.assertEqual("file", store.Root("/").protocol)

--- a/tests/upload_notes/test_upload_cli.py
+++ b/tests/upload_notes/test_upload_cli.py
@@ -8,6 +8,7 @@ import tempfile
 from collections.abc import Iterable
 from unittest import mock
 
+import cumulus_fhir_support
 import ddt
 import respx
 
@@ -178,7 +179,7 @@ class TestUploadNotes(CtakesMixin, AsyncTestCase):
             f.write("\n".join(lines))
 
     def get_exported_ids(self) -> set[str]:
-        rows = common.read_ndjson(f"{self.export_path}/DocumentReference.ndjson")
+        rows = cumulus_fhir_support.read_multiline_json(f"{self.export_path}/DocumentReference.ndjson")
         return {row["id"] for row in rows}
 
     def get_pushed_ids(self) -> set[str]:


### PR DESCRIPTION
- We now load any ndjson files that cumulus-fhir-support says to.
- Root classes no longer adjust filenames from ls() -- that was a hack to solve the fact that we often looked up the right filesystem to use for a given path by examining the path - we are now more careful about passing a filesystem object around with the path.

Depends on https://github.com/smart-on-fhir/cumulus-fhir-support/pull/3

### Checklist
- [x] Consider if documentation (like in `docs/`) needs to be updated
- [x] Consider if tests should be added
