### PR TITLE
Always prefer resource rows that come later

### DIFF
--- a/cumulus_etl/etl/tasks/base.py
+++ b/cumulus_etl/etl/tasks/base.py
@@ -326,7 +326,13 @@ class EtlTask:
             id_set.add(row_id)
             return True
 
-        return [row for row in rows if is_unique(row)]
+        # Uniquify in reverse, so that later rows will be preferred.
+        # This makes it easy to throw updates of source data alongside the originals,
+        # by either appending to an ndjson file or adding new files that sort later.
+        rows = [row for row in reversed(rows) if is_unique(row)]
+        # But keep original row ordering for cleanliness of ndjson output-format ordering.
+        rows.reverse()
+        return rows
 
     def _write_one_table_batch(self, rows: list[dict], table_index: int, batch_index: int) -> bool:
         # Checkpoint scrubber data before writing to the store, because if we get interrupted, it's safer to have an

--- a/tests/etl/test_etl_cli.py
+++ b/tests/etl/test_etl_cli.py
@@ -455,14 +455,26 @@ class TestEtlFormats(BaseEtlSimple):
             {
                 "_delta_log/00000000000000000000.json",  # create
                 "_delta_log/.00000000000000000000.json.crc",
+                "_delta_log/00000000000000000000.crc",
+                "_delta_log/.00000000000000000000.crc.crc",
                 "_delta_log/00000000000000000001.json",  # merge
                 "_delta_log/.00000000000000000001.json.crc",
+                "_delta_log/00000000000000000001.crc",
+                "_delta_log/.00000000000000000001.crc.crc",
                 "_delta_log/00000000000000000002.json",  # optimize
                 "_delta_log/.00000000000000000002.json.crc",
+                "_delta_log/00000000000000000002.crc",
+                "_delta_log/.00000000000000000002.crc.crc",
                 "_delta_log/00000000000000000003.json",  # vacuum start
                 "_delta_log/.00000000000000000003.json.crc",
+                "_delta_log/00000000000000000003.crc",
+                "_delta_log/.00000000000000000003.crc.crc",
                 "_delta_log/00000000000000000004.json",  # vacuum end
                 "_delta_log/.00000000000000000004.json.crc",
+                "_delta_log/00000000000000000004.crc",
+                "_delta_log/.00000000000000000004.crc.crc",
+                "_delta_log/_last_vacuum_info",
+                "_delta_log/._last_vacuum_info.crc",
                 "_symlink_format_manifest/manifest",
                 "_symlink_format_manifest/.manifest.crc",
             },


### PR DESCRIPTION
When iterating through the input ndjson, if we see the same row ID inside a batch, we now prefer the row that came later.

This means that our behavior is more consistent:
- If rows are in same batch, later is preferred (new)
- If rows are across batches, later is preferred (same)

This way, you can safely throw ndjson updates to your original FHIR data alongside the original data and it can reliably be processed (as long as you choose good filename ordering).


### Checklist
- [x] Consider if documentation (like in `docs/`) needs to be updated
- [x] Consider if tests should be added
