### PR TITLE
feat(deid): keep some fields from DiagnosticReport.presentedForm

### DIFF
--- a/cumulus_etl/deid/ms-config.json
+++ b/cumulus_etl/deid/ms-config.json
@@ -172,7 +172,7 @@
     {"path": "DiagnosticReport.media.link", "method": "keep"},
     // Skip DiagnosticReport.conclusion
     {"path": "DiagnosticReport.conclusionCode", "method": "keep"},
-    // Skip DiagnosticReport.presentedForm (can add back later when/if we want to run NLP on it)
+    {"path": "DiagnosticReport.presentedForm", "method": "keep"}, // will be dropped later after running NLP on it
 
     // ** DocumentReference: https://www.hl7.org/fhir/R4/documentreference.html **
     // Skip DocumentReference.masterIdentifier

--- a/cumulus_etl/deid/scrubber.py
+++ b/cumulus_etl/deid/scrubber.py
@@ -436,12 +436,14 @@ class Scrubber:
     @staticmethod
     def _check_attachments(resource_type: str, node_path: str, key: str, value: Any) -> Any:
         """Strip any attachment data"""
-        if (
-            resource_type == "DocumentReference"
-            and node_path == "root.content.attachment"
-            and key in {"data", "url"}
+        if any(
+            (
+                (resource_type == "DiagnosticReport" and node_path == "root.presentedForm"),
+                (resource_type == "DocumentReference" and node_path == "root.content.attachment"),
+            )
         ):
-            raise MaskValue
+            if key in {"data", "url"}:
+                raise MaskValue
 
         return value
 

--- a/cumulus_etl/fhir/fhir_client.py
+++ b/cumulus_etl/fhir/fhir_client.py
@@ -283,8 +283,9 @@ def create_fhir_client_for_cli(
         raise SystemExit(errors.ARGS_INVALID) from exc
 
     client_resources = set(resources)
-    if "DocumentReference" in client_resources:
-        # A DocumentReference scope implies a Binary scope as well, since we'll usually need to download attachments
+    if {"DiagnosticReport", "DocumentReference"} & client_resources:
+        # Resources with attachments imply a Binary scope as well,
+        # since we'll usually need to download the referenced content.
         client_resources.add("Binary")
 
     return FhirClient(

--- a/tests/data/mstool/input/DiagnosticReport.ndjson
+++ b/tests/data/mstool/input/DiagnosticReport.ndjson
@@ -20,5 +20,5 @@
   }],
   "conclusion" : "dropped",
   "conclusionCode" : [{ "text": "kept" }],
-  "presentedForm" : [{ "title": "dropped" }]
+  "presentedForm" : [{ "data": "xxx", "title": "dropped" }]
 }

--- a/tests/data/mstool/output/DiagnosticReport.ndjson
+++ b/tests/data/mstool/output/DiagnosticReport.ndjson
@@ -23,5 +23,6 @@
   "media" : [{
     "link" : { "reference": "Media/x" }
   }],
-  "conclusionCode" : [{ "text": "kept" }]
+  "conclusionCode" : [{ "text": "kept" }],
+  "presentedForm" : [{ "data": "xxx" }]
 }

--- a/tests/deid/test_deid_scrubber.py
+++ b/tests/deid/test_deid_scrubber.py
@@ -66,6 +66,45 @@ class TestScrubber(utils.AsyncTestCase):
             f"Encounter/{scrubber.codebook.fake_id('Encounter', '67890')}",
         )
 
+    def test_diagnosticreport(self):
+        """Verify a basic DiagnosticReport has attachments stripped"""
+        report = {
+            "resourceType": "DiagnosticReport",
+            "id": "dr1",
+            "presentedForm": [
+                {
+                    "data": "blarg",
+                    "language": "en",
+                    "size": 5,
+                },
+                {
+                    "url": "https://example.com/",
+                    "contentType": "text/plain",
+                },
+            ],
+        }
+
+        scrubber = Scrubber()
+        self.assertTrue(scrubber.scrub_resource(report))
+        self.assertEqual(
+            report,
+            {
+                "resourceType": "DiagnosticReport",
+                "id": scrubber.codebook.fake_id("DiagnosticReport", "dr1"),
+                "presentedForm": [
+                    {
+                        "_data": MASKED_EXTENSION,
+                        "language": "en",
+                        "size": 5,
+                    },
+                    {
+                        "_url": MASKED_EXTENSION,
+                        "contentType": "text/plain",
+                    },
+                ],
+            },
+        )
+
     def test_documentreference(self):
         """Test DocumentReference, which is interesting because of its list of encounters and attachments"""
         docref = {


### PR DESCRIPTION
Specifically, treat it the same as we treat DocumentReference.content.
- Strip data & url into _data & _url data-absent-reason extensions.
- But keep all the interesting metadata like contentType and language.
- Add Binary scope when requesting DiagnosticReport scopes.


### Checklist
- [x] Consider if documentation (like in `docs/`) needs to be updated
- [x] Consider if tests should be added
