### PR TITLE
docs: add completion tables in our AWS template

### DIFF
--- a/docs/setup/cumulus-aws-template.yaml
+++ b/docs/setup/cumulus-aws-template.yaml
@@ -198,6 +198,8 @@ Resources:
               - !Sub "s3://${S3Bucket}/${EtlSubdir}/servicerequest"
               - !Sub "s3://${S3Bucket}/${EtlSubdir}/covid_symptom__nlp_results"
               - !Sub "s3://${S3Bucket}/${EtlSubdir}/covid_symptom__nlp_results_term_exists"
+              - !Sub "s3://${S3Bucket}/${EtlSubdir}/etl__completion"
+              - !Sub "s3://${S3Bucket}/${EtlSubdir}/etl__completion_encounters"
             CreateNativeDeltaTable: True
             WriteManifest: False
 


### PR DESCRIPTION
These aren't necessarily used, but it's lightly helpful to have them already in place if you want to experiment with the completion tracking feature (--write-completion)


### Checklist
- [x] Consider if documentation (like in `docs/`) needs to be updated
- [x] Consider if tests should be added
