### PR TITLE
feat(upload-notes): add patient ID info to label studio metadata

### DIFF
--- a/tests/upload_notes/test_upload_cli.py
+++ b/tests/upload_notes/test_upload_cli.py
@@ -323,13 +323,13 @@ class TestUploadNotes(CtakesMixin, AsyncTestCase):
 
         # Confirm we imported tasks formatted with NLP correctly
         tasks = self.ls_client.push_tasks.call_args[0][0]
-        self.assertEqual(["23", "25"], [t.enc_id for t in tasks])
+        self.assertEqual(["23", "25"], [t.encounter_id for t in tasks])
         self.assertEqual(
             [
                 "71b6e68140b2b8dc76a313be69627739573510954ec677d3d503f549673cce97",
                 "44fd65be3e9fee4557a6c12cb40ee0659137b9445a813f87d9950a97534ad353",
             ],
-            [t.anon_id for t in tasks],
+            [t.anon_encounter_id for t in tasks],
         )
         self.assertEqual(
             [
@@ -394,7 +394,12 @@ class TestUploadNotes(CtakesMixin, AsyncTestCase):
     async def test_philter_redact(self, upload_args, expect_redacted):
         notes = [
             LabelStudioNote(
-                "Pat", "EncID", "EncAnon", title="My Title", text="John Smith called on 10/13/2010"
+                "Pat",
+                "PatAnon",
+                "EncID",
+                "EncAnon",
+                title="My Title",
+                text="John Smith called on 10/13/2010",
             )
         ]
         with mock.patch("cumulus_etl.upload_notes.cli.read_notes_from_ndjson", return_value=notes):
@@ -416,7 +421,12 @@ class TestUploadNotes(CtakesMixin, AsyncTestCase):
     async def test_philter_label(self):
         notes = [
             LabelStudioNote(
-                "Pat", "EncID", "EncAnon", title="My Title", text="John Smith called on 10/13/2010"
+                "Pat",
+                "PatAnon",
+                "EncID",
+                "EncAnon",
+                title="My Title",
+                text="John Smith called on 10/13/2010",
             )
         ]
         with mock.patch("cumulus_etl.upload_notes.cli.read_notes_from_ndjson", return_value=notes):

--- a/tests/upload_notes/test_upload_labelstudio.py
+++ b/tests/upload_notes/test_upload_labelstudio.py
@@ -27,12 +27,13 @@ class TestUploadLabelStudio(AsyncTestCase):
 
     @staticmethod
     def make_note(
-        *, enc_id: str = "enc", ctakes: bool = True, philter_label: bool = True
+        *, encounter_id: str = "enc", ctakes: bool = True, philter_label: bool = True
     ) -> LabelStudioNote:
         text = "Normal note text"
         note = LabelStudioNote(
             "patient",
-            enc_id,
+            "patient-anon",
+            encounter_id,
             "enc-anon",
             doc_mappings={"doc": "doc-anon"},
             doc_spans={"doc": (0, len(text))},
@@ -75,8 +76,10 @@ class TestUploadLabelStudio(AsyncTestCase):
             {
                 "data": {
                     "text": "Normal note text",
+                    "patient_id": "patient",
+                    "anon_patient_id": "patient-anon",
                     "enc_id": "enc",
-                    "anon_id": "enc-anon",
+                    "anon_enc_id": "enc-anon",
                     "docref_mappings": {"doc": "doc-anon"},
                     "docref_spans": {"doc": [0, 16]},
                     "mylabel": [{"value": "Itch"}, {"value": "Nausea"}],
@@ -165,8 +168,10 @@ class TestUploadLabelStudio(AsyncTestCase):
             {
                 "data": {
                     "text": "Normal note text",
+                    "patient_id": "patient",
+                    "anon_patient_id": "patient-anon",
                     "enc_id": "enc",
-                    "anon_id": "enc-anon",
+                    "anon_enc_id": "enc-anon",
                     "docref_mappings": {"doc": "doc-anon"},
                     "docref_spans": {"doc": [0, 16]},
                     "mylabel": [],
@@ -186,8 +191,10 @@ class TestUploadLabelStudio(AsyncTestCase):
         self.assertEqual(
             {
                 "text": "Normal note text",
+                "patient_id": "patient",
+                "anon_patient_id": "patient-anon",
                 "enc_id": "enc",
-                "anon_id": "enc-anon",
+                "anon_enc_id": "enc-anon",
                 "docref_mappings": {"doc": "doc-anon"},
                 "docref_spans": {"doc": [0, 16]},
                 "mylabel": [
@@ -203,8 +210,10 @@ class TestUploadLabelStudio(AsyncTestCase):
         self.assertEqual(
             {
                 "text": "Normal note text",
+                "patient_id": "patient",
+                "anon_patient_id": "patient-anon",
                 "enc_id": "enc",
-                "anon_id": "enc-anon",
+                "anon_enc_id": "enc-anon",
                 "docref_mappings": {"doc": "doc-anon"},
                 "docref_spans": {"doc": [0, 16]},
                 "mylabel": [],  # this needs to be sent, or the server will complain
@@ -234,7 +243,7 @@ class TestUploadLabelStudio(AsyncTestCase):
         """Verify that we push what we can and ignore any existing tasks by default"""
         self.ls_project.get_tasks.return_value = [{"id": 1, "data": {"enc_id": "enc"}}]
 
-        await self.push_tasks(self.make_note(), self.make_note(enc_id="enc2"))
+        await self.push_tasks(self.make_note(), self.make_note(encounter_id="enc2"))
         self.assertFalse(self.ls_project.delete_tasks.called)
         self.assertEqual("enc2", self.get_pushed_task()["data"]["enc_id"])
 
@@ -249,8 +258,10 @@ class TestUploadLabelStudio(AsyncTestCase):
             {
                 "data": {
                     "text": "Normal note text",
+                    "patient_id": "patient",
+                    "anon_patient_id": "patient-anon",
                     "enc_id": "enc",
-                    "anon_id": "enc-anon",
+                    "anon_enc_id": "enc-anon",
                     "docref_mappings": {"doc": "doc-anon"},
                     "docref_spans": {"doc": [0, 16]},
                     "mylabel": [{"value": "Tag"}],


### PR DESCRIPTION
- Adds a patient_id and anon_patient_id column
- Renames the anon_id column to anon_enc_id for clarity


### Checklist
- [x] Consider if documentation (like in `docs/`) needs to be updated
- [x] Consider if tests should be added
