### PR TITLE
bulk: store "deleted" and "error" results in export subfolders

### DIFF
--- a/docs/bulk-exports.md
+++ b/docs/bulk-exports.md
@@ -44,6 +44,23 @@ You can save the exported files for archiving after the fact with `--export-to=P
 However, bulk exports tend to be brittle and slow for many EHRs at the time of this writing.
 It might be wiser to separately export, make sure the data is all there and good, and then ETL it.
 
+## Archiving Exports
+
+Exports can take a long time, and it's often convenient to archive the results.
+For later re-processing, sanity checking, quality assurance, or whatever.
+
+It's recommended that you archive everything in the export folder.
+This is what you may expect to archive:
+
+- The resource export files themselves
+  (these will look like `1.Patient.ndjson` or `Patient.000.ndjson` or similar)
+- The `log.ndjson` log file
+- The `deleted/` subfolder, if present
+  (this will hold a list of resources that the FHIR server says should be deleted)
+- The `error/` subfolder, if present
+  (this will hold a list of errors from the FHIR server
+  as well as warnings and informational messages, despite the name)
+
 ## Resuming an Interrupted Export
 
 Bulk exports can be brittle.

--- a/docs/setup/sample-runs.md
+++ b/docs/setup/sample-runs.md
@@ -205,13 +205,9 @@ Follow the [S3 setup guide](aws.md) document for guidance there.
 While technically optional, it's recommended that you manually specify these arguments because their
 defaults are subject to change or might not match your situation.
 
-* `--input-format`: There are two reasonable values (`ndjson` and `i2b2`). If you want to pull from
-  your bulk export FHIR server, pass in its URL as your input path and use `ndjson` as your input
-  format. Otherwise, you can use either value to point at a local folder with either FHIR ndjson
-  or i2b2 csv files sitting in them, respectively.
-
 * `--output-format`: There are two reasonable values (`ndjson` and `deltalake`).
-  For production use, you want `deltalake` as it is supports incremental, batched updates.
+  For production use, you can use the default value of `deltalake` as it supports incremental,
+  batched updates.
   But `ndjson` is useful when debugging as it is human-readable.
 
 * `--batch-size`: How many resources to save in a single output file. If there are more resources


### PR DESCRIPTION
If the bulk export server provides an array of error messages or an array of deleted resources, make sure we persist those on disk.

Previously, we only printed the error messages to the console. We still do that, but also write them to an error/ subfolder.

Previously, we ignored any deleted resources.
Now we write them to a deleted/ subfolder.

This matches the behavior of bulk-data-client.

This is part 1 of #167.
Next step is actually processing a `deleted/` folder in any input ndjson.

### Checklist
- [x] Consider if documentation (like in `docs/`) needs to be updated
- [x] Consider if tests should be added
