### PR TITLE
feat: add --type and --type-filter to export subcommand

### DIFF
--- a/cumulus_etl/__init__.py
+++ b/cumulus_etl/__init__.py
@@ -1,3 +1,3 @@
 """Turns FHIR data into de-identified & aggregated records"""
 
-__version__ = "2.1.2"
+__version__ = "2.2.0"

--- a/cumulus_etl/loaders/fhir/bulk_export.py
+++ b/cumulus_etl/loaders/fhir/bulk_export.py
@@ -36,6 +36,7 @@ class BulkExporter:
         *,
         since: str | None = None,
         until: str | None = None,
+        type_filter: list[str] | None = None,
         resume: str | None = None,
         prefer_url_resources: bool = False,
     ):
@@ -48,6 +49,7 @@ class BulkExporter:
         :param destination: a local folder to store all the files
         :param since: start date for export
         :param until: end date for export
+        :param type_filter: search filter for export (_typeFilter)
         :param resume: a polling status URL from a previous expor
         :param prefer_url_resources: if the URL includes _type, ignore the provided resources
         """
@@ -69,6 +71,7 @@ class BulkExporter:
             resources=resources,
             since=since,
             until=until,
+            type_filter=type_filter,
             prefer_url_resources=prefer_url_resources,
         )
 
@@ -84,6 +87,7 @@ class BulkExporter:
         resources: set[str],
         since: str | None,
         until: str | None,
+        type_filter: list[str] | None,
         prefer_url_resources: bool,
     ) -> str:
         parsed = urllib.parse.urlsplit(url)
@@ -97,6 +101,8 @@ class BulkExporter:
         ignore_provided_resources = prefer_url_resources and "_type" in query
         if not ignore_provided_resources:
             query.setdefault("_type", []).extend(resources)
+        if type_filter:
+            query.setdefault("_typeFilter", []).extend(type_filter)
         if since:
             query["_since"] = since
         if until:

--- a/cumulus_etl/loaders/fhir/ndjson_loader.py
+++ b/cumulus_etl/loaders/fhir/ndjson_loader.py
@@ -22,6 +22,7 @@ class FhirNdjsonLoader(base.Loader):
         export_to: str | None = None,
         since: str | None = None,
         until: str | None = None,
+        type_filter: list[str] | None = None,
         resume: str | None = None,
         inline: bool = False,
         inline_resources: set[str] | None = None,
@@ -40,6 +41,7 @@ class FhirNdjsonLoader(base.Loader):
         self.export_to = export_to
         self.since = since
         self.until = until
+        self.type_filter = type_filter
         self.resume = resume
         self.inline = inline
         self.inline_resources = inline_resources
@@ -114,6 +116,7 @@ class FhirNdjsonLoader(base.Loader):
                 target_dir.name,
                 since=self.since,
                 until=self.until,
+                type_filter=self.type_filter,
                 resume=self.resume,
                 prefer_url_resources=prefer_url_resources,
             )

--- a/docs/bulk-exports.md
+++ b/docs/bulk-exports.md
@@ -24,9 +24,10 @@ with the `--export-group` and `--export-timestamp` options. See `--help` for mor
 
 2. Cumulus ETL has an `export` command to perform just a bulk export without an ETL step.
    Run it like so: `cumulus-etl export FHIR_URL ./output` (see `--help` for more options).
-   - You can use all sorts of
-   [interesting FHIR options](https://hl7.org/fhir/uv/bulkdata/export.html#query-parameters)
-   like `_typeFilter` or `_since` in the URL.
+   - You can provide standard
+   [bulk FHIR options](https://hl7.org/fhir/uv/bulkdata/export.html#query-parameters)
+   like `_type` and `_typeFilter` in the URL or via CLI arguments like
+   `--type` and `--type-filter`.
    - This workflow will generate an export log file, from which Cumulus ETL can pull
    some export metadata like the Group name and export timestamp.
 

--- a/tests/loaders/ndjson/test_bulk_export.py
+++ b/tests/loaders/ndjson/test_bulk_export.py
@@ -285,6 +285,16 @@ class TestBulkExporter(utils.AsyncTestCase, utils.FhirClientMixin):
         with self.assertRaises(errors.FatalError):
             await self.export(since="2000-01-01T00:00:00+00.00", until="2010")
 
+    async def test_type_filter(self):
+        self.mock_kickoff(
+            params="?_type=Condition%2CPatient&"
+            "_typeFilter=Patient%3Factive%3Dfalse%2CPatient%3Factive%3Dtrue",
+            status_code=500,  # early exit
+        )
+
+        with self.assertRaises(errors.FatalError):
+            await self.export(type_filter=["Patient?active=false", "Patient?active=true"])
+
     async def test_export_error(self):
         """Verify that we download and present any server-reported errors during the bulk export"""
         self.mock_kickoff()


### PR DESCRIPTION
--type is more familiar to folks that are used to the bulk API than --task - now you can use both.

And --type-filter is helpful because manually putting a _typeFilter argument into your URL is a pain, because you have to encode it yourself.


### Checklist
- [x] Consider if documentation (like in `docs/`) needs to be updated
- [x] Consider if tests should be added
