### PR TITLE
fix(upload-notes): rename Keyword to Tag when highlighting

### DIFF
--- a/cumulus_etl/upload_notes/labelstudio.py
+++ b/cumulus_etl/upload_notes/labelstudio.py
@@ -191,14 +191,12 @@ class LabelStudioClient:
         results = []
         for span in note.highlights:
             results.append(
-                self._format_match(
-                    span.begin, span.end, note.text[span.begin : span.end], ["Keyword"]
-                )
+                self._format_match(span.begin, span.end, note.text[span.begin : span.end], ["Tag"])
             )
         prediction["result"] = results
         task["predictions"].append(prediction)
 
-        self._update_used_labels(task, ["Keyword"])
+        self._update_used_labels(task, ["Tag"])
 
     def _format_philter_predictions(self, task: dict, note: LabelStudioNote) -> None:
         """

--- a/tests/upload_notes/test_upload_labelstudio.py
+++ b/tests/upload_notes/test_upload_labelstudio.py
@@ -253,7 +253,7 @@ class TestUploadLabelStudio(AsyncTestCase):
                     "anon_id": "enc-anon",
                     "docref_mappings": {"doc": "doc-anon"},
                     "docref_spans": {"doc": [0, 16]},
-                    "mylabel": [{"value": "Keyword"}],
+                    "mylabel": [{"value": "Tag"}],
                 },
                 "predictions": [
                     {
@@ -265,7 +265,7 @@ class TestUploadLabelStudio(AsyncTestCase):
                                 "type": "labels",
                                 "value": {
                                     "end": 11,
-                                    "labels": ["Keyword"],
+                                    "labels": ["Tag"],
                                     "score": 1.0,
                                     "start": 7,
                                     "text": "note",
@@ -277,7 +277,7 @@ class TestUploadLabelStudio(AsyncTestCase):
                                 "type": "labels",
                                 "value": {
                                     "end": 16,
-                                    "labels": ["Keyword"],
+                                    "labels": ["Tag"],
                                     "score": 1.0,
                                     "start": 12,
                                     "text": "text",


### PR DESCRIPTION
Andy found Keyword to take up too much space in the Label Studio UI.


### Checklist
- [x] Consider if documentation (like in `docs/`) needs to be updated
- [x] Consider if tests should be added
