### PR TITLE
fix(upload-notes): save the codebook after using it

### DIFF
--- a/cumulus_etl/deid/scrubber.py
+++ b/cumulus_etl/deid/scrubber.py
@@ -47,7 +47,6 @@ class Scrubber:
 
     def __init__(self, codebook_dir: str | None = None, use_philter: bool = False):
         self.codebook = codebook.Codebook(codebook_dir)
-        self.codebook_dir = codebook_dir
         self.philter = philter.Philter() if use_philter else None
         # List of ignored extensions (resource -> url -> count)
         self.dropped_extensions: ExtensionCount = {}
@@ -111,8 +110,7 @@ class Scrubber:
 
     def save(self) -> None:
         """Saves any resources used to persist across runs (like the codebook)"""
-        if self.codebook_dir:
-            self.codebook.db.save(self.codebook_dir)
+        self.codebook.save()
 
     def print_extension_report(self) -> None:
         self._print_extension_table(

--- a/tests/deid/test_deid_scrubber.py
+++ b/tests/deid/test_deid_scrubber.py
@@ -275,9 +275,9 @@ class TestScrubber(utils.AsyncTestCase):
 
         with tempfile.TemporaryDirectory() as tmpdir:
             # Start with one encounter in db
-            db = CodebookDB()
+            db = CodebookDB(tmpdir)
             db.encounter("1")
-            db.save(tmpdir)
+            db.save()
 
             # Confirm we loaded that encounter correctly
             scrubber = Scrubber(tmpdir)


### PR DESCRIPTION
If you are uploading notes that you haven't ETL'd before, this will (a) create the codebook if you have never ETL'd and (b) update any cached mappings.


### Checklist
- [x] Consider if documentation (like in `docs/`) needs to be updated
- [x] Consider if tests should be added
