### PR TITLE
feat: stop filling export logs with status_progress messages

### DIFF
--- a/cumulus_etl/__init__.py
+++ b/cumulus_etl/__init__.py
@@ -1,3 +1,3 @@
 """Turns FHIR data into de-identified & aggregated records"""
 
-__version__ = "2.1.1"
+__version__ = "2.1.2"

--- a/cumulus_etl/loaders/fhir/export_log.py
+++ b/cumulus_etl/loaders/fhir/export_log.py
@@ -226,14 +226,9 @@ class BulkExportLogWriter:
         )
 
     def status_progress(self, response: httpx.Response):
-        self._event(
-            "status_progress",
-            {
-                "body": self._body(response),
-                "xProgress": response.headers.get("X-Progress"),
-                "retryAfter": response.headers.get("Retry-After"),
-            },
-        )
+        # We no longer log this event because it just clogs up the log file
+        # with thousands of lines that aren't interesting and bloat the size of the logs.
+        pass
 
     def status_complete(self, response: httpx.Response):
         response_json = response.json()


### PR DESCRIPTION
They don't really tell us anything. Status errors will still be logged.


### Checklist
- [x] Consider if documentation (like in `docs/`) needs to be updated
- [x] Consider if tests should be added
