### PR TITLE
build: bump label-studio-sdk dependency to 1.x

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,7 @@ dependencies = [
     "httpx < 1",
     "inscriptis < 3",
     "jwcrypto < 2",
-    "label-studio-sdk < 1",
+    "label-studio-sdk < 2",
     "oracledb < 3",
     "philter-lite < 1",
     "pyarrow < 17",


### PR DESCRIPTION
I've manually tested that we can still upload notes just fine. Their release docs for 1.0 say the API we use shouldn't be impacted (though there were breaking changes on other API).

### Checklist
- [x] Consider if documentation (like in `docs/`) needs to be updated
- [x] Consider if tests should be added
