### PR TITLE
fix: improve FHIR-root-URL parsing to cover more cases

### DIFF
--- a/cumulus_etl/fhir/__init__.py
+++ b/cumulus_etl/fhir/__init__.py
@@ -2,10 +2,10 @@
 
 from .fhir_client import FhirClient, create_fhir_client_for_cli
 from .fhir_utils import (
+    FhirUrl,
     download_reference,
     get_docref_note,
     parse_datetime,
-    parse_group_from_url,
     ref_resource,
     unref_resource,
 )

--- a/cumulus_etl/loaders/fhir/bulk_export.py
+++ b/cumulus_etl/loaders/fhir/bulk_export.py
@@ -74,7 +74,7 @@ class BulkExporter:
 
         # Public properties, to be read after the export:
         self.export_datetime = None
-        self.group_name = fhir.parse_group_from_url(self._url)
+        self.group_name = fhir.FhirUrl(self._url).group
         self.export_url = self._url
 
     def format_kickoff_url(

--- a/cumulus_etl/loaders/fhir/export_log.py
+++ b/cumulus_etl/loaders/fhir/export_log.py
@@ -76,7 +76,7 @@ class BulkExportLogParser:
 
     def _parse_kickoff(self, row: dict) -> None:
         details = row["eventDetail"]
-        self.group_name = fhir.parse_group_from_url(details["exportUrl"])
+        self.group_name = fhir.FhirUrl(details["exportUrl"]).group
         self.export_url = details["exportUrl"]
 
     def _parse_status_complete(self, row: dict) -> None:

--- a/tests/fhir/test_fhir_client.py
+++ b/tests/fhir/test_fhir_client.py
@@ -419,16 +419,8 @@ IRxyq6i4LnRleQHDKzI0hdZJPEQd3k3RsPC9IsBf0A==
             fhir.create_fhir_client_for_cli(args, store.Root("/tmp"), [])
         self.assertEqual(errors.ARGS_INVALID, cm.exception.code)
 
-    @ddt.data(
-        "http://example.invalid/root/",
-        "http://example.invalid/root/$export?",
-        "http://example.invalid/root/Group/xxx",
-        "http://example.invalid/root/Group/xxx/$export?_type=Patient",
-        "http://example.invalid/root/Patient",
-        "http://example.invalid/root/Patient/$export",
-    )
     @mock.patch("cumulus_etl.fhir.fhir_client.FhirClient")
-    def test_can_find_auth_root(self, input_url, mock_client):
+    def test_can_find_auth_root(self, mock_client):
         """Verify that we detect the auth root for an input URL"""
         args = argparse.Namespace(
             fhir_url=None,
@@ -439,8 +431,10 @@ IRxyq6i4LnRleQHDKzI0hdZJPEQd3k3RsPC9IsBf0A==
             basic_passwd=None,
             bearer_token=None,
         )
-        fhir.create_fhir_client_for_cli(args, store.Root(input_url), [])
-        self.assertEqual("http://example.invalid/root/", mock_client.call_args[0][0])
+        fhir.create_fhir_client_for_cli(
+            args, store.Root("http://example.invalid/root/Group/xxx/$export?_type=Patient"), []
+        )
+        self.assertEqual("http://example.invalid/root", mock_client.call_args[0][0])
 
     async def test_must_be_context_manager(self):
         """Verify that FHIRClient enforces its use as a context manager."""

--- a/tests/loaders/ndjson/test_ndjson_loader.py
+++ b/tests/loaders/ndjson/test_ndjson_loader.py
@@ -207,7 +207,7 @@ class TestNdjsonLoader(AsyncTestCase):
                     "--skip-init-checks",
                 ]
             )
-        self.assertEqual("https://example.com/hello1/", mock_client.call_args[0][0])
+        self.assertEqual("https://example.com/hello1", mock_client.call_args[0][0])
 
         # Confirm that we don't allow conflicting URLs
         with self.assertRaises(SystemExit):


### PR DESCRIPTION
Before, we were just using some regexes on the URL, but let's actually use a parser and separate out the pieces.

This is better in general, but also happens to let us handle cases like the user putting an export URL like ".../$export?_type=..." on the shell, having the shell zero-out the $export string because it thinks it is a variable, and then us seeing a URL like "/?_type=..." (which isn't really a valid URL, but we will insert missing $export strings later in the process).

As part of this, I refactored some instances of URL parsing into one single FhirUrl class, which we can build upon in the future as needed.

### Checklist
- [x] Consider if documentation (like in `docs/`) needs to be updated
- [x] Consider if tests should be added
