### PR TITLE
fix: report an accurate bulk export duration in the logs

### DIFF
--- a/cumulus_etl/__init__.py
+++ b/cumulus_etl/__init__.py
@@ -1,3 +1,3 @@
 """Turns FHIR data into de-identified & aggregated records"""
 
-__version__ = "2.1.0"
+__version__ = "2.1.1"

--- a/cumulus_etl/loaders/fhir/export_log.py
+++ b/cumulus_etl/loaders/fhir/export_log.py
@@ -321,7 +321,7 @@ class BulkExportLogWriter:
 
     def export_complete(self):
         timestamp = common.datetime_now(local=True)
-        duration = (timestamp - self._start_time) if self._start_time else 0
+        duration = (timestamp - self._start_time) if self._start_time else None
         self._event(
             "export_complete",
             {
@@ -329,7 +329,7 @@ class BulkExportLogWriter:
                 "resources": self._num_resources,
                 "bytes": self._num_bytes,
                 "attachments": None,
-                "duration": duration.microseconds // 1000,
+                "duration": duration // datetime.timedelta(milliseconds=1) if duration else 0,
             },
             timestamp=timestamp,
         )

--- a/tests/loaders/ndjson/test_bulk_export.py
+++ b/tests/loaders/ndjson/test_bulk_export.py
@@ -63,7 +63,8 @@ class TestBulkExporter(utils.AsyncTestCase, utils.FhirClientMixin):
             complete_timestamp = found_rows[complete_index]["timestamp"]
             kickoff_datetime = datetime.datetime.fromisoformat(kickoff_timestamp)
             complete_datetime = datetime.datetime.fromisoformat(complete_timestamp)
-            expected_duration = (complete_datetime - kickoff_datetime).microseconds // 1000
+            one_ms = datetime.timedelta(milliseconds=1)
+            expected_duration = (complete_datetime - kickoff_datetime) // one_ms
             found_duration = found_rows[complete_index]["eventDetail"]["duration"]
             self.assertEqual(found_duration, expected_duration)
 
@@ -697,7 +698,9 @@ class TestBulkExporter(utils.AsyncTestCase, utils.FhirClientMixin):
 
         def status_check(request):
             del request
-            future = utils.FROZEN_TIME_UTC + datetime.timedelta(milliseconds=192)
+            future = utils.FROZEN_TIME_UTC + datetime.timedelta(
+                hours=3, milliseconds=192, microseconds=252
+            )
             self.time_machine.move_to(future)
             return respx.MockResponse(
                 json={
@@ -718,7 +721,7 @@ class TestBulkExporter(utils.AsyncTestCase, utils.FhirClientMixin):
             ("manifest_complete", None),
             (
                 "export_complete",
-                {"attachments": None, "bytes": 0, "duration": 192, "files": 0, "resources": 0},
+                {"attachments": None, "bytes": 0, "duration": 10800192, "files": 0, "resources": 0},
             ),
         )
 


### PR DESCRIPTION
### Checklist
- [x] Consider if documentation (like in `docs/`) needs to be updated
- [x] Consider if tests should be added
