### PR TITLE
fix(upload-notes): improve --highlight matching

### DIFF
--- a/cumulus_etl/upload_notes/labelstudio.py
+++ b/cumulus_etl/upload_notes/labelstudio.py
@@ -41,10 +41,8 @@ class LabelStudioNote:
         default_factory=list
     )
 
-    # Matches found by word search, label -> list of found spans
-    highlights: dict[str, list[ctakesclient.typesystem.Span]] = dataclasses.field(
-        default_factory=dict
-    )
+    # Matches found by word search, list of found spans
+    highlights: list[ctakesclient.typesystem.Span] = dataclasses.field(default_factory=list)
 
     # Matches found by Philter
     philter_map: dict[int, int] = dataclasses.field(default_factory=dict)
@@ -190,17 +188,16 @@ class LabelStudioClient:
         }
 
         results = []
-        for label, spans in note.highlights.items():
-            for span in spans:
-                results.append(
-                    self._format_match(
-                        span.begin, span.end, note.text[span.begin : span.end], [label]
-                    )
+        for span in note.highlights:
+            results.append(
+                self._format_match(
+                    span.begin, span.end, note.text[span.begin : span.end], ["Keyword"]
                 )
+            )
         prediction["result"] = results
         task["predictions"].append(prediction)
 
-        self._update_used_labels(task, note.highlights.keys())
+        self._update_used_labels(task, ["Keyword"])
 
     def _format_philter_predictions(self, task: dict, note: LabelStudioNote) -> None:
         """

--- a/tests/upload_notes/test_upload_labelstudio.py
+++ b/tests/upload_notes/test_upload_labelstudio.py
@@ -262,7 +262,7 @@ class TestUploadLabelStudio(AsyncTestCase):
 
     async def test_push_highlights(self):
         note = self.make_note(philter_label=False, ctakes=False)
-        note.highlights["LabelName"] = [
+        note.highlights = [
             ctakesclient.typesystem.Span(7, 11),
             ctakesclient.typesystem.Span(12, 16),
         ]
@@ -286,7 +286,7 @@ class TestUploadLabelStudio(AsyncTestCase):
                                 "type": "labels",
                                 "value": {
                                     "end": 11,
-                                    "labels": ["LabelName"],
+                                    "labels": ["Keyword"],
                                     "score": 1.0,
                                     "start": 7,
                                     "text": "note",
@@ -298,7 +298,7 @@ class TestUploadLabelStudio(AsyncTestCase):
                                 "type": "labels",
                                 "value": {
                                     "end": 16,
-                                    "labels": ["LabelName"],
+                                    "labels": ["Keyword"],
                                     "score": 1.0,
                                     "start": 12,
                                     "text": "text",


### PR DESCRIPTION
- No longer ignore matches in previous docs when grouping (whoops)
- Instead of labeling a found term with the term itself, just mark it with a generic "Keyword" label to be less noisy in the Label Studio interface (Andy request)
- Escape regex characters in highlight terms
- Improve boundary matching when a term includes non-word characters (like a + or -)


### Checklist
- [x] Consider if documentation (like in `docs/`) needs to be updated
- [x] Consider if tests should be added
