### PR TITLE
docker: tag releases with the major version number too

### DIFF
--- a/.github/workflows/docker-hub.yaml
+++ b/.github/workflows/docker-hub.yaml
@@ -12,8 +12,13 @@ jobs:
     name: Build and push image
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@v4
+
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
+
+      - name: Grab version
+        run: echo "ETL_VERSION=$(grep __version__ cumulus_etl/__init__.py | cut -d'"' -f2)" >> $GITHUB_ENV
 
       - name: Get Docker metadata
         id: meta
@@ -21,6 +26,9 @@ jobs:
         with:
           flavor: latest=true
           images: smartonfhir/cumulus-etl
+          tags: |
+            type=ref,event=branch
+            type=pep440,pattern={{major}},value=${{ env.ETL_VERSION }}
 
       - name: Log in to Docker Hub
         uses: docker/login-action@v3


### PR DESCRIPTION
I tested these changes and wanted to land them separately from #354 because I wanted to get a release tagged as `1` out there, so that folks that didn't want to update scripts or deal with the change yet had a fallback.

### Checklist
- [x] Consider if documentation (like in `docs/`) needs to be updated
- [x] Consider if tests should be added
