### PR TITLE
feat: don't simply toss extensions

### DIFF
--- a/cumulus_etl/deid/ms-config.json
+++ b/cumulus_etl/deid/ms-config.json
@@ -20,17 +20,10 @@
   "fhirVersion": "R4",
   "processingErrors": "raise",
   "fhirPathRules": [
-    // Only allow a few known extensions
-    {"path": "Patient.extension('http://hl7.org/fhir/Profile/us-core#ethnicity')", "method": "keep"}, // Old DSTU1 URL, still out there in the wild: https://www.hl7.org/fhir/DSTU1/us-core.html
-    {"path": "Patient.extension('http://hl7.org/fhir/Profile/us-core#race')", "method": "keep"}, // Old DSTU1 URL, still out there in the wild: https://www.hl7.org/fhir/DSTU1/us-core.html
-    {"path": "Patient.extension('http://hl7.org/fhir/us/core/StructureDefinition/us-core-birthsex')", "method": "keep"},
-    {"path": "Patient.extension('http://hl7.org/fhir/us/core/StructureDefinition/us-core-ethnicity')", "method": "keep"},
-    {"path": "Patient.extension('http://hl7.org/fhir/us/core/StructureDefinition/us-core-genderIdentity')", "method": "keep"},
-    {"path": "Patient.extension('http://hl7.org/fhir/us/core/StructureDefinition/us-core-race')", "method": "keep"},
-    {"path": "Patient.extension('http://hl7.org/fhir/us/core/StructureDefinition/us-core-sex-for-clinical-use')", "method": "keep"},
-    {"path": "Patient.extension('http://open.epic.com/FHIR/StructureDefinition/extension/sex-for-clinical-use')", "method": "keep"}, // Epic has used this pre-final-spec URL
-    {"path": "nodesByName('modifierExtension')", "method": "keep"}, // keep these so we can ignore resources with modifiers we don't understand
-    {"path": "nodesByType('Extension')", "method": "redact"}, // drop all unknown extensions
+    // modifierExtension is handled by ETL so that we can skip resources we don't understand
+    {"path": "nodesByName('modifierExtension')", "method": "keep"},
+    // extension is handled by ETL so that we can flag the URLs of extensions we strip
+    {"path": "nodesByName('extension')", "method": "keep"},
 
     // Elements that might be embedded and kept elsewhere -- redact pieces of the whole
     {"path": "nodesByType('Attachment').title", "method": "redact"},
@@ -56,6 +49,7 @@
     {"path": "nodesByType('Dosage').sequence", "method": "keep"},
     // Skip Dosage.text
     {"path": "nodesByType('Dosage').additionalInstruction", "method": "keep"},
+    // Skip Dosage.patientInstruction
     {"path": "nodesByType('Dosage').timing", "method": "keep"},
     {"path": "nodesByType('Dosage').asNeeded", "method": "keep"},
     {"path": "nodesByType('Dosage').site", "method": "keep"},

--- a/cumulus_etl/etl/tasks/nlp_task.py
+++ b/cumulus_etl/etl/tasks/nlp_task.py
@@ -78,7 +78,7 @@ class BaseNlpTask(EtlTask):
             can_process = (
                 nlp.is_docref_valid(docref)
                 and (doc_check is None or doc_check(docref))
-                and self.scrubber.scrub_resource(docref, scrub_attachments=False)
+                and self.scrubber.scrub_resource(docref, scrub_attachments=False, keep_stats=False)
             )
             if not can_process:
                 continue

--- a/docs/deid.md
+++ b/docs/deid.md
@@ -97,17 +97,24 @@ Zip codes are redacted down to just the first three digits (e.g. `12139` becomes
 Additionally, for certain small-population zip codes where even three digits is too identifying,
 the zip code is entirely redacted to `00000`.
 
-#### Extensions
-
-All extensions are removed, except for:
-- The USCDI patient extensions (birth sex, gender identity, race, and ethnicity)
-- "Modifier" extensions which will flag to the ETL that a resource should be skipped
-
 #### Clinical Notes
 
 Be aware that clinical notes are not removed at this stage.
 They are kept for now, so that Cumulus ETL can run natural language processing on them.
 See below for more information on that.
+
+### Extensions
+
+Extensions are stripped out unless they are on a list of recognized extensions,
+to ensure that PHI doesn't accidentally slip in.
+The allowed extensions include the standard USCDI patient extensions
+(birth sex, gender identity, race, and ethnicity)
+as well as various harmless vendor extensions.
+
+Any unrecognized
+["Modifier" extension](https://www.hl7.org/fhir/R4/extensibility.html#modifierExtension)
+will cause Cumulus ETL to entirely skip the containing resource,
+since the resource can't be properly understood.
 
 ### IDs
 

--- a/tests/data/mstool/output/Patient.1.json
+++ b/tests/data/mstool/output/Patient.1.json
@@ -21,6 +21,22 @@
   },
   "extension": [
     {
+      "url": "http://hl7.org/fhir/StructureDefinition/patient-birthPlace",
+      "valueAddress": {
+        "city": "Boston",
+        "state": "Massachusetts",
+        "country": "US"
+      }
+    },
+    {
+      "url": "http://synthetichealth.github.io/synthea/disability-adjusted-life-years",
+      "valueDecimal": 0.30562800211089186
+    },
+    {
+      "url": "http://synthetichealth.github.io/synthea/quality-adjusted-life-years",
+      "valueDecimal": 53.69437199788911
+    },
+    {
       "url": "http://hl7.org/fhir/Profile/us-core#ethnicity",
       "valueString": "kept"
     },
@@ -64,6 +80,21 @@
   "deceasedBoolean": false,
   "address": [
     {
+      "extension": [
+        {
+          "url": "http://hl7.org/fhir/StructureDefinition/geolocation",
+          "extension": [
+            {
+              "url": "latitude",
+              "valueDecimal": 42.26414395224488
+            },
+            {
+              "url": "longitude",
+              "valueDecimal": -72.64290225131757
+            }
+          ]
+        }
+      ],
       "state": "Massachusetts",
       "postalCode": "01000",
       "country": "US"

--- a/tests/data/mstool/output/Patient.2.json
+++ b/tests/data/mstool/output/Patient.2.json
@@ -19,6 +19,28 @@
       }
     ]
   },
+  "extension": [
+    {
+      "url": "http://hl7.org/fhir/StructureDefinition/patient-mothersMaidenName",
+      "valueString": "Marquetta Schamberger"
+    },
+    {
+      "url": "http://hl7.org/fhir/StructureDefinition/patient-birthPlace",
+      "valueAddress": {
+        "city": "Macau",
+        "state": "Macao Special Administrative Region of the People's Republic of China",
+        "country": "CN"
+      }
+    },
+    {
+      "url": "http://synthetichealth.github.io/synthea/disability-adjusted-life-years",
+      "valueDecimal": 9.931319288245724
+    },
+    {
+      "url": "http://synthetichealth.github.io/synthea/quality-adjusted-life-years",
+      "valueDecimal": 38.068680711754276
+    }
+  ],
   "gender": "female",
   "birthDate": "1971",
   "deceasedDateTime": "2023-03-02",

--- a/tests/data/mstool/output/Patient.3.json
+++ b/tests/data/mstool/output/Patient.3.json
@@ -19,10 +19,47 @@
       }
     ]
   },
+  "extension": [
+    {
+      "url": "http://hl7.org/fhir/StructureDefinition/patient-mothersMaidenName",
+      "valueString": "Peggie Terry"
+    },
+    {
+      "url": "http://hl7.org/fhir/StructureDefinition/patient-birthPlace",
+      "valueAddress": {
+        "city": "Fall River",
+        "state": "Massachusetts",
+        "country": "US"
+      }
+    },
+    {
+      "url": "http://synthetichealth.github.io/synthea/disability-adjusted-life-years",
+      "valueDecimal": 0.6074581808639448
+    },
+    {
+      "url": "http://synthetichealth.github.io/synthea/quality-adjusted-life-years",
+      "valueDecimal": 108.39254181913606
+    }
+  ],
   "gender": "male",
   "birthDate": "1910",
   "address": [
     {
+      "extension": [
+        {
+          "url": "http://hl7.org/fhir/StructureDefinition/geolocation",
+          "extension": [
+            {
+              "url": "latitude",
+              "valueDecimal": 42.21439783732538
+            },
+            {
+              "url": "longitude",
+              "valueDecimal": -71.10738356606545
+            }
+          ]
+        }
+      ],
       "state": "Massachusetts",
       "postalCode": "02100",
       "country": "US"


### PR DESCRIPTION
- Print a report at the end of the ETL run of all extensions stripped by resource, URL, and count.
- Plus a report on resources skipped due to unrecognized modifier extensions.
- Leave stub extension in place, with just the `url` field, so that we can inspect stripped extensions in SQL if we want.

This commit allows a bunch of extensions in use today. Scanned some sample data from Cerner and Epic to find common extensions. We'll surely add to the list going forward, to avoid annoying folks with the unknown-extension warning.

Ignore the following extensions:
- http://hl7.org/fhir/StructureDefinition/iso21090-TEL-address
- http://hl7.org/fhir/StructureDefinition/rendered-value
- http://hl7.org/fhir/us/core/StructureDefinition/us-core-direct
- https://fhir-ehr.cerner.com/r4/StructureDefinition/clinical-instruction
- https://fhir-ehr.cerner.com/r4/StructureDefinition/estimated-financial-responsibility-amount
- http://open.epic.com/FHIR/StructureDefinition/extension/birth-location

Drop support for the following extension:
- http://hl7.org/fhir/us/core/StructureDefinition/us-core-sex-for-clinical-use (this was in US Core 6.0 ballot, but didn't make final cut - it seems to be replaced by just 'us-core-sex')

Fixes #346

### Example output
```
────────────────────────────────────────────────────────────────────────────────
Unrecognized extensions dropped from resources:
 Condition                            
 └── http://example.com/blarg (1 time)
 Encounter                                                                      
 ├── http://cerner.com/long-url/extensions/estimated-financial-responsibility-am
 │   ount (1 time)                                                              
 └── http://example.com/blarg (2 times)                                         
────────────────────────────────────────────────────────────────────────────────
🚨 Resources skipped due to unrecognized modifier extensions: 🚨
 Encounter                          
 └── http://example.com/foo (1 time)
────────────────────────────────────────────────────────────────────────────────
⭐ All tasks completed successfully! ⭐
```

### Checklist
- [x] Consider if documentation (like in `docs/`) needs to be updated
- [x] Consider if tests should be added
