### PR TITLE
feat(upload-notes): sort notes by encounter/patient

### DIFF
--- a/cumulus_etl/upload_notes/labelstudio.py
+++ b/cumulus_etl/upload_notes/labelstudio.py
@@ -21,6 +21,7 @@ from cumulus_etl import batching, errors
 class LabelStudioNote:
     """Holds all the data that Label Studio will need for a single note (or a single grouped encounter note)"""
 
+    patient_id: str
     enc_id: str  # real Encounter ID
     anon_id: str  # anonymized Encounter ID
     text: str = ""  # text of the note, sent to Label Studio

--- a/tests/upload_notes/test_upload_labelstudio.py
+++ b/tests/upload_notes/test_upload_labelstudio.py
@@ -31,6 +31,7 @@ class TestUploadLabelStudio(AsyncTestCase):
     ) -> LabelStudioNote:
         text = "Normal note text"
         note = LabelStudioNote(
+            "patient",
             enc_id,
             "enc-anon",
             doc_mappings={"doc": "doc-anon"},


### PR DESCRIPTION
Previously, we grouped by encounter and sorted notes inside the encounter. Now, we still sort inside an encounter but also sort among encounters for the earliest to latest. And group by patient and also sort them by earliest doc to latest doc.

Should help chart reviewers make mental sense of the notes as they go one by one.


### Checklist
- [x] Consider if documentation (like in `docs/`) needs to be updated
- [x] Consider if tests should be added
