### PR TITLE
feat(export): add a --cancel option

### DIFF
--- a/tests/loaders/ndjson/test_bulk_export.py
+++ b/tests/loaders/ndjson/test_bulk_export.py
@@ -767,6 +767,11 @@ class TestBulkExporter(utils.AsyncTestCase, utils.FhirClientMixin):
             [mock.call(x) for x in (60, 120, 60, 60, 20, 240, 480)], self.sleep_mock.call_args_list
         )
 
+    async def test_cancel_without_resume(self):
+        async with self.fhir_client([]) as client:
+            exporter = BulkExporter(client, set(), self.fhir_url, self.tmpdir)
+            self.assertFalse(await exporter.cancel())
+
 
 class TestBulkExportLogWriter(utils.AsyncTestCase):
     async def test_log_writer_multiple_params(self):


### PR DESCRIPTION
This helps recover from situations where the server only lets you make so many exports at once, and you don't need a previous one.

Or just to be a good citizen.

Note that the ETL normally cancels/cleans up for you in the success case. But if the ETL gets interrupted, this lets you manually clean up.

I only added this for the `export` subcommand - it didn't feel like it made as much sense in the `etl` subcommand flow. I also felt this was a rare enough case to not bother with docs about it, but I could be convinced otherwise.

### Checklist
- [x] Consider if documentation (like in `docs/`) needs to be updated
- [x] Consider if tests should be added
