### PR TITLE
fix: allow overwriting delta lake entries with same timestamp

### DIFF
--- a/tests/formats/test_deltalake.py
+++ b/tests/formats/test_deltalake.py
@@ -157,8 +157,8 @@ class TestDeltaLake(utils.AsyncTestCase):
             [
                 {"id": "past", "meta": {"lastUpdated": now}, "value": 2},
                 {"id": "past-with-offset", "meta": {"lastUpdated": now}, "value": 2},
-                {"id": "now", "meta": {"lastUpdated": now}, "value": 1},
-                {"id": "now-without-zed", "meta": {"lastUpdated": now_without_zed}, "value": 1},
+                {"id": "now", "meta": {"lastUpdated": now}, "value": 2},
+                {"id": "now-without-zed", "meta": {"lastUpdated": now}, "value": 2},
                 {"id": "future", "meta": {"lastUpdated": future}, "value": 1},
                 {
                     "id": "future-with-offset",


### PR DESCRIPTION
Without allowing this, we can't meaningfully update rows as ETL evolves to allow more content (_data and _url fields recently, maybe future allowed extensions, that sort of thing).

This does allow more data churn, but correctness takes priority. We could maybe get both if we inserted the ETL version into every row? But for now, this is an easy tweak.

### Checklist
- [x] Consider if documentation (like in `docs/`) needs to be updated
- [x] Consider if tests should be added
