### PR TITLE
feat(deid): drop valueString instead of passing it through

### DIFF
--- a/cumulus_etl/deid/ms-config.json
+++ b/cumulus_etl/deid/ms-config.json
@@ -351,7 +351,7 @@
     {"path": "Observation.effective", "method": "keep"},
     {"path": "Observation.issued", "method": "keep"},
     {"path": "Observation.performer", "method": "keep"},
-    {"path": "Observation.value", "method": "keep"}, // should run philter on valueString
+    {"path": "Observation.value", "method": "keep"}, // we drop valueString inside ETL
     {"path": "Observation.dataAbsentReason", "method": "keep"},
     {"path": "Observation.interpretation", "method": "keep"},
     // Skip Observation.note
@@ -363,7 +363,7 @@
     {"path": "Observation.hasMember", "method": "keep"},
     {"path": "Observation.derivedFrom", "method": "keep"},
     {"path": "Observation.component.code", "method": "keep"},
-    {"path": "Observation.component.value", "method": "keep"}, // should run philter on valueString
+    {"path": "Observation.component.value", "method": "keep"}, // we drop valueString inside ETL
     {"path": "Observation.component.dataAbsentReason", "method": "keep"},
     {"path": "Observation.component.interpretation", "method": "keep"},
     // Skip Observation.component.referenceRange

--- a/docs/deid.md
+++ b/docs/deid.md
@@ -155,7 +155,6 @@ There are some freeform text fields that Cumulus ETS asks the Microsoft Anonymiz
 These fields are useful for presenting or computing a phenotype:
 - `CodeableConcept.text`
 - `Coding.display`
-- `Observation.valueString` and `Observation.component.valueString`
 
 Although Cumulus wants to largely preserve these fields,
 they may contain PHI since they are freeform text fields after all.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,14 +2,13 @@
 name = "cumulus-etl"
 requires-python = ">= 3.10"
 # These dependencies are mostly pinned to be under the next major version.
-# That makes particular sense as long as we don't have official releases yet and our code is used
-# by pulling from main directly.
-# But now there's a risk of missing a major release and bit-rotting the dependency tree.
+# That makes particular sense as long as we don't have official releases yet and our docker
+# images are built from main directly every commit.
 #
-# We should either (a) configure a bot to warn us about stale dependencies, or
-# (b) once we switch to a more planned release schedule (via docker or similar), just go back to
-# open-pinned dependencies so that we're more likely to notice new releases (we'll still have time
-# to fix any breakages since users won't immediately see the problem).
+# We mitigate the risk of missing a new release by having a bot watch for them.
+#
+# But if we ever start releasing on PyPI, we could switch to open-pinned dependencies to be
+# less annoying to pip users.
 dependencies = [
     "ctakesclient >= 5.1, < 6",
     "cumulus-fhir-support >= 1.2, < 2",

--- a/tests/deid/test_deid_philter.py
+++ b/tests/deid/test_deid_philter.py
@@ -23,21 +23,6 @@ class TestPhilter(AsyncTestCase):
             {"Coding": {"display": "Patient 012-34-5678"}},
             {"Coding": {"display": "Patient ***-**-****"}},
         ),
-        (
-            # philter catches the month for some reason, but correctly leaves the date numbers alone
-            {"resourceType": "Observation", "valueString": "Born on december 12 2012"},
-            {"resourceType": "Observation", "valueString": "Born on ******** 12 2012"},
-        ),
-        (
-            {
-                "resourceType": "Observation",
-                "component": [{"valueString": "Contact at foo@bar.com"}],
-            },
-            {
-                "resourceType": "Observation",
-                "component": [{"valueString": "Contact at ***@***.***"}],
-            },
-        ),
     )
     @ddt.unpack
     def test_scrub_resource(self, resource, expected):


### PR DESCRIPTION
Previously, we would let Observation.valueString (and its component form) through, optionally masking it with philter if you passed --philter in.

But it held PHI too often, and if we ever will use the field, it will likely be via ETL-side NLP. We don't need to keep the string intact into Athena.

So now, we unconditionally drop Observation.valueString, replacing it with a data-absent-reason extension marker (so consumers know it _was_ present).


### Checklist
- [x] Consider if documentation (like in `docs/`) needs to be updated
- [x] Consider if tests should be added
