### PR TITLE
Skip tasks or error out when resources are missing

### DIFF
--- a/cumulus_etl/errors.py
+++ b/cumulus_etl/errors.py
@@ -34,6 +34,7 @@ FHIR_AUTH_FAILED = 32
 SERVICE_MISSING = 33  # generic init-check service is missing
 COMPLETION_ARG_MISSING = 34
 TASK_HELP = 35
+MISSING_REQUESTED_RESOURCES = 36
 
 
 class FatalError(Exception):

--- a/cumulus_etl/etl/tasks/base.py
+++ b/cumulus_etl/etl/tasks/base.py
@@ -260,9 +260,6 @@ class EtlTask:
             self.formatters[index].delete_records(deleted_ids)
 
     def _update_completion_table(self) -> None:
-        # TODO: what about empty sets - do we assume the export gave 0 results or skip it?
-        #  Is there a difference we could notice? (like empty input file vs no file at all)
-
         if not self.completion_tracking_enabled:
             return
 

--- a/cumulus_etl/loaders/base.py
+++ b/cumulus_etl/loaders/base.py
@@ -46,7 +46,15 @@ class Loader(abc.ABC):
         self.root = root
 
     @abc.abstractmethod
-    async def load_all(self, resources: list[str]) -> LoaderResults:
+    async def detect_resources(self) -> set[str] | None:
+        """
+        Inspect which resources are available for use.
+
+        :returns: the types of resources detected (or None if that can't be determined yet)
+        """
+
+    @abc.abstractmethod
+    async def load_resources(self, resources: set[str]) -> LoaderResults:
         """
         Loads the listed remote resources and places them into a local folder as FHIR ndjson
 

--- a/cumulus_etl/loaders/fhir/bulk_export.py
+++ b/cumulus_etl/loaders/fhir/bulk_export.py
@@ -30,7 +30,7 @@ class BulkExporter:
     def __init__(
         self,
         client: fhir.FhirClient,
-        resources: list[str],
+        resources: set[str],
         url: str,
         destination: str,
         *,
@@ -81,7 +81,7 @@ class BulkExporter:
         self,
         url: str,
         *,
-        resources: list[str],
+        resources: set[str],
         since: str | None,
         until: str | None,
         prefer_url_resources: bool,

--- a/cumulus_etl/upload_notes/downloader.py
+++ b/cumulus_etl/upload_notes/downloader.py
@@ -27,7 +27,7 @@ async def download_docrefs_from_fhir_server(
     else:
         # else we'll download the entire target path as a bulk export (presumably the user has scoped a Group)
         ndjson_loader = loaders.FhirNdjsonLoader(root_input, client, export_to=export_to)
-        return await ndjson_loader.load_all(["DocumentReference"])
+        return await ndjson_loader.load_resources({"DocumentReference"})
 
 
 async def _download_docrefs_from_fake_ids(

--- a/tests/loaders/i2b2/test_i2b2_loader.py
+++ b/tests/loaders/i2b2/test_i2b2_loader.py
@@ -22,7 +22,7 @@ class TestI2b2Loader(AsyncTestCase):
             vitals = f"{self.datadir}/i2b2/input/observation_fact_vitals.csv"
             shutil.copy(vitals, tmpdir)
 
-            results = await i2b2_loader.load_all(["Observation", "Patient"])
+            results = await i2b2_loader.load_resources({"Observation", "Patient"})
 
             self.assertEqual(["Observation.1.ndjson"], os.listdir(results.path))
 
@@ -37,7 +37,24 @@ class TestI2b2Loader(AsyncTestCase):
                 "PATIENT_NUM,BIRTH_DATE\n" "123,1982-10-16\n" "123,1983-11-17\n" "456,2000-01-13\n",
             )
 
-            results = await i2b2_loader.load_all(["Patient"])
+            results = await i2b2_loader.load_resources({"Patient"})
             rows = common.read_resource_ndjson(store.Root(results.path), "Patient")
             values = [(r["id"], r["birthDate"]) for r in rows]
             self.assertEqual(values, [("123", "1982-10-16"), ("456", "2000-01-13")])
+
+    async def test_detect_resources(self):
+        """Verify we can inspect a folder and find all resources."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            common.write_text(f"{tmpdir}/visit_dimension.csv", "")
+            common.write_text(f"{tmpdir}/unrelated.csv", "")
+            common.write_text(f"{tmpdir}/observation_fact_lab_views.csv", "")
+
+            i2b2_loader = loader.I2b2Loader(store.Root(tmpdir))
+            resources = await i2b2_loader.detect_resources()
+
+        self.assertEqual(resources, {"Encounter", "Observation"})
+
+    async def test_detect_resources_tcp(self):
+        """Verify we skip trying to detect resources before exporting from oracle."""
+        i2b2_loader = loader.I2b2Loader(store.Root("tcp://localhost"))
+        self.assertIsNone(await i2b2_loader.detect_resources())

--- a/tests/loaders/i2b2/test_i2b2_oracle_extract.py
+++ b/tests/loaders/i2b2/test_i2b2_oracle_extract.py
@@ -93,7 +93,7 @@ class TestOracleExtraction(AsyncTestCase):
 
         root = store.Root("tcp://localhost/foo")
         oracle_loader = loader.I2b2Loader(root)
-        results = await oracle_loader.load_all(["Condition", "Encounter", "Patient"])
+        results = await oracle_loader.load_resources({"Condition", "Encounter", "Patient"})
 
         # Check results
         self.assertEqual(

--- a/tests/upload_notes/test_upload_cli.py
+++ b/tests/upload_notes/test_upload_cli.py
@@ -259,12 +259,12 @@ class TestUploadNotes(CtakesMixin, AsyncTestCase):
     @mock.patch("cumulus_etl.upload_notes.downloader.loaders.FhirNdjsonLoader")
     async def test_gather_all_docrefs_from_server(self, mock_loader):
         # Mock out the bulk export loading, as that's well tested elsewhere
-        async def load_all(*args):
+        async def load_resources(*args):
             del args
             return common.RealDirectory(self.input_path)
 
-        load_all_mock = mock_loader.return_value.load_all
-        load_all_mock.side_effect = load_all
+        load_resources_mock = mock_loader.return_value.load_resources
+        load_resources_mock.side_effect = load_resources
 
         # Do the actual upload-notes push
         await self.run_upload_notes(input_path="https://localhost")
@@ -273,7 +273,7 @@ class TestUploadNotes(CtakesMixin, AsyncTestCase):
         self.assertEqual(1, mock_loader.call_count)
         self.assertEqual("https://localhost", mock_loader.call_args[0][0].path)
         self.assertEqual(self.export_path, mock_loader.call_args[1]["export_to"])
-        self.assertEqual([mock.call(["DocumentReference"])], load_all_mock.call_args_list)
+        self.assertEqual([mock.call({"DocumentReference"})], load_resources_mock.call_args_list)
 
         # Make sure we do read the result and push the docrefs out
         self.assertEqual({"43", "44"}, self.get_pushed_ids())


### PR DESCRIPTION
- If tasks are selected with --task or --task-filter and a needed resource is missing, we now error out.
- If tasks are not specifically selected, we now only run tasks for which resources are available (and error out if no resources exist at all)
- If --allow-missing-resources is passed, we skip both above checks and do historical behavior of running any given task with zero input rows (which pushes up a schema, cleans up the delta lake, and stamps the resource as complete in the completion tracking tables).

This addresses a lingering issue from #296, where we didn't adequately protect ourselves from incorrectly handling "empty set" inputs and wrongly marking them as complete. I've decided to go the simplest route and refuse to handle empty-sets unless specifically told to. I think this is appropriate given how unlikely empty sets are in the real world. (We see them with Cerner for some resources like ServiceRequest, but it's the exception not the rule.)

(An alternate solution that I did consider was looking at the bulk export log if it was present, and seeing what resources were exported - then continuing if the export log says it exported Patients, even if no patient files where present. But it seemed more complicated code-wise and more brittle if users are moving files around. The approach I went with requires a human in the loop to agree to allow empty sets. Or... someone just adds the --allow flag to their scripts and we lose this protection anyway - but that's at least not on me. :smile:)

### Checklist
- [x] Consider if documentation (like in `docs/`) needs to be updated
- [x] Consider if tests should be added
