### PR TITLE
feat: add new "cumulus-etl export" command for bulk exporting

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -57,13 +57,17 @@ jobs:
         run: |
           python -m pytest --cov=cumulus_etl --cov-report=xml
 
+      - name: Log missing coverage
+        run: |
+          coverage report -m --skip-covered
+
       - name: Check coverage report
         if: github.ref != 'refs/heads/main'
-        uses: orgoro/coverage@v3.1
+        uses: orgoro/coverage@v3.2
         with:
           coverageFile: coverage.xml
           token: ${{ secrets.GITHUB_TOKEN }}
-          thresholdAll: .93
+          thresholdAll: .97
           thresholdNew: 1
           thresholdModified: 1
 

--- a/cumulus_etl/__init__.py
+++ b/cumulus_etl/__init__.py
@@ -1,3 +1,3 @@
-"""Cumulus public entry point"""
+"""Turns FHIR data into de-identified & aggregated records"""
 
-__version__ = "1.1.1"
+__version__ = "1.2.0"

--- a/cumulus_etl/cli.py
+++ b/cumulus_etl/cli.py
@@ -9,7 +9,7 @@ import tempfile
 
 import rich.logging
 
-from cumulus_etl import common, etl, upload_notes
+from cumulus_etl import common, etl, export, upload_notes
 from cumulus_etl.etl import convert
 
 
@@ -22,6 +22,7 @@ class Command(enum.Enum):
     CHART_REVIEW = "chart-review"
     CONVERT = "convert"
     ETL = "etl"
+    EXPORT = "export"
     UPLOAD_NOTES = "upload-notes"
 
     # Why isn't this part of Enum directly...?
@@ -67,12 +68,15 @@ async def main(argv: list[str]) -> None:
         run_method = upload_notes.run_upload_notes
     elif subcommand == Command.CONVERT.value:
         run_method = convert.run_convert
+    elif subcommand == Command.EXPORT.value:
+        run_method = export.run_export
     else:
         parser.description = "Extract, transform, and load FHIR data."
         if not subcommand:
             # Add a note about other subcommands we offer, and tell argparse not to wrap our formatting
             parser.formatter_class = argparse.RawDescriptionHelpFormatter
-            parser.description += "\n\nother commands available:\n  convert\n  upload-notes"
+            parser.description += "\n\nother commands available:\n"
+            parser.description += "  convert\n  export\n  upload-notes"
         run_method = etl.run_etl
 
     with tempfile.TemporaryDirectory() as tempdir:

--- a/cumulus_etl/errors.py
+++ b/cumulus_etl/errors.py
@@ -33,6 +33,7 @@ LABEL_STUDIO_MISSING = 31
 FHIR_AUTH_FAILED = 32
 SERVICE_MISSING = 33  # generic init-check service is missing
 COMPLETION_ARG_MISSING = 34
+TASK_HELP = 35
 
 
 class FatalError(Exception):

--- a/cumulus_etl/export/__init__.py
+++ b/cumulus_etl/export/__init__.py
@@ -1,0 +1,3 @@
+"""Bulk export"""
+
+from .cli import run_export

--- a/cumulus_etl/export/cli.py
+++ b/cumulus_etl/export/cli.py
@@ -1,0 +1,49 @@
+"""Do a standalone bulk export from an EHR"""
+
+import argparse
+
+from cumulus_etl import cli_utils, fhir, loaders, store
+from cumulus_etl.etl.tasks import task_factory
+
+
+def define_export_parser(parser: argparse.ArgumentParser) -> None:
+    parser.usage = "cumulus-etl export [OPTION]... FHIR_URL DIR"
+
+    parser.add_argument("url_input", metavar="https://fhir.example.com/Group/ABC")
+    parser.add_argument("export_to", metavar="/path/to/output")
+    cli_utils.add_bulk_export(parser, as_subgroup=False)
+
+    cli_utils.add_auth(parser, use_fhir_url=False)
+    cli_utils.add_task_selection(parser)
+
+
+async def export_main(args: argparse.Namespace) -> None:
+    """Exports data from an EHR to a folder."""
+    # record filesystem options before creating Roots
+    store.set_user_fs_options(vars(args))
+
+    selected_tasks = task_factory.get_selected_tasks(args.task, args.task_filter)
+    required_resources = {t.resource for t in selected_tasks}
+    using_default_tasks = not args.task and not args.task_filter
+
+    fhir_root = store.Root(args.url_input)
+    client = fhir.create_fhir_client_for_cli(args, fhir_root, required_resources)
+
+    async with client:
+        loader = loaders.FhirNdjsonLoader(
+            fhir_root,
+            client=client,
+            export_to=args.export_to,
+            since=args.since,
+            until=args.until,
+        )
+        await loader.load_from_bulk_export(
+            sorted(required_resources), prefer_url_resources=using_default_tasks
+        )
+
+
+async def run_export(parser: argparse.ArgumentParser, argv: list[str]) -> None:
+    """Parses an export CLI"""
+    define_export_parser(parser)
+    args = parser.parse_args(argv)
+    await export_main(args)

--- a/cumulus_etl/fhir/fhir_client.py
+++ b/cumulus_etl/fhir/fhir_client.py
@@ -247,9 +247,9 @@ def create_fhir_client_for_cli(
 
     The usual FHIR server authentication options should be represented in args.
     """
-    client_base_url = args.fhir_url
+    client_base_url = getattr(args, "fhir_url", None)
     if root_input.protocol in {"http", "https"}:
-        if args.fhir_url and not root_input.path.startswith(args.fhir_url):
+        if client_base_url and not root_input.path.startswith(client_base_url):
             print(
                 "You provided both an input FHIR server and a different --fhir-url. Try dropping --fhir-url.",
                 file=sys.stderr,

--- a/cumulus_etl/loaders/fhir/export_log.py
+++ b/cumulus_etl/loaders/fhir/export_log.py
@@ -172,8 +172,15 @@ class BulkExportLogWriter:
         software = capabilities.get("software", {})
         response_info = {}
 
+        # Create a "merged" version of the params.
+        # (Merged in the sense that duplicates are converted to comma separated lists.)
+        request_headers = {}
+        for k, v in httpx.URL(url).params.multi_items():
+            if k in request_headers:
+                request_headers[k] += f",{v}"
+            else:
+                request_headers[k] = v
         # Spec says we shouldn't log the `patient` parameter, so strip it here.
-        request_headers = dict(httpx.URL(url).params)
         request_headers.pop("patient", None)
 
         if isinstance(response, Exception):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,6 @@ authors = [
   { name="Andy McMurry, PhD", email="andrew.mcmurry@childrens.harvard.edu" },
   { name="Michael Terry", email="michael.terry@childrens.harvard.edu" },
 ]
-description = "Turns FHIR data into de-identified & aggregated records"
 readme = "README.md"
 license = { text="Apache License 2.0" }
 classifiers = [
@@ -37,7 +36,7 @@ classifiers = [
     "Programming Language :: Python :: 3",
     "Topic :: Software Development :: Libraries :: Python Modules",
 ]
-dynamic = ["version"]
+dynamic = ["description", "version"]
 
 [project.optional-dependencies]
 tests = [

--- a/tests/etl/test_etl_cli.py
+++ b/tests/etl/test_etl_cli.py
@@ -87,6 +87,11 @@ class TestEtlJobFlow(BaseEtlSimple):
             await self.run_etl(tasks=["blarg"])
         self.assertEqual(errors.TASK_UNKNOWN, cm.exception.code)
 
+    async def test_help_task(self):
+        with self.assertRaises(SystemExit) as cm:
+            await self.run_etl(tasks=["patient", "help"])
+        self.assertEqual(errors.TASK_HELP, cm.exception.code)
+
     async def test_failed_task(self):
         # Make it so any writes will fail
         with mock.patch(
@@ -193,6 +198,12 @@ class TestEtlJobFlow(BaseEtlSimple):
         with self.assertRaises(SystemExit) as cm:
             await self.run_etl(input_path="https://localhost:12345/", tasks=["patient"])
         self.assertEqual(errors.BULK_EXPORT_FAILED, cm.exception.code)
+
+    async def test_bulk_no_url(self):
+        """Verify that if no FHIR URL is provided, but export args *are*, we'll error out."""
+        with self.assertRaises(SystemExit) as cm:
+            await self.run_etl(export_to="output/dir")
+        self.assertEqual(errors.ARGS_CONFLICT, cm.exception.code)
 
     async def test_no_ms_tool(self):
         """Verify that we require the MS tool to be in PATH."""

--- a/tests/export/test_export_cli.py
+++ b/tests/export/test_export_cli.py
@@ -1,0 +1,78 @@
+"""Tests for export/cli.py"""
+
+from unittest import mock
+
+import ddt
+
+from cumulus_etl import cli
+from cumulus_etl.etl.tasks.task_factory import get_default_tasks
+from tests.utils import AsyncTestCase
+
+
+@ddt.ddt
+class TestExportCLI(AsyncTestCase):
+    """Tests for high-level export support."""
+
+    def setUp(self):
+        super().setUp()
+        self.loader_mock = mock.AsyncMock()
+        self.loader_init_mock = self.patch(
+            "cumulus_etl.loaders.FhirNdjsonLoader", return_value=self.loader_mock
+        )
+        self.client_mock = self.patch("cumulus_etl.fhir.create_fhir_client_for_cli")
+
+    async def run_export(self, *args) -> None:
+        await cli.main(["export", "https://example.com", "fake/path", *args])
+
+    @ddt.data(
+        ([], True),
+        (["--task=patient"], False),
+        (["--task-filter=gpu"], False),
+    )
+    @ddt.unpack
+    async def test_prefer_url_resources(self, args, expected_prefer):
+        """Verify that if no task filtering is done, we flag to prefer the url's _type"""
+        await self.run_export(*args)
+        self.assertEqual(
+            expected_prefer,
+            self.loader_mock.load_from_bulk_export.call_args.kwargs["prefer_url_resources"],
+        )
+
+    @ddt.data(
+        ([], ["*default*"]),  # special value that the test will expand
+        (["--task=patient,condition"], ["Condition", "Patient"]),
+        (["--task-filter=covid_symptom"], ["DocumentReference"]),
+    )
+    @ddt.unpack
+    async def test_task_selection(self, args, expected_resources):
+        """Verify that we do the expected task filtering as requested"""
+        await self.run_export(*args)
+        if expected_resources == ["*default*"]:
+            expected_resources = sorted(t.resource for t in get_default_tasks())
+        self.assertEqual(
+            expected_resources,
+            self.loader_mock.load_from_bulk_export.call_args.args[0],
+        )
+
+    async def test_arg_passthrough(self):
+        """Verify that we accept and send down all our different args"""
+        await self.run_export(
+            "--since=1920",
+            "--until=1923",
+            "--smart-client-id=ID",
+            "--smart-jwks=jwks.json",
+            "--basic-user=alice",
+            "--basic-passwd=passwd.txt",
+            "--bearer-token=token.txt",
+        )
+        # built-in positional args
+        self.assertEqual("https://example.com", self.loader_init_mock.call_args.args[0].path)
+        self.assertEqual("fake/path", self.loader_init_mock.call_args.kwargs["export_to"])
+        # custom args from above
+        self.assertEqual("1920", self.loader_init_mock.call_args.kwargs["since"])
+        self.assertEqual("1923", self.loader_init_mock.call_args.kwargs["until"])
+        self.assertEqual("ID", self.client_mock.call_args.args[0].smart_client_id)
+        self.assertEqual("jwks.json", self.client_mock.call_args.args[0].smart_jwks)
+        self.assertEqual("alice", self.client_mock.call_args.args[0].basic_user)
+        self.assertEqual("passwd.txt", self.client_mock.call_args.args[0].basic_passwd)
+        self.assertEqual("token.txt", self.client_mock.call_args.args[0].bearer_token)


### PR DESCRIPTION
This new command is quite simple. It just takes a URL and an output folder. The usual auth and export args (like --since) are accepted.

You can also filter exported resources by task with --task.

But even if you don't use --since or --task, you can provide an export URL that has _since, _type, _typeFilter, whatever you want.

In addition:
- "--task=help" will now print a list of task names and exit.
- The traditional way to kick off a bulk export when doing an ETL job (by providing a URL as the input path) now also lets you specify custom parameters like _since or _typeFilter directly in the URL.
- Handle non-compliant servers that give us transactionTime values that aren't formatted correctly (as bulk-data-server does).

### Checklist
- [x] Consider if documentation (like in `docs/`) needs to be updated
- [x] Consider if tests should be added
