### PR TITLE
feat: add inlining options and a new `inline` command

### DIFF
--- a/cumulus_etl/cli.py
+++ b/cumulus_etl/cli.py
@@ -9,7 +9,7 @@ import tempfile
 
 import rich.logging
 
-from cumulus_etl import common, etl, export, upload_notes
+from cumulus_etl import common, etl, export, inliner, upload_notes
 from cumulus_etl.etl import convert, init
 
 
@@ -20,6 +20,7 @@ class Command(enum.Enum):
     ETL = "etl"
     EXPORT = "export"
     INIT = "init"
+    INLINE = "inline"
     UPLOAD_NOTES = "upload-notes"
 
     # Why isn't this part of Enum directly...?
@@ -69,13 +70,15 @@ async def main(argv: list[str]) -> None:
         run_method = export.run_export
     elif subcommand == Command.INIT.value:
         run_method = init.run_init
+    elif subcommand == Command.INLINE.value:
+        run_method = inliner.run_inline
     else:
         parser.description = "Extract, transform, and load FHIR data."
         if not subcommand:
             # Add a note about other subcommands we offer, and tell argparse not to wrap our formatting
             parser.formatter_class = argparse.RawDescriptionHelpFormatter
             parser.description += "\n\nother commands available:\n"
-            parser.description += "  convert\n  export\n  init\n  upload-notes"
+            parser.description += "  convert\n  export\n  init\n  inline\n  upload-notes"
         run_method = etl.run_etl
 
     with tempfile.TemporaryDirectory() as tempdir:

--- a/cumulus_etl/cli_utils.py
+++ b/cumulus_etl/cli_utils.py
@@ -1,6 +1,7 @@
 """Helper methods for CLI parsing."""
 
 import argparse
+import itertools
 import os
 import socket
 import tempfile
@@ -61,6 +62,25 @@ def add_bulk_export(parser: argparse.ArgumentParser, *, as_subgroup: bool = True
         "--until", metavar="TIMESTAMP", help="end date for export from the FHIR server"
     )
     parser.add_argument("--resume", metavar="URL", help="polling status URL from a previous export")
+    parser.add_argument(
+        "--inline",
+        action="store_true",
+        help="attachments will be inlined after the export",
+    )
+    parser.add_argument(
+        "--inline-resource",
+        metavar="RESOURCES",
+        action="append",
+        help="only consider this resource for inlining (default is all supported inline targets: "
+        "DiagnosticReport and DocumentReference)",
+    )
+    parser.add_argument(
+        "--inline-mimetype",
+        metavar="MIMETYPES",
+        action="append",
+        help="only inline this attachment mimetype (default is text, HTML, and XHTML)",
+        default=["text/plain", "text/html", "application/xhtml+xml"],
+    )
     return parser
 
 
@@ -176,3 +196,44 @@ def make_progress_bar() -> rich.progress.Progress:
         rich.progress.TimeElapsedColumn(),
     ]
     return rich.progress.Progress(*columns)
+
+
+def expand_inline_resources(arg: Iterable[str] | None) -> set[str]:
+    """
+    This converts a list of inline resource args into the final properly cased resource names.
+
+    If you have an arg like --inline-resource, this will process that for you.
+    """
+    allowed = {"diagnosticreport": "DiagnosticReport", "documentreference": "DocumentReference"}
+
+    if arg is None:
+        return set(allowed.values())
+
+    resources = expand_comma_list_arg(arg)
+    for resource in resources:
+        if resource.casefold() not in allowed:
+            errors.fatal(f"Unsupported resource for inlining: {resource}", errors.ARGS_INVALID)
+
+    return {allowed[resource.casefold()] for resource in resources}
+
+
+def expand_comma_list_arg(arg: Iterable[str] | None, casefold: bool = False) -> Iterable[str]:
+    """
+    This converts a list of string args, splits any strings on commas, and combines results.
+
+    This is useful for CLI arguments with action="append" but you also want to allow comma
+    separated args. --task does this, as well as others.
+
+    An example CLI:
+      --task=patient --task=condition,procedure
+    Would give:
+      ["patient", "condition,procedure"]
+    And this method would turn that into:
+      ["patient", "condition", procedure"]
+    """
+    if arg is None:
+        return []
+    split_args = itertools.chain.from_iterable(x.split(",") for x in arg)
+    if casefold:
+        return map(str.casefold, split_args)
+    return split_args

--- a/cumulus_etl/common.py
+++ b/cumulus_etl/common.py
@@ -232,7 +232,8 @@ class NdjsonWriter:
         # lazily create the file, to avoid 0-line ndjson files (unless created in __init__)
         self._ensure_file()
 
-        json.dump(obj, self._file)
+        # Specify separators for most compact (no whitespace) representation to save disk space.
+        json.dump(obj, self._file, separators=(",", ":"))
         self._file.write("\n")
 
 

--- a/cumulus_etl/errors.py
+++ b/cumulus_etl/errors.py
@@ -37,6 +37,7 @@ TASK_HELP = 35
 MISSING_REQUESTED_RESOURCES = 36
 TOO_MANY_SMART_CREDENTIALS = 37
 BAD_SMART_CREDENTIAL = 38
+INLINE_TASK_FAILED = 39
 
 
 class FatalError(Exception):
@@ -44,11 +45,25 @@ class FatalError(Exception):
 
 
 class NetworkError(FatalError):
-    """An unrecoverable network error"""
+    """A network error"""
 
     def __init__(self, msg: str, response: httpx.Response):
         super().__init__(msg)
         self.response = response
+
+
+class FatalNetworkError(NetworkError):
+    """An unrecoverable network error that should not be retried"""
+
+    def __init__(self, *args):
+        super().__init__(*args)
+
+
+class TemporaryNetworkError(NetworkError):
+    """An recoverable network error that could be retried"""
+
+    def __init__(self, *args):
+        super().__init__(*args)
 
 
 class FhirConnectionConfigError(FatalError):

--- a/cumulus_etl/etl/cli.py
+++ b/cumulus_etl/etl/cli.py
@@ -309,6 +309,9 @@ async def etl_main(args: argparse.Namespace) -> None:
     # Grab a list of all required resource types for the tasks we are running
     required_resources = set(t.resource for t in selected_tasks)
 
+    inline_resources = cli_utils.expand_inline_resources(args.inline_resource)
+    inline_mimetypes = set(cli_utils.expand_comma_list_arg(args.inline_mimetype, casefold=True))
+
     # Create a client to talk to a FHIR server.
     # This is useful even if we aren't doing a bulk export, because some resources like DocumentReference can still
     # reference external resources on the server (like the document text).
@@ -326,6 +329,9 @@ async def etl_main(args: argparse.Namespace) -> None:
                 since=args.since,
                 until=args.until,
                 resume=args.resume,
+                inline=args.inline,
+                inline_resources=inline_resources,
+                inline_mimetypes=inline_mimetypes,
             )
 
         required_resources = await check_available_resources(

--- a/cumulus_etl/etl/tasks/task_factory.py
+++ b/cumulus_etl/etl/tasks/task_factory.py
@@ -1,11 +1,10 @@
 """Finds and creates ETL tasks"""
 
-import itertools
 import sys
 from collections.abc import Iterable
 from typing import TypeVar
 
-from cumulus_etl import errors
+from cumulus_etl import cli_utils, errors
 from cumulus_etl.etl.studies import covid_symptom, hftest
 from cumulus_etl.etl.tasks import basic_tasks
 
@@ -67,13 +66,11 @@ def get_selected_tasks(
     :param filter_tags: only tasks that have all the listed tags will be eligible for selection
     :returns: a list of selected EtlTask subclasses, to instantiate and run
     """
-    names = names and set(itertools.chain.from_iterable(t.lower().split(",") for t in names))
-    filter_tags = filter_tags and list(
-        itertools.chain.from_iterable(t.lower().split(",") for t in filter_tags)
-    )
-    filter_tag_set = set(filter_tags or [])
+    names = set(cli_utils.expand_comma_list_arg(names, casefold=True))
+    filter_tags = list(cli_utils.expand_comma_list_arg(filter_tags, casefold=True))
+    filter_tag_set = set(filter_tags)
 
-    if names and "help" in names:
+    if "help" in names:
         # OK, we actually are just going to print the list of all task names and be done.
         _print_task_names()
         raise SystemExit(errors.TASK_HELP)  # not an *error* exactly, but not successful ETL either

--- a/cumulus_etl/export/cli.py
+++ b/cumulus_etl/export/cli.py
@@ -26,6 +26,9 @@ async def export_main(args: argparse.Namespace) -> None:
     required_resources = {t.resource for t in selected_tasks}
     using_default_tasks = not args.task and not args.task_filter
 
+    inline_resources = cli_utils.expand_inline_resources(args.inline_resource)
+    inline_mimetypes = set(cli_utils.expand_comma_list_arg(args.inline_mimetype, casefold=True))
+
     fhir_root = store.Root(args.url_input)
     client = fhir.create_fhir_client_for_cli(args, fhir_root, required_resources)
 
@@ -39,6 +42,9 @@ async def export_main(args: argparse.Namespace) -> None:
             since=args.since,
             until=args.until,
             resume=args.resume,
+            inline=args.inline,
+            inline_resources=inline_resources,
+            inline_mimetypes=inline_mimetypes,
         )
         await loader.load_from_bulk_export(
             sorted(required_resources), prefer_url_resources=using_default_tasks

--- a/cumulus_etl/fhir/__init__.py
+++ b/cumulus_etl/fhir/__init__.py
@@ -5,6 +5,7 @@ from .fhir_utils import (
     FhirUrl,
     download_reference,
     get_docref_note,
+    parse_content_type,
     parse_datetime,
     ref_resource,
     unref_resource,

--- a/cumulus_etl/fhir/fhir_client.py
+++ b/cumulus_etl/fhir/fhir_client.py
@@ -1,8 +1,10 @@
 """HTTP client that talk to a FHIR server"""
 
 import argparse
+import asyncio
+import email
 import enum
-from collections.abc import Iterable
+from collections.abc import Callable, Iterable
 from json import JSONDecodeError
 
 import httpx
@@ -27,6 +29,9 @@ class FhirClient:
 
     See https://hl7.org/fhir/smart-app-launch/backend-services.html for details.
     """
+
+    # Limit the number of connections open at once, because EHRs tend to be very busy.
+    MAX_CONNECTIONS = 5
 
     def __init__(
         self,
@@ -71,8 +76,7 @@ class FhirClient:
         self._capabilities: dict = {}
 
     async def __aenter__(self):
-        # Limit the number of connections open at once, because EHRs tend to be very busy.
-        limits = httpx.Limits(max_connections=5)
+        limits = httpx.Limits(max_connections=self.MAX_CONNECTIONS)
         timeout = 300  # five minutes to be generous
         # Follow redirects by default -- some EHRs definitely use them for bulk download files,
         # and might use them in other cases, who knows.
@@ -86,7 +90,15 @@ class FhirClient:
             await self._session.aclose()
 
     async def request(
-        self, method: str, path: str, headers: dict | None = None, stream: bool = False
+        self,
+        method: str,
+        path: str,
+        headers: dict | None = None,
+        stream: bool = False,
+        retry_delays: Iterable[int] | None = None,
+        request_callback: Callable[[], None] = None,
+        error_callback: Callable[[errors.NetworkError], None] = None,
+        retry_callback: Callable[[httpx.Response, int], None] = None,
     ) -> httpx.Response:
         """
         Issues an HTTP request.
@@ -104,62 +116,80 @@ class FhirClient:
         :param path: relative path from the server root to request
         :param headers: optional header dictionary
         :param stream: whether to stream content in or load it all into memory at once
+        :param retry_delays: how many minutes to wait between retries, and how many retries to do
+        :param request_callback: called right before each request
+        :param error_callback: called after each network error
+        :param retry_callback: called right before sleeping
         :returns: The response object
         """
-        url = fhir_auth.urljoin(self._server_root, path)
+        # MIKE: changes from before.
+        # - 429 is handled like a server error, and we don't reset the error count for it
+        #   - We log an error message for it
+        #   - We don't log a progress call for it
+        #   - We use the next delay period rather than 60s for it
+        # - Retry-After header is no longer always fully accepted when retrying errors
+        #   - It's now a capped by the provided retry time
+        #   - i.e. Retry-After can speed us up, but not slow us down
+        # - We now support Retry-After headers that are http-dates
+        # - Instead of retrying on 429 and ALL 5xx errors, only retry a specific list of codes
 
-        final_headers = {
-            "Accept": "application/fhir+json",
-            "Accept-Charset": "UTF-8",
-        }
-        # merge in user headers with defaults
-        final_headers.update(headers or {})
+        retry_delays = [] if retry_delays is None else list(retry_delays)
+        retry_delays.append(None)  # add a final no-delay request
 
-        response = await self._request_with_signed_headers(
-            method, url, final_headers, stream=stream
-        )
+        # Actually loop, attempting the request multiple times as needed
+        for delay in retry_delays:
+            if request_callback:
+                request_callback()
 
-        # Check if our access token expired and thus needs to be refreshed
-        if response.status_code == 401:
-            await self._auth.authorize(self._session, reauthorize=True)
-            if stream:
-                await response.aclose()
-            response = await self._request_with_signed_headers(
-                method, url, final_headers, stream=stream
-            )
+            try:
+                return await self._one_request(method, path, headers=headers, stream=stream)
+            except errors.NetworkError as exc:
+                if error_callback:
+                    error_callback(exc)
+
+                if delay is None or isinstance(exc, errors.FatalNetworkError):
+                    raise
+
+                response = exc.response
+
+            # Respect Retry-After, but only if it lets us request faster than we would have
+            # otherwise. Which is maybe a little hostile, but this assumes that we are using
+            # reasonable delays ourselves (for example, our retry_delay list is in *minutes* not
+            # seconds). The point of this logic is so that the caller can reliably predict that
+            # if they give delays totaling 10 minutes, that's the longest we'll wait.
+            delay *= 60  # switch from minutes to seconds
+            delay = min(self.get_retry_after(response, delay), delay)
+
+            if retry_callback:
+                retry_callback(response, delay)
+
+            # And actually do the waiting
+            await asyncio.sleep(delay)
+
+    def get_retry_after(self, response: httpx.Response, default: int) -> int:
+        """
+        Returns the value of the Retry-After header, in seconds.
+
+        Parsing can be tricky because the header is also allowed to be in http-date format,
+        providing a specific timestamp.
+
+        Since seconds is easier to work with for the ETL, we normalize to seconds.
+
+        See https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Retry-After
+        """
+        value = response.headers.get("Retry-After", default)
+        try:
+            return int(value)
+        except ValueError:
+            pass
 
         try:
-            response.raise_for_status()
-        except httpx.HTTPStatusError as exc:
-            if exc.response.status_code == 429:
-                # 429 is a special kind of error -- it's not fatal, just a request to wait a bit. So let it pass.
-                return exc.response
+            retry_time = email.utils.parsedate_to_datetime(value)
+        except ValueError:
+            return default
 
-            if stream:
-                await response.aread()
-                await response.aclose()
-
-            # All other 4xx or 5xx codes are treated as fatal errors
-            message = None
-            try:
-                json_response = exc.response.json()
-                if not isinstance(json_response, dict):
-                    message = exc.response.text
-                elif json_response.get("resourceType") == "OperationOutcome":
-                    issue = json_response["issue"][0]  # just grab first issue
-                    message = issue.get("details", {}).get("text")
-                    message = message or issue.get("diagnostics")
-            except JSONDecodeError:
-                message = exc.response.text
-            if not message:
-                message = str(exc)
-
-            raise errors.NetworkError(
-                f'An error occurred when connecting to "{url}": {message}',
-                response,
-            ) from exc
-
-        return response
+        delay = retry_time - common.datetime_now()
+        return max(0, delay.total_seconds())
 
     def get_capabilities(self) -> dict:
         """
@@ -214,6 +244,76 @@ class FhirClient:
             self._server_type = ServerType.EPIC
 
         self._capabilities = capabilities
+
+    async def _one_request(
+        self, method: str, path: str, headers: dict | None = None, stream: bool = False
+    ) -> httpx.Response:
+        url = fhir_auth.urljoin(self._server_root, path)
+
+        final_headers = {
+            "Accept": "application/fhir+json",
+            "Accept-Charset": "UTF-8",
+        }
+        # merge in user headers with defaults
+        final_headers.update(headers or {})
+
+        response = await self._request_with_signed_headers(
+            method, url, final_headers, stream=stream
+        )
+
+        # Check if our access token expired and thus needs to be refreshed
+        if response.status_code == 401:
+            await self._auth.authorize(self._session, reauthorize=True)
+            if stream:
+                await response.aclose()
+            response = await self._request_with_signed_headers(
+                method, url, final_headers, stream=stream
+            )
+
+        try:
+            response.raise_for_status()
+        except httpx.HTTPStatusError as exc:
+            if stream:
+                await response.aread()
+                await response.aclose()
+
+            # All other 4xx or 5xx codes are treated as fatal errors
+            message = None
+            try:
+                json_response = exc.response.json()
+                if not isinstance(json_response, dict):
+                    message = exc.response.text
+                elif json_response.get("resourceType") == "OperationOutcome":
+                    issue = json_response["issue"][0]  # just grab first issue
+                    message = issue.get("details", {}).get("text")
+                    message = message or issue.get("diagnostics")
+            except JSONDecodeError:
+                message = exc.response.text
+            if not message:
+                message = str(exc)
+
+            if response.status_code in {
+                # https://developer.mozilla.org/en-US/docs/Web/HTTP/Status
+                408,  # request timeout
+                429,  # too many requests (server is busy)
+                # 500 is so generic an error that you might think it is worth retrying.
+                # But in my (mterry's) experience, it does not seem to be a fixable error
+                # on Cerner at least. TODO: confirm on Epic
+                # 500,  # internal server error
+                502,  # bad gateway (can be temporary blip)
+                503,  # service unavailable (temporary blip)
+                504,  # gateway timeout (temporary blip)
+            }:
+                error_class = errors.TemporaryNetworkError
+            else:
+                error_class = errors.FatalNetworkError
+
+            raise error_class(
+                f'An error occurred when connecting to "{url}": {message}',
+                response,
+            ) from exc
+
+        return response
 
     async def _request_with_signed_headers(
         self, method: str, url: str, headers: dict, **kwargs

--- a/cumulus_etl/fhir/fhir_utils.py
+++ b/cumulus_etl/fhir/fhir_utils.py
@@ -181,7 +181,7 @@ async def download_reference(client: "FhirClient", reference: str) -> dict | Non
 ######################################################################################################################
 
 
-def _parse_content_type(content_type: str) -> (str, str):
+def parse_content_type(content_type: str) -> (str, str):
     """Returns (mimetype, encoding)"""
     msg = email.message.EmailMessage()
     msg["content-type"] = content_type
@@ -212,7 +212,7 @@ async def _get_docref_note_from_attachment(client: "FhirClient", attachment: dic
 
     :returns: the attachment's note text
     """
-    mimetype, charset = _parse_content_type(attachment["contentType"])
+    mimetype, charset = parse_content_type(attachment["contentType"])
 
     if "data" in attachment:
         return base64.standard_b64decode(attachment["data"]).decode(charset)
@@ -270,7 +270,7 @@ async def get_docref_note(client: "FhirClient", docref: dict) -> str:
     best_attachment_priority = 0
     for index, attachment in enumerate(attachments):
         if "contentType" in attachment:
-            mimetype, _ = _parse_content_type(attachment["contentType"])
+            mimetype, _ = parse_content_type(attachment["contentType"])
             priority = _mimetype_priority(mimetype)
             if priority > best_attachment_priority:
                 best_attachment_priority = priority

--- a/cumulus_etl/inliner/__init__.py
+++ b/cumulus_etl/inliner/__init__.py
@@ -1,0 +1,4 @@
+"""Inline attachments inside existing NDJSON"""
+
+from .cli import run_inline
+from .inliner import inliner

--- a/cumulus_etl/inliner/cli.py
+++ b/cumulus_etl/inliner/cli.py
@@ -1,0 +1,62 @@
+"""Inline attachments inside NDJSON by downloading the URLs"""
+
+import argparse
+
+from cumulus_etl import cli_utils, common, errors, fhir, store
+from cumulus_etl.inliner import inliner
+
+
+def define_inline_parser(parser: argparse.ArgumentParser) -> None:
+    parser.usage = "cumulus-etl inline [OPTION]... DIR FHIR_URL"
+
+    parser.add_argument("src", metavar="/path/to/input")
+    parser.add_argument("url_input", metavar="https://fhir.example.com/")
+
+    parser.add_argument(
+        "--resource",
+        metavar="RESOURCES",
+        action="append",
+        help="only consider this resource (default is all supported inline targets: "
+        "DiagnosticReport and DocumentReference)",
+    )
+    parser.add_argument(
+        "--mimetype",
+        metavar="MIMETYPES",
+        action="append",
+        help="only inline this attachment mimetype (default is text, HTML, and XHTML)",
+        default=["text/plain", "text/html", "application/xhtml+xml"],
+    )
+
+    cli_utils.add_auth(parser, use_fhir_url=False)
+    cli_utils.add_aws(parser)
+
+
+async def inline_main(args: argparse.Namespace) -> None:
+    """Exports data from an EHR to a folder."""
+    # record filesystem options before creating Roots
+    store.set_user_fs_options(vars(args))
+
+    src_root = store.Root(args.src)
+    fhir_root = store.Root(args.url_input)
+
+    # Help the user in case they got the order of the arguments wrong.
+    if fhir_root.protocol not in {"http", "https"}:
+        errors.fatal(
+            f"Provided URL {args.url_input} does not look like a URL. See --help for argument usage.",
+            errors.ARGS_INVALID,
+        )
+
+    resources = cli_utils.expand_inline_resources(args.resource)
+    mimetypes = set(cli_utils.expand_comma_list_arg(args.mimetype, casefold=True))
+
+    common.print_header()
+
+    async with fhir.create_fhir_client_for_cli(args, fhir_root, {"Binary"} | resources) as client:
+        await inliner.inliner(client, src_root, resources, mimetypes)
+
+
+async def run_inline(parser: argparse.ArgumentParser, argv: list[str]) -> None:
+    """Parses an inline CLI"""
+    define_inline_parser(parser)
+    args = parser.parse_args(argv)
+    await inline_main(args)

--- a/cumulus_etl/inliner/inliner.py
+++ b/cumulus_etl/inliner/inliner.py
@@ -1,0 +1,227 @@
+import argparse
+import asyncio
+import base64
+import dataclasses
+import hashlib
+import tempfile
+from collections.abc import Iterable
+from functools import partial
+
+import cumulus_fhir_support
+import fsspec
+import rich.progress
+import rich.table
+
+from cumulus_etl import cli_utils, common, errors, fhir, store
+from cumulus_etl.inliner import reader, writer
+
+
+@dataclasses.dataclass
+class Stats:
+    total_attachments: int = 0
+    total_resources: int = 0
+
+    already_inlined_attachments: int = 0
+    already_inlined_resources: int = 0
+
+    newly_inlined_attachments: int = 0
+    newly_inlined_resources: int = 0
+
+    fatal_error_attachments: int = 0
+    fatal_error_resources: int = 0
+
+    fatal_retry_attachments: int = 0
+    fatal_retry_resources: int = 0
+
+    def merge_attachment_stats(self, other: "Stats") -> None:
+        """Takes stats for attachments in a resource and merges them into the resource's stats"""
+        for field in {
+            "total_attachments",
+            "already_inlined_attachments",
+            "newly_inlined_attachments",
+            "fatal_error_attachments",
+            "fatal_retry_attachments",
+        }:
+            if other_val := getattr(other, field):
+                setattr(self, field, getattr(self, field) + other_val)
+                resource_field = field.replace("attachments", "resources")
+                setattr(self, resource_field, getattr(self, resource_field) + 1)
+
+
+async def inliner(
+    client: fhir.FhirClient,
+    in_root: store.Root,
+    resources: Iterable[str],
+    mimetypes: Iterable[str],
+) -> None:
+    resources = set(resources)
+    mimetypes = set(mimetypes)
+
+    # Grab files to read of the given resources
+    found_files = cumulus_fhir_support.list_multiline_json_in_dir(
+        in_root.path, resources, fsspec_fs=in_root.fs
+    )
+
+    # Predict how much work we'll have to do by getting counts of lines and files
+    if in_root.protocol == "file":
+        total_lines = sum(common.read_local_line_count(path) for path in found_files)
+    else:
+        # We shouldn't double our network usage just for pretty progress bars...
+        total_lines = 0
+    total_files = len(found_files)
+
+    # Actually do the work
+    stats = Stats()
+    with cli_utils.make_progress_bar() as progress:
+        progress_task = progress.add_task("Inlining…", total=total_lines or total_files)
+        for path in found_files:
+            await _inline_one_file(
+                client,
+                path,
+                in_root.fs,
+                mimetypes=mimetypes,
+                stats=stats,
+                progress=progress if total_lines else None,
+                progress_task=progress_task if total_lines else None,
+            )
+            if not total_lines:
+                progress.update(progress_task, advance=1)
+
+    table = rich.table.Table("", "Attachments", "Resources", box=None)
+    table.add_row("Total examined", str(stats.total_attachments), str(stats.total_resources))
+    if stats.already_inlined_attachments:
+        table.add_row(
+            "Already inlined",
+            str(stats.already_inlined_attachments),
+            str(stats.already_inlined_resources),
+        )
+    table.add_row(
+        "Newly inlined", str(stats.newly_inlined_attachments), str(stats.newly_inlined_resources)
+    )
+    if stats.fatal_error_attachments:
+        table.add_row(
+            "Fatal errors", str(stats.fatal_error_attachments), str(stats.fatal_error_resources)
+        )
+    if stats.fatal_retry_resources:
+        table.add_row(
+            "Retried but gave up",
+            str(stats.fatal_retry_attachments),
+            str(stats.fatal_retry_resources),
+        )
+    rich.get_console().print(table)
+
+
+async def _inline_one_file(
+    client: fhir.FhirClient,
+    path: str,
+    fs: fsspec.AbstractFileSystem,
+    *,
+    mimetypes: set[str],
+    stats: Stats,
+    progress: rich.progress.Progress | None,
+    progress_task: rich.progress.TaskID | None,
+) -> None:
+    with tempfile.NamedTemporaryFile() as output_file:
+        # Use an ordered NDJSON writer to preserve the order of lines in the input file,
+        # which preserves the ability for users to append updated row data to files.
+        with writer.OrderedNdjsonWriter(output_file.name) as output:
+            await reader.peek_ahead_processor(
+                cumulus_fhir_support.read_multiline_json(path, fsspec_fs=fs),
+                partial(
+                    _inline_one_line,
+                    client=client,
+                    mimetypes=mimetypes,
+                    output=output,
+                    stats=stats,
+                    progress=progress,
+                    progress_task=progress_task,
+                ),
+                # Look at twice the allowed connections - downloads will block, but that's OK.
+                # This will allow us to download some attachments while other workers are sleeping
+                # because they are waiting to retry due to an HTTP error.
+                peek_at=client.MAX_CONNECTIONS * 2,
+            )
+        # Atomically swap out the inlined version with the original
+        with fs.transaction:
+            fs.put_file(output_file.name, path)
+
+
+async def _inline_one_line(
+    index: int,
+    resource: dict,
+    *,
+    client: fhir.FhirClient,
+    mimetypes: set[str],
+    output: writer.OrderedNdjsonWriter,
+    stats: Stats,
+    progress: rich.progress.Progress | None,
+    progress_task: rich.progress.TaskID | None,
+) -> None:
+    match resource.get("resourceType"):
+        case "DiagnosticReport":
+            attachments = resource.get("presentedForm", [])
+        case "DocumentReference":
+            attachments = [
+                content["attachment"]
+                for content in resource.get("content", [])
+                if "attachment" in content
+            ]
+        case _:
+            attachments = []  # don't do anything, but we will leave the resource line in place
+
+    attachment_stats = Stats()
+    for attachment in attachments:
+        await _inline_one_attachment(
+            client, attachment, mimetypes=mimetypes, stats=attachment_stats
+        )
+    stats.merge_attachment_stats(attachment_stats)
+
+    output.write(index, resource)
+    if progress:
+        progress.update(progress_task, advance=1)
+
+
+async def _inline_one_attachment(
+    client: fhir.FhirClient, attachment: dict, *, mimetypes: set[str], stats: Stats
+) -> None:
+    # First, check if we should even examine this attachment
+    if "contentType" not in attachment:
+        return
+    mimetype, _charset = fhir.parse_content_type(attachment["contentType"])
+    if mimetype not in mimetypes:
+        return
+
+    # OK - this is a valid attachment to process
+    stats.total_attachments += 1
+
+    if "data" in attachment:
+        stats.already_inlined_attachments += 1
+        return
+
+    if "url" not in attachment:
+        return  # neither data nor url... nothing to do
+
+    try:
+        response = await client.request(
+            "GET",
+            attachment["url"],
+            headers={"Accept": mimetype},
+            # Only three total attempts with relatively short delays, since we are likely chewing
+            # through many many attachments and don't want to balloon our runtime.
+            retry_delays=[1, 1],  # three tries, two minutes total
+        )
+    except errors.FatalNetworkError:
+        stats.fatal_error_attachments += 1
+        return
+    except errors.TemporaryNetworkError:
+        stats.fatal_retry_attachments += 1
+        return
+
+    stats.newly_inlined_attachments += 1
+
+    attachment["data"] = base64.standard_b64encode(response.content).decode("ascii")
+    # Overwrite other associated metadata with latest info (existing metadata might be stale)
+    attachment["contentType"] = f"{mimetype}; charset={response.encoding}"
+    attachment["size"] = len(response.content)
+    sha1_hash = hashlib.sha1(response.content).digest()  # noqa: S324
+    attachment["hash"] = base64.standard_b64encode(sha1_hash).decode("ascii")

--- a/cumulus_etl/inliner/reader.py
+++ b/cumulus_etl/inliner/reader.py
@@ -1,0 +1,72 @@
+import asyncio
+
+from cumulus_etl import errors
+
+
+async def peek_ahead_iterator(iterable, *, peek_at: int):
+    """
+    This method will run several coroutines from `iterable` at a time.
+
+    Results will be yielded as they come in, out of order but with the original index.
+
+    :param iterable: a sequence of coroutines to run
+    :param peek_at: how many to load into memory and run at once
+    :returns: the result of each coroutine, in arbitrary order
+    """
+    coroutine_iter = iter(iterable)
+    coroutines_remaining = True
+    running_tasks = set()
+
+    while coroutines_remaining or running_tasks:
+        # Refill our tasks to wait upon, from the incoming list of coroutines
+        if coroutines_remaining:
+            try:
+                while len(running_tasks) < peek_at:
+                    running_tasks.add(asyncio.create_task(next(coroutine_iter)))
+            except StopIteration:
+                coroutines_remaining = False
+                if not running_tasks:
+                    break
+
+        # Wait on all running tasks for at least one to finish. Returns two sets of futures.
+        done, pending = await asyncio.wait(running_tasks, return_when=asyncio.FIRST_COMPLETED)
+
+        # Start yielding back results as they come in
+        for item in done:
+            yield item.result()
+        running_tasks = pending
+
+
+async def _worker(worker_id: int, reader, queue: asyncio.Queue, processor):
+    while True:
+        index, resource = await queue.get()
+
+        try:
+            await processor(index, resource)
+        except Exception as exc:
+            # something went wrong, this is a fatal error, so abort read/write loop
+            errors.fatal(exc, errors.INLINE_TASK_FAILED)
+
+        queue.task_done()
+
+
+async def _reader(queue: asyncio.Queue, iterable):
+    for index, item in enumerate(iterable):
+        await queue.put((index, item))
+
+
+async def peek_ahead_processor(iterable, processor, *, peek_at: int):
+    queue = asyncio.Queue(peek_at)
+    reader = asyncio.create_task(_reader(queue, iterable))
+    tasks = [asyncio.create_task(_worker(i, reader, queue, processor)) for i in range(peek_at)]
+
+    try:
+        await reader  # read all of the input, processing as we go
+        await queue.join()  # finish up final batch of workers
+    finally:
+        # Close out the tasks
+        for task in tasks:
+            task.cancel()
+
+    # TODO: return exceptions?
+    await asyncio.gather(*tasks, return_exceptions=True)

--- a/cumulus_etl/inliner/writer.py
+++ b/cumulus_etl/inliner/writer.py
@@ -1,0 +1,46 @@
+from cumulus_etl import common
+
+
+class OrderedNdjsonWriter:
+    """
+    Convenience context manager to write multiple objects to a ndjson file in order.
+
+    Specifically, it will keep the output in the intended order, even if lines are provided
+    out of order.
+
+    Note that this is not atomic - partial writes will make it to the target file.
+    And queued writes may not make it to the target file at all, if interrupted.
+    """
+
+    def __init__(self, path: str):
+        self._writer = common.NdjsonWriter(path)
+        self._queued_rows: dict[int, dict] = {}
+        self._current_num: int = 0
+
+    def __enter__(self):
+        self._writer.__enter__()
+        return self
+
+    def __exit__(self, exc_type, exc_value, traceback):
+        self._writer.__exit__(exc_type, exc_value, traceback)
+
+    def _process_queue(self) -> None:
+        while self._current_num in self._queued_rows:
+            self._writer.write(self._queued_rows.pop(self._current_num))
+            self._current_num += 1
+
+    def write(self, index: int, obj: dict) -> None:
+        """
+        Writes the object to the file at the specified row number.
+
+        May hold the row in memory until previous rows can be written first.
+        """
+        # We just queue the rows in memory until we write them out. Our expectation is that we
+        # won't hold so many in the queue that it will be a memory issue.
+        #
+        # If this does turn out to be a problem, we can explore other solutions like keeping
+        # track of byte indices for missing rows and seeking to that location, then inserting data
+        # (but you'd have to be careful to shift-down/re-write the later row data and update
+        # other byte indices).
+        self._queued_rows[index] = obj
+        self._process_queue()

--- a/cumulus_etl/loaders/fhir/bulk_export.py
+++ b/cumulus_etl/loaders/fhir/bulk_export.py
@@ -25,7 +25,7 @@ class BulkExporter:
     - Epic (https://www.epic.com/)
     """
 
-    _TIMEOUT_THRESHOLD = 60 * 60 * 24  # a day, which is probably an overly generous timeout
+    _TIMEOUT_THRESHOLD = 60 * 60 * 24 * 30  # thirty days (we've seen some multi-week Epic waits)
 
     def __init__(
         self,
@@ -280,73 +280,59 @@ class BulkExporter:
         :param retry_errors: if True, server-side errors will be retried a few times
         :returns: the HTTP response
         """
-        # Set up error handling variables.
-        # These times are extremely generous - partly because we can afford to be
-        # as a long-running async task and partly because EHR servers seem prone to
-        # outages that clear up after a bit.
-        error_retry_minutes = [1, 2, 4, 8]  # and then raise
-        max_errors = len(error_retry_minutes)
-        num_errors = 0
+
+        def _add_new_delay(response: httpx.Response, delay: int) -> None:
+            # Print a message to the user, so they don't see us do nothing for a while
+            if rich_text is not None:
+                progress_msg = response.headers.get("X-Progress", "waiting…")
+                formatted_total = common.human_time_offset(self._total_wait_time)
+                formatted_delay = common.human_time_offset(delay)
+                rich_text.plain = (
+                    f"{progress_msg} ({formatted_total} so far, waiting for {formatted_delay} more)"
+                )
+
+            self._total_wait_time += delay
 
         # Actually loop, attempting the request multiple times as needed
         while self._total_wait_time < self._TIMEOUT_THRESHOLD:
-            if log_request:
-                log_request()
-
-            try:
-                response = await self._client.request(method, path, headers=headers, stream=stream)
-            except errors.NetworkError as exc:
-                if log_error:
-                    log_error(exc)
-                if retry_errors and exc.response.is_server_error and num_errors < max_errors:
-                    response = exc.response
-                else:
-                    raise
+            response = await self._client.request(
+                method,
+                path,
+                headers=headers,
+                stream=stream,
+                # These retry times are extremely generous - partly because we can afford to be
+                # as a long-running async task and partly because EHR servers seem prone to
+                # outages that clear up after a bit.
+                retry_delays=[1, 2, 4, 8],  # five tries, 15 minutes total
+                request_callback=log_request,
+                error_callback=log_error,
+                retry_callback=_add_new_delay,
+            )
 
             if response.status_code == target_status_code:
                 return response
 
-            if response.is_server_error:
-                num_errors += 1
-            else:
-                num_errors = 0  # reset count if server is back to normal
-
-            # 202 == server is still working on it, 429 == server is busy,
-            # 5xx == server-side error. In all cases, we wait.
-            if response.status_code in [202, 429] or response.is_server_error:
-                if log_progress and not response.is_server_error:
+            # 202 == server is still working on it.
+            if response.status_code == 202:
+                if log_progress:
                     log_progress(response)
 
-                # Calculate how long to wait, with a basic exponential backoff for errors.
-                if num_errors:
-                    default_delay = error_retry_minutes[num_errors - 1] * 60
-                else:
-                    default_delay = 60  # one minute
-                delay = int(response.headers.get("Retry-After", default_delay))
-                if response.status_code == 202:
-                    # Some servers can request unreasonably long delays (e.g. I've seen Cerner
-                    # ask for five hours), which is... not helpful for our UX and often way
-                    # too long for small exports. So as long as the server isn't telling us
-                    # it's overloaded or erroring out, limit the delay time to 5 minutes.
-                    delay = min(delay, 300)
+                # Some servers can request unreasonably long delays (e.g. I've seen Cerner
+                # ask for five hours), which is... not helpful for our UX and often way
+                # too long for small exports. So limit the delay time to 5 minutes.
+                delay = min(self._client.get_retry_after(response, 60), 300)
 
-                # Print a message to the user, so they don't see us do nothing for a while
-                if rich_text is not None:
-                    progress_msg = response.headers.get("X-Progress", "waiting…")
-                    formatted_total = common.human_time_offset(self._total_wait_time)
-                    formatted_delay = common.human_time_offset(delay)
-                    rich_text.plain = f"{progress_msg} ({formatted_total} so far, waiting for {formatted_delay} more)"
-
-                # And wait as long as the server requests
+                _add_new_delay(response, delay)
                 await asyncio.sleep(delay)
-                self._total_wait_time += delay
 
             else:
-                # It feels silly to abort on an unknown *success* code, but the spec has such clear guidance on
-                # what the expected response codes are, that it's not clear if a code outside those parameters means
-                # we should keep waiting or stop waiting. So let's be strict here for now.
+                # It feels silly to abort on an unknown *success* code, but the spec has such clear
+                # guidance on what the expected response codes are, that it's not clear if a code
+                # outside those parameters means we should keep waiting or stop waiting.
+                # So let's be strict here for now.
                 raise errors.NetworkError(
-                    f"Unexpected status code {response.status_code} from the bulk FHIR export server.",
+                    f"Unexpected status code {response.status_code} "
+                    "from the bulk FHIR export server.",
                     response,
                 )
 
@@ -446,4 +432,4 @@ class BulkExporter:
         url_last_part = url.split("/")[-1]
         filename_last_part = filename.split("/")[-1]
         human_size = common.human_file_size(response.num_bytes_downloaded)
-        print(f"  Downloaded {url_last_part} as {filename_last_part} ({human_size})")
+        print(f"  Downloaded {filename_last_part} ({human_size})")

--- a/cumulus_etl/loaders/fhir/ndjson_loader.py
+++ b/cumulus_etl/loaders/fhir/ndjson_loader.py
@@ -4,7 +4,7 @@ import tempfile
 
 import cumulus_fhir_support
 
-from cumulus_etl import cli_utils, common, errors, fhir, store
+from cumulus_etl import cli_utils, common, errors, fhir, inliner, store
 from cumulus_etl.loaders import base
 from cumulus_etl.loaders.fhir.bulk_export import BulkExporter
 from cumulus_etl.loaders.fhir.export_log import BulkExportLogParser
@@ -23,6 +23,9 @@ class FhirNdjsonLoader(base.Loader):
         since: str | None = None,
         until: str | None = None,
         resume: str | None = None,
+        inline: bool = False,
+        inline_resources: set[str] | None = None,
+        inline_mimetypes: set[str] | None = None,
     ):
         """
         :param root: location to load ndjson from
@@ -38,6 +41,9 @@ class FhirNdjsonLoader(base.Loader):
         self.since = since
         self.until = until
         self.resume = resume
+        self.inline = inline
+        self.inline_resources = inline_resources
+        self.inline_mimetypes = inline_mimetypes
 
     async def detect_resources(self) -> set[str] | None:
         if self.root.protocol in {"http", "https"}:
@@ -56,7 +62,7 @@ class FhirNdjsonLoader(base.Loader):
             bulk_dir = await self.load_from_bulk_export(resources)
             input_root = store.Root(bulk_dir.name)
         else:
-            if self.export_to or self.since or self.until or self.resume:
+            if self.export_to or self.since or self.until or self.resume or self.inline:
                 errors.fatal(
                     "You provided FHIR bulk export parameters but did not provide a FHIR server",
                     errors.ARGS_CONFLICT,
@@ -91,6 +97,15 @@ class FhirNdjsonLoader(base.Loader):
         """
         target_dir = cli_utils.make_export_dir(self.export_to)
 
+        if self.inline and not self.export_to:
+            errors.fatal(
+                "Attachment inlining requested, but without an export folder. "
+                "If you want to save inlined attachments for archiving, please specify an "
+                "export folder to preserve the downloaded NDJSON with --export-to. "
+                "See --help for more information.",
+                errors.ARGS_INVALID,
+            )
+
         try:
             bulk_exporter = BulkExporter(
                 self.client,
@@ -106,6 +121,15 @@ class FhirNdjsonLoader(base.Loader):
 
         except errors.FatalError as exc:
             errors.fatal(str(exc), errors.BULK_EXPORT_FAILED)
+
+        if self.inline:
+            common.print_header()
+            await inliner.inliner(
+                self.client,
+                store.Root(target_dir.name),
+                self.inline_resources,
+                self.inline_mimetypes,
+            )
 
         return target_dir
 

--- a/tests/fhir/test_fhir_client.py
+++ b/tests/fhir/test_fhir_client.py
@@ -461,21 +461,26 @@ IRxyq6i4LnRleQHDKzI0hdZJPEQd3k3RsPC9IsBf0A==
 
             self.assertEqual(2, self.respx_mock["token"].call_count)
 
-    async def test_get_error_429(self):
-        """Verify that 429 errors are passed through and not treated as exceptions."""
-        self.respx_mock.get(f"{self.server_url}/retry-me").respond(429)
-        self.respx_mock.get(f"{self.server_url}/nope").respond(430)
+    @ddt.data(
+        (400, errors.FatalError),
+        (408, errors.TemporaryNetworkError),
+        (429, errors.TemporaryNetworkError),
+        (430, errors.FatalError),
+        (500, errors.FatalError),
+        (502, errors.TemporaryNetworkError),
+        (503, errors.TemporaryNetworkError),
+        (504, errors.TemporaryNetworkError),
+    )
+    @ddt.unpack
+    async def test_get_error_types(self, code, exception):
+        """Verify that errors are passed up as the right kind of exception."""
+        self.respx_mock.get(f"{self.server_url}/try-me").respond(code)
 
         async with fhir.FhirClient(
             self.server_url, [], smart_client_id=self.client_id, smart_jwks=self.jwks
         ) as server:
-            # Confirm 429 passes
-            response = await server.request("GET", "retry-me")
-            self.assertEqual(429, response.status_code)
-
-            # Sanity check that 430 does not
-            with self.assertRaises(errors.FatalError):
-                await server.request("GET", "nope")
+            with self.assertRaises(exception):
+                await server.request("GET", "try-me")
 
     @ddt.data(
         # OperationOutcome


### PR DESCRIPTION
Inlining here means downloading attachment URLs and insert them as attachment data, allowing you to download the attachment just once, at the cost of extra storage space.

This is often useful in preparation for NLP tasks, where you want to often refer back to DocumentReference clinical notes, but do not want to constantly deal with the flakiness of an EHR server. (Or losing access to that server.)

New features:
- There is a new `inline` command that can inline an existing folder of NDJSON.
- The `export` and `etl` commands both now accept an opt-in flag to inline data after performing a bulk export.
- If the server provides a Retry-After header that is a timestamp (rather than a number of seconds), we now parse that correctly.

Behavior changes:
- If the server gives us a 429 error, we now log it as an error message, and don't log a successful progress call.
- If the server gives us a 429 error, we use the next exponential backoff delay instead of hard coding 60 seconds as the delay.
- If the server gives us a Retry-After header on an error message, we no longer unconditionally accept and use it. Rather the requested delay is capped by our next exponential backoff delay. That is, the server's Retry-After time will be used if it's LESS than our next backoff, but if it's longer, we'll still use our own backoff. This is lightly hostile, but (a) it's only done on error cases, (b) our backoff times are generous, and counted in minutes not seconds, and (c) it lets us guarantee a max delay time for callers.
- Instead of retrying on 429 and ALL 5xx errors, there's a specific list of error codes that we retry on. Currently it's 408, 429, 502, 503, and 504.
- Have the bulk exporter time out after 30 days, rather than one. We've seen Epic exports take a couple weeks.


### Checklist
- [ ] Consider if documentation (like in `docs/`) needs to be updated
- [ ] Consider if tests should be added
