### PR TITLE
fix: only use v2 scopes if no other choice

### DIFF
--- a/cumulus_etl/__init__.py
+++ b/cumulus_etl/__init__.py
@@ -1,3 +1,3 @@
 """Turns FHIR data into de-identified & aggregated records"""
 
-__version__ = "2.2.0"
+__version__ = "2.2.1"

--- a/cumulus_etl/fhir/fhir_auth.py
+++ b/cumulus_etl/fhir/fhir_auth.py
@@ -63,8 +63,9 @@ class JwtAuth(Auth):
         """
         await self._ensure_config(session)
 
-        # Use v2 scopes if the server supports them, else fall back to v1
-        if "permission-v2" in self._config.get("capabilities", []):
+        # Use v1 scopes unless the server says is only uses v2
+        capabilities = self._config.get("capabilities", [])
+        if "permission-v2" in capabilities and "permission-v1" not in capabilities:
             scope = "rs"
         else:
             scope = "read"


### PR DESCRIPTION
Some servers claim to support v2 but do not actually (Cerner)


### Checklist
- [x] Consider if documentation (like in `docs/`) needs to be updated
- [x] Consider if tests should be added
