### PR TITLE
Parse any deleted resource IDs from bulk exports and act on it

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -67,7 +67,7 @@ jobs:
         with:
           coverageFile: coverage.xml
           token: ${{ secrets.GITHUB_TOKEN }}
-          thresholdAll: .97
+          thresholdAll: .98
           thresholdNew: 1
           thresholdModified: 1
 

--- a/cumulus_etl/etl/cli.py
+++ b/cumulus_etl/etl/cli.py
@@ -296,6 +296,7 @@ async def etl_main(args: argparse.Namespace) -> None:
             tasks=[t.name for t in selected_tasks],
             export_group_name=export_group_name,
             export_datetime=export_datetime,
+            deleted_ids=loader_results.deleted_ids,
         )
         common.write_json(config.path_config(), config.as_json(), indent=4)
 

--- a/cumulus_etl/etl/config.py
+++ b/cumulus_etl/etl/config.py
@@ -33,6 +33,7 @@ class JobConfig:
         tasks: list[str] | None = None,
         export_group_name: str | None = None,
         export_datetime: datetime.datetime | None = None,
+        deleted_ids: dict[str, set[str]] | None = None,
     ):
         self._dir_input_orig = dir_input_orig
         self.dir_input = dir_input_deid
@@ -50,6 +51,7 @@ class JobConfig:
         self.tasks = tasks or []
         self.export_group_name = export_group_name
         self.export_datetime = export_datetime
+        self.deleted_ids = deleted_ids or {}
 
         # initialize format class
         self._output_root = store.Root(self._dir_output, create=True)

--- a/cumulus_etl/etl/tasks/base.py
+++ b/cumulus_etl/etl/tasks/base.py
@@ -144,11 +144,9 @@ class EtlTask:
             with self._indeterminate_progress(progress, "Finalizing"):
                 # Ensure that we touch every output table (to create them and/or to confirm schema).
                 # Consider case of Medication for an EHR that only has inline Medications inside
-                # MedicationRequest.
-                # The Medication table wouldn't get created otherwise. Plus this is a good place to
-                # push any schema changes.
-                # (The reason it's nice if the table & schema exist is so that downstream SQL can
-                # be dumber.)
+                # MedicationRequest. The Medication table wouldn't get created otherwise.
+                # Plus this is a good place to push any schema changes. (The reason it's nice if
+                # the table & schema exist is so that downstream SQL can be dumber.)
                 self._touch_remaining_tables()
 
                 # If the input data indicates we should delete some IDs, do that here.

--- a/cumulus_etl/formats/base.py
+++ b/cumulus_etl/formats/base.py
@@ -74,6 +74,14 @@ class Format(abc.ABC):
         :param batch: the batch of data
         """
 
+    @abc.abstractmethod
+    def delete_records(self, ids: set[str]) -> None:
+        """
+        Deletes all mentioned IDs from the table.
+
+        :param ids: all IDs to remove
+        """
+
     def finalize(self) -> None:
         """
         Performs any necessary cleanup after all batches have been written.

--- a/cumulus_etl/formats/batched_files.py
+++ b/cumulus_etl/formats/batched_files.py
@@ -83,3 +83,12 @@ class BatchedFileFormat(Format):
         full_path = self.dbroot.joinpath(f"{self.dbname}.{self._index:03}.{self.suffix}")
         self.write_format(batch, full_path)
         self._index += 1
+
+    def delete_records(self, ids: set[str]) -> None:
+        """
+        Deletes the given IDs.
+
+        Though this is a no-op for batched file outputs, since:
+        - we guarantee the output folder is empty at the start
+        - the spec says deleted IDs won't overlap with output IDs
+        """

--- a/cumulus_etl/formats/batched_files.py
+++ b/cumulus_etl/formats/batched_files.py
@@ -91,4 +91,6 @@ class BatchedFileFormat(Format):
         Though this is a no-op for batched file outputs, since:
         - we guarantee the output folder is empty at the start
         - the spec says deleted IDs won't overlap with output IDs
+
+        But subclasses may still want to write these to disk to preserve the metadata.
         """

--- a/cumulus_etl/formats/ndjson.py
+++ b/cumulus_etl/formats/ndjson.py
@@ -35,3 +35,22 @@ class NdjsonFormat(BatchedFileFormat):
 
         # This is mostly used in tests and debugging, so we'll write out sparse files (no null columns)
         common.write_rows_to_ndjson(path, batch.rows, sparse=True)
+
+    def table_metadata_path(self) -> str:
+        return self.dbroot.joinpath(f"{self.dbname}.meta")  # no batch number
+
+    def read_table_metadata(self) -> dict:
+        try:
+            return common.read_json(self.table_metadata_path())
+        except (FileNotFoundError, PermissionError):
+            return {}
+
+    def write_table_metadata(self, metadata: dict) -> None:
+        self.root.makedirs(self.dbroot.path)
+        common.write_json(self.table_metadata_path(), metadata, indent=2)
+
+    def delete_records(self, ids: set[str]) -> None:
+        # Read and write back table metadata, with the addition of these new deleted IDs
+        meta = self.read_table_metadata()
+        meta.setdefault("deleted", []).extend(sorted(ids))
+        self.write_table_metadata(meta)

--- a/cumulus_etl/loaders/__init__.py
+++ b/cumulus_etl/loaders/__init__.py
@@ -1,5 +1,5 @@
 """Public API for loaders"""
 
-from .base import Loader
+from .base import Loader, LoaderResults
 from .fhir.ndjson_loader import FhirNdjsonLoader
 from .i2b2.loader import I2b2Loader

--- a/cumulus_etl/loaders/base.py
+++ b/cumulus_etl/loaders/base.py
@@ -23,6 +23,10 @@ class LoaderResults:
     group_name: str | None = None
     export_datetime: datetime.datetime | None = None
 
+    # A list of resource IDs that should be deleted from the output tables.
+    # This is a map of resource -> set of IDs like {"Patient": {"A", "B"}}
+    deleted_ids: dict[str, set[str]] = dataclasses.field(default_factory=dict)
+
 
 class Loader(abc.ABC):
     """

--- a/cumulus_etl/loaders/base.py
+++ b/cumulus_etl/loaders/base.py
@@ -1,8 +1,27 @@
 """Base abstract loader"""
 
 import abc
+import dataclasses
+import datetime
 
 from cumulus_etl import common, store
+
+
+@dataclasses.dataclass(kw_only=True)
+class LoaderResults:
+    """Bundles results of a load request"""
+
+    # Where loaded files reside on disk (use .path for convenience)
+    directory: common.Directory
+
+    @property
+    def path(self) -> str:
+        return self.directory.name
+
+    # Completion tracking values - noting an export group name for this bundle of data
+    # and the time when it was exported ("transactionTime" in bulk-export terms).
+    group_name: str | None = None
+    export_datetime: datetime.datetime | None = None
 
 
 class Loader(abc.ABC):
@@ -21,12 +40,8 @@ class Loader(abc.ABC):
         """
         self.root = root
 
-        # Public properties (potentially set when loading) for reporting back to caller
-        self.group_name = None
-        self.export_datetime = None
-
     @abc.abstractmethod
-    async def load_all(self, resources: list[str]) -> common.Directory:
+    async def load_all(self, resources: list[str]) -> LoaderResults:
         """
         Loads the listed remote resources and places them into a local folder as FHIR ndjson
 

--- a/cumulus_etl/loaders/fhir/ndjson_loader.py
+++ b/cumulus_etl/loaders/fhir/ndjson_loader.py
@@ -37,11 +37,11 @@ class FhirNdjsonLoader(base.Loader):
         self.until = until
         self.resume = resume
 
-    async def load_all(self, resources: list[str]) -> common.Directory:
+    async def load_all(self, resources: list[str]) -> base.LoaderResults:
         # Are we doing a bulk FHIR export from a server?
         if self.root.protocol in ["http", "https"]:
-            loaded_dir = await self.load_from_bulk_export(resources)
-            input_root = store.Root(loaded_dir.name)
+            results = await self.load_from_bulk_export(resources)
+            input_root = store.Root(results.path)
         else:
             if self.export_to or self.since or self.until or self.resume:
                 errors.fatal(
@@ -49,13 +49,14 @@ class FhirNdjsonLoader(base.Loader):
                     errors.ARGS_CONFLICT,
                 )
 
+            results = base.LoaderResults(directory=self.root.path)
             input_root = self.root
 
             # Parse logs for export information
             try:
                 parser = BulkExportLogParser(input_root)
-                self.group_name = parser.group_name
-                self.export_datetime = parser.export_datetime
+                results.group_name = parser.group_name
+                results.export_datetime = parser.export_datetime
             except BulkExportLogParser.LogParsingError:
                 # Once we require group name & export datetime, we should warn about this.
                 # For now, just ignore any errors.
@@ -75,11 +76,13 @@ class FhirNdjsonLoader(base.Loader):
         filenames = common.ls_resources(input_root, set(resources), warn_if_empty=True)
         for filename in filenames:
             input_root.get(filename, f"{tmpdir.name}/")
-        return tmpdir
+        results.directory = tmpdir
+
+        return results
 
     async def load_from_bulk_export(
         self, resources: list[str], prefer_url_resources: bool = False
-    ) -> common.Directory:
+    ) -> base.LoaderResults:
         """
         Performs a bulk export and drops the results in an export dir.
 
@@ -101,11 +104,11 @@ class FhirNdjsonLoader(base.Loader):
             )
             await bulk_exporter.export()
 
-            # Copy back these settings from the export
-            self.group_name = bulk_exporter.group_name
-            self.export_datetime = bulk_exporter.export_datetime
-
         except errors.FatalError as exc:
             errors.fatal(str(exc), errors.BULK_EXPORT_FAILED)
 
-        return target_dir
+        return base.LoaderResults(
+            directory=target_dir,
+            group_name=bulk_exporter.group_name,
+            export_datetime=bulk_exporter.export_datetime,
+        )

--- a/cumulus_etl/loaders/fhir/ndjson_loader.py
+++ b/cumulus_etl/loaders/fhir/ndjson_loader.py
@@ -132,7 +132,8 @@ class FhirNdjsonLoader(base.Loader):
                 request = entry.get("request", {})
                 if request.get("method") != "DELETE":
                     continue
-                url = request.get("url")  # should be relative URL like "Patient/123"
+                url = request.get("url")
+                # Sanity check that we have a relative URL like "Patient/123"
                 if not url or url.count("/") != 1:
                     continue
                 resource, res_id = url.split("/")

--- a/cumulus_etl/loaders/i2b2/loader.py
+++ b/cumulus_etl/loaders/i2b2/loader.py
@@ -8,7 +8,7 @@ from pathlib import Path
 from typing import TypeVar
 
 from cumulus_etl import cli_utils, common, store
-from cumulus_etl.loaders.base import Loader
+from cumulus_etl.loaders import base
 from cumulus_etl.loaders.i2b2 import extract, schema, transform
 from cumulus_etl.loaders.i2b2.oracle import extract as oracle_extract
 
@@ -18,7 +18,7 @@ CsvToI2b2Callable = Callable[[str], Iterable[schema.Dimension]]
 I2b2ToFhirCallable = Callable[[AnyDimension], dict]
 
 
-class I2b2Loader(Loader):
+class I2b2Loader(base.Loader):
     """
     Loader for i2b2 data.
 
@@ -34,11 +34,12 @@ class I2b2Loader(Loader):
         super().__init__(root)
         self.export_to = export_to
 
-    async def load_all(self, resources: list[str]) -> common.Directory:
+    async def load_all(self, resources: list[str]) -> base.LoaderResults:
         if self.root.protocol in ["tcp"]:
-            return self._load_all_from_oracle(resources)
-
-        return self._load_all_from_csv(resources)
+            directory = self._load_all_from_oracle(resources)
+        else:
+            directory = self._load_all_from_csv(resources)
+        return base.LoaderResults(directory=directory)
 
     def _load_all_with_extractors(
         self,

--- a/tests/etl/test_etl_cli.py
+++ b/tests/etl/test_etl_cli.py
@@ -267,20 +267,16 @@ class TestEtlJobFlow(BaseEtlSimple):
     async def test_completion_args(self, etl_args, loader_vals, expected_vals):
         """Verify that we parse completion args with the correct fallbacks and checks."""
         # Grab all observations before we mock anything
-        observations = loaders.FhirNdjsonLoader(store.Root(self.input_path)).load_all(
+        observations = await loaders.FhirNdjsonLoader(store.Root(self.input_path)).load_all(
             ["Observation"]
         )
-
-        def fake_load_all(internal_self, resources):
-            del resources
-            internal_self.group_name = loader_vals[0]
-            internal_self.export_datetime = loader_vals[1]
-            return observations
+        observations.group_name = loader_vals[0]
+        observations.export_datetime = loader_vals[1]
 
         with (
             self.assertRaises(SystemExit) as cm,
             mock.patch("cumulus_etl.etl.cli.etl_job", side_effect=SystemExit) as mock_etl_job,
-            mock.patch.object(loaders.FhirNdjsonLoader, "load_all", new=fake_load_all),
+            mock.patch.object(loaders.FhirNdjsonLoader, "load_all", return_value=observations),
         ):
             await self.run_etl(tasks=["observation"], **etl_args)
 

--- a/tests/formats/test_ndjson.py
+++ b/tests/formats/test_ndjson.py
@@ -56,3 +56,20 @@ class TestNdjsonFormat(utils.AsyncTestCase):
         else:
             with self.assertRaises(SystemExit):
                 NdjsonFormat.initialize_class(self.root)
+
+    def test_writes_deleted_ids(self):
+        """Verify that we write a table metadata file with deleted IDs"""
+        meta_path = f"{self.root.joinpath('condition')}/condition.meta"
+
+        # Test with a fresh directory
+        formatter = NdjsonFormat(self.root, "condition")
+        formatter.delete_records({"b", "a"})
+        metadata = common.read_json(meta_path)
+        self.assertEqual(metadata, {"deleted": ["a", "b"]})
+
+        # Confirm we append to existing metadata, should we ever need to
+        metadata["extra"] = "bonus metadata!"
+        common.write_json(meta_path, metadata)
+        formatter.delete_records({"c"})
+        metadata = common.read_json(meta_path)
+        self.assertEqual(metadata, {"deleted": ["a", "b", "c"], "extra": "bonus metadata!"})

--- a/tests/loaders/i2b2/test_i2b2_oracle_extract.py
+++ b/tests/loaders/i2b2/test_i2b2_oracle_extract.py
@@ -93,7 +93,7 @@ class TestOracleExtraction(AsyncTestCase):
 
         root = store.Root("tcp://localhost/foo")
         oracle_loader = loader.I2b2Loader(root)
-        tmpdir = await oracle_loader.load_all(["Condition", "Encounter", "Patient"])
+        results = await oracle_loader.load_all(["Condition", "Encounter", "Patient"])
 
         # Check results
         self.assertEqual(
@@ -102,17 +102,17 @@ class TestOracleExtraction(AsyncTestCase):
                 "Encounter.ndjson",
                 "Patient.ndjson",
             },
-            set(os.listdir(tmpdir.name)),
+            set(os.listdir(results.path)),
         )
 
         self.assertEqual(
             i2b2_mock_data.condition(),
-            common.read_json(os.path.join(tmpdir.name, "Condition.ndjson")),
+            common.read_json(os.path.join(results.path, "Condition.ndjson")),
         )
         self.assertEqual(
             i2b2_mock_data.encounter(),
-            common.read_json(os.path.join(tmpdir.name, "Encounter.ndjson")),
+            common.read_json(os.path.join(results.path, "Encounter.ndjson")),
         )
         self.assertEqual(
-            i2b2_mock_data.patient(), common.read_json(os.path.join(tmpdir.name, "Patient.ndjson"))
+            i2b2_mock_data.patient(), common.read_json(os.path.join(results.path, "Patient.ndjson"))
         )


### PR DESCRIPTION
- Updates Loader classes to return any information found about deleted resources
- Updates the Delta Lake formatter to use that info to delete rows
- Updates the ndjson formatter to preserve the `deleted` metadata on disk
- Updates `convert` logic to read that preserved metadata and then carry that into the Delta Lake

As a reminder, the spec's commentary on how to handle `deleted` is in the [bulk export section](https://hl7.org/fhir/uv/bulkdata/export.html).

Fixes #167 

### Checklist
- [x] Consider if documentation (like in `docs/`) needs to be updated
- [x] Consider if tests should be added
