### PR TITLE
build: push to pypi upon release

### DIFF
--- a/.github/workflows/docker-hub.yaml
+++ b/.github/workflows/docker-hub.yaml
@@ -1,12 +1,8 @@
 name: Docker Hub
 
-# Currently, we publish every commit to main into Docker hub.
-# And then manually tag stable releases.
-# In the future, we may want to trigger off of actual release tags.
 on:
-  push:
-    branches:
-      - main
+  release:
+    types: [created]
 
 jobs:
   push_to_docker_hub:
@@ -25,10 +21,10 @@ jobs:
         id: meta
         uses: docker/metadata-action@v5
         with:
-          flavor: latest=false
+          flavor: latest=true
           images: smartonfhir/cumulus-etl
           tags: |
-            type=ref,event=branch
+            type=pep440,pattern={{major}},value=${{ env.ETL_VERSION }}
 
       - name: Log in to Docker Hub
         uses: docker/login-action@v3

--- a/.github/workflows/pypi.yaml
+++ b/.github/workflows/pypi.yaml
@@ -1,0 +1,27 @@
+name: PyPI
+
+on:
+  release:
+    types: [created]
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: read
+      id-token: write # this permission is required for PyPI "trusted publishing"
+
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install build
+
+    - name: Build
+      run: python -m build
+
+    - name: Publish
+      uses: pypa/gh-action-pypi-publish@release/v1

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,28 +1,20 @@
 [project]
 name = "cumulus-etl"
 requires-python = ">= 3.10"
-# These dependencies are mostly pinned to be under the next major version.
-# That makes particular sense as long as we don't have official releases yet and our docker
-# images are built from main directly every commit.
-#
-# We mitigate the risk of missing a new release by having a bot watch for them.
-#
-# But if we ever start releasing on PyPI, we could switch to open-pinned dependencies to be
-# less annoying to pip users.
 dependencies = [
-    "ctakesclient >= 5.1, < 6",
-    "cumulus-fhir-support >= 1.2, < 2",
-    "delta-spark >= 3.2.1, < 4",
-    "httpx < 1",
-    "inscriptis < 3",
-    "jwcrypto < 2",
-    "label-studio-sdk < 2",
-    "nltk >= 3.9, < 4",
-    "openai < 2",
-    "oracledb < 4",
-    "philter-lite < 1",
-    "pyarrow < 20",
-    "rich < 14",
+    "ctakesclient >= 5.1",
+    "cumulus-fhir-support >= 1.2",
+    "delta-spark >= 3.2.1",
+    "httpx",
+    "inscriptis",
+    "jwcrypto",
+    "label-studio-sdk",
+    "nltk >= 3.9",
+    "openai",
+    "oracledb",
+    "philter-lite",
+    "pyarrow",
+    "rich",
     "s3fs",
 ]
 authors = [


### PR DESCRIPTION
Also, only push docker images upon release. And drop upper limits on dependencies, to make pip users' lives easier.


### Checklist
- [x] Consider if documentation (like in `docs/`) needs to be updated
- [x] Consider if tests should be added
