### PR TITLE
docker: add git revision to version during docker build

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -86,6 +86,8 @@ jobs:
         with:
           load: true  # just build, no push
           tags: smartonfhir/cumulus-etl:latest
+          build-args: |
+            LOCAL_VERSION=${{ github.sha }}
 
       - name: Download NLP images
         run: |

--- a/.github/workflows/docker-hub.yaml
+++ b/.github/workflows/docker-hub.yaml
@@ -29,7 +29,7 @@ jobs:
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       - name: Build and push image to Docker Hub
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@v6
         with:
           push: true
           platforms: |
@@ -37,3 +37,5 @@ jobs:
             linux/arm64
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+          build-args: |
+            LOCAL_VERSION=${{ github.sha }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -38,6 +38,14 @@ RUN pip3 install nltk
 RUN python3 -m nltk.downloader -d /usr/local/share/nltk_data averaged_perceptron_tagger
 
 COPY . /app
+
+# A local version is the trailing bit of a Python version after a plus sign, like 5.0+ubuntu1.
+# We use it here mostly to inject a git commit sha when building from git.
+ARG LOCAL_VERSION
+RUN [ -z "$LOCAL_VERSION" ] || sed -i "s/\(__version__.*\)\"/\1+$LOCAL_VERSION\"/" /app/cumulus_etl/__init__.py
+# Print the final version we're using
+RUN grep __version__ /app/cumulus_etl/__init__.py
+
 RUN --mount=type=cache,target=/root/.cache \
   pip3 install /app
 RUN rm -r /app


### PR DESCRIPTION
Using a "local version identifier" per PEP 440, the version looks like: `1.3.0+d7abeb366a8179691f3234502986dad14698a4c5`

PEP for reference: https://peps.python.org/pep-0440/

This will help distinguish ETL builds from each other while we still build directly from git.


### Checklist
- [x] Consider if documentation (like in `docs/`) needs to be updated
- [x] Consider if tests should be added
