### PR TITLE
fix(export): use a consistent exportId across export restarts

### DIFF
--- a/cumulus_etl/__init__.py
+++ b/cumulus_etl/__init__.py
@@ -1,3 +1,3 @@
 """Turns FHIR data into de-identified & aggregated records"""
 
-__version__ = "2.3.0"
+__version__ = "2.3.1"

--- a/cumulus_etl/loaders/fhir/bulk_export.py
+++ b/cumulus_etl/loaders/fhir/bulk_export.py
@@ -149,6 +149,7 @@ class BulkExporter:
 
         if self._resume:
             poll_location = self._resume
+            self._log.export_id = poll_location
             print("Resuming bulk FHIR export… (all other export arguments ignored)")
         else:
             poll_location = await self._kick_off()
@@ -215,11 +216,12 @@ class BulkExporter:
         except Exception as exc:
             self._log.kickoff(self._url, self._client.get_capabilities(), exc)
             raise
-        else:
-            self._log.kickoff(self._url, self._client.get_capabilities(), response)
 
         # Grab the poll location URL for status updates
         poll_location = response.headers["Content-Location"]
+        self._log.export_id = poll_location
+
+        self._log.kickoff(self._url, self._client.get_capabilities(), response)
 
         print()
         print("If interrupted, try again but add the following argument to resume the export:")

--- a/cumulus_etl/loaders/fhir/export_log.py
+++ b/cumulus_etl/loaders/fhir/export_log.py
@@ -118,7 +118,10 @@ class BulkExportLogWriter:
 
     def __init__(self, root: store.Root):
         self.root = root
-        self._export_id = str(uuid.uuid4())
+        # Start with a random export ID, which will be used if we fail to even kick off an export.
+        # But this will normally be overridden by the poll location for a consistent exportId
+        # across interrupted exports and their restarts.
+        self.export_id = str(uuid.uuid4())
         self._filename = root.joinpath("log.ndjson")
         self._num_files = 0
         self._num_resources = 0
@@ -137,7 +140,7 @@ class BulkExportLogWriter:
         # b) it makes the API of the class easier by avoiding a context manager
         with self.root.fs.open(self._filename, "a", encoding="utf8") as f:
             row = {
-                "exportId": self._export_id,
+                "exportId": self.export_id,
                 "timestamp": timestamp.isoformat(),
                 "eventId": event_id,
                 "eventDetail": detail,


### PR DESCRIPTION
Previously, we followed bulk-export-client's lead and generated a new uuid for each run of the client. Which in the case of resuming a previously interrupted export, means that the same "logical" export can now have two different IDs.

Which, could be fine. But the ETL also tries to parse info from export logs like export group name and export timestamp. It's a lot easier to do that with consistent export IDs.

We maybe should also investigate making that log reading robust against clients that don't set consistent IDs, but this is an easy change for now to make this client at least a little more consistent.

(The spec does not give any required form to the ID, so as far as I can tell, it's an opaque string that we can stuff a URL into.)


### Checklist
- [x] Consider if documentation (like in `docs/`) needs to be updated
- [x] Consider if tests should be added
