### PR TITLE
Retry bulk export requests that yield 5xx server errors

### DIFF
--- a/cumulus_etl/fhir/fhir_client.py
+++ b/cumulus_etl/fhir/fhir_client.py
@@ -91,12 +91,14 @@ class FhirClient:
         """
         Issues an HTTP request.
 
-        The default Accept type is application/fhir+json, but can be overridden by a provided header.
+        The default Accept type is application/fhir+json, but can be overridden by a provided
+        header.
 
-        This is a lightly modified version of FHIRServer._get(), but additionally supports streaming and
-        reauthorization.
+        This is a lightly modified version of FHIRServer._get(), but additionally supports
+        streaming and reauthorization.
 
-        Will raise a FatalError for an HTTP error, except for 429 which gets returned like a success code.
+        Will raise a FatalError for an HTTP error, except for 429 which gets returned like a
+        success code.
 
         :param method: HTTP method to issue
         :param path: relative path from the server root to request
@@ -169,16 +171,17 @@ class FhirClient:
         """
         return self._capabilities
 
-    ###################################################################################################################
+    #############################################################################################
     #
     # Helpers
     #
-    ###################################################################################################################
+    #############################################################################################
 
     async def _read_capabilities(self) -> None:
         """
-        Reads the server's CapabilityStatement and sets any properties as a result (like server/vendor type).
+        Reads the server's CapabilityStatement and sets any properties as a result.
 
+        Notably, this gathers the server/vendor type.
         This is expected to be called extremely early, right as the http session is opened.
         """
         if not self._server_root:
@@ -259,6 +262,7 @@ def create_fhir_client_for_cli(
             # Use the input URL as the base URL. But note that it may not be the server root.
             # For example, it may be a Group export URL. Let's try to find the actual root.
             client_base_url = root_input.path
+            client_base_url = re.sub(r"/\$export(\?.*)?$", "/", client_base_url)
             client_base_url = re.sub(r"/Patient/?$", "/", client_base_url)
             client_base_url = re.sub(r"/Group/[^/]+/?$", "/", client_base_url)
 

--- a/tests/fhir/test_fhir_client.py
+++ b/tests/fhir/test_fhir_client.py
@@ -287,6 +287,28 @@ class TestFhirClient(AsyncTestCase):
             fhir.create_fhir_client_for_cli(args, store.Root("/tmp"), [])
         self.assertEqual(errors.ARGS_INVALID, cm.exception.code)
 
+    @ddt.data(
+        "http://example.invalid/root/",
+        "http://example.invalid/root/$export?",
+        "http://example.invalid/root/Group/xxx",
+        "http://example.invalid/root/Group/xxx/$export?_type=Patient",
+        "http://example.invalid/root/Patient",
+        "http://example.invalid/root/Patient/$export",
+    )
+    @mock.patch("cumulus_etl.fhir.fhir_client.FhirClient")
+    def test_can_find_auth_root(self, input_url, mock_client):
+        """Verify that we detect the auth root for an input URL"""
+        args = argparse.Namespace(
+            fhir_url=None,
+            smart_client_id=None,
+            smart_jwks=None,
+            basic_user=None,
+            basic_passwd=None,
+            bearer_token=None,
+        )
+        fhir.create_fhir_client_for_cli(args, store.Root(input_url), [])
+        self.assertEqual("http://example.invalid/root/", mock_client.call_args[0][0])
+
     async def test_must_be_context_manager(self):
         """Verify that FHIRClient enforces its use as a context manager."""
         client = fhir.FhirClient(


### PR DESCRIPTION
Retry each request four times (for a total of five requests) in an exponential backoff of 1, 2, 4, and 8 minutes (total of 15 minutes).

This should hopefully help when dealing with flaky EHRs.

Fixes: #334

### Checklist
- [x] Consider if documentation (like in `docs/`) needs to be updated
- [x] Consider if tests should be added
