### PR TITLE
fix: a couple extensions were incorrectly being warned about

### DIFF
--- a/cumulus_etl/deid/scrubber.py
+++ b/cumulus_etl/deid/scrubber.py
@@ -328,7 +328,7 @@ class Scrubber:
                 "http://hl7.org/fhir/StructureDefinition/geolocation",
                 "http://hl7.org/fhir/StructureDefinition/iso21090-TEL-address",
                 "http://hl7.org/fhir/StructureDefinition/patient-birthPlace",
-                "http://hl7.org/fhir/StructureDefinition/patient-mothersMaidenName"
+                "http://hl7.org/fhir/StructureDefinition/patient-mothersMaidenName",
                 # Usually harmless, but we ignore it to avoid accidentally leaving in the
                 # rendered value of a PHI element that we removed or didn't allow-list.
                 "http://hl7.org/fhir/StructureDefinition/rendered-value",


### PR DESCRIPTION
Due to a missing comma, two known-but-we-want-to-silently-ignore-them extensions were being warned about instead of silently ignored:
- http://hl7.org/fhir/StructureDefinition/patient-mothersMaidenName
- http://hl7.org/fhir/StructureDefinition/rendered-value


### Checklist
- [x] Consider if documentation (like in `docs/`) needs to be updated
- [x] Consider if tests should be added
