### PR TITLE
ci: add a coverage check at end of unit tests

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -19,21 +19,21 @@ jobs:
     runs-on: ubuntu-22.04
     strategy:
       matrix:
-        # while we are still private, don't go crazy with the Python versions as they eat up CI minutes
+        # Don't go crazy with the Python versions as the test suite is a beast.
+        # Just test the minimum version we support.
         python-version: ["3.10"]
 
     steps:
       - uses: actions/checkout@v4
 
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
 
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install pytest
           pip install .[tests]
 
       - name: Check out MS tool
@@ -55,7 +55,17 @@ jobs:
 
       - name: Test with pytest
         run: |
-          python -m pytest
+          python -m pytest --cov=cumulus_etl --cov-report=xml
+
+      - name: Check coverage report
+        if: github.ref != 'refs/heads/main'
+        uses: orgoro/coverage@v3.1
+        with:
+          coverageFile: coverage.xml
+          token: ${{ secrets.GITHUB_TOKEN }}
+          thresholdAll: .93
+          thresholdNew: 1
+          thresholdModified: 1
 
   nlp-regression:
     runs-on: ubuntu-latest
@@ -99,15 +109,14 @@ jobs:
           echo "All Good!"
 
   lint:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
 
       - name: Install linters
-        # black is synced with the .pre-commit-hooks version
         run: |
           python -m pip install --upgrade pip
-          pip install bandit[toml] pycodestyle pylint 'black >= 24, < 25'
+          pip install .[dev]
 
       - name: Run pycodestyle
         # E203: pycodestyle is a little too rigid about slices & whitespace

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,7 +1,6 @@
 repos:
   - repo: https://github.com/psf/black
-    # this version is synced with the black mentioned in .github/workflows/ci.yml
-    rev: 24.3.0
+    rev: 24.4.2  # keep in rough sync with pyproject.toml
     hooks:
       - id: black
         entry: bash -c 'black "$@"; git add -u' --

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -71,10 +71,14 @@ tests = [
     "ddt",
     "moto[server,s3] >= 5.0",
     "pytest",
+    "pytest-cov",
     "respx",
     "time-machine",
 ]
 dev = [
-    "black >= 24, < 25",
-    "pre-commit"
+    "bandit[toml]",
+    "black >= 24, < 25",  # keep in rough sync with .pre-commit-config.yaml
+    "pre-commit",
+    "pycodestyle",
+    "pylint",
 ]


### PR DESCRIPTION
It's currently set to require all new & modified code to be fully covered. And to allow the current coverage score of 93% in general.

Let's see how annoying this is. :smile:

### Checklist
- [x] Consider if documentation (like in `docs/`) needs to be updated
- [x] Consider if tests should be added
