### PR TITLE
build: set version dynamically from tag rather than __init__.py

### DIFF
--- a/.github/workflows/docker-hub.yaml
+++ b/.github/workflows/docker-hub.yaml
@@ -14,8 +14,11 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
-      - name: Grab version
-        run: echo "ETL_VERSION=$(grep __version__ cumulus_etl/__init__.py | cut -d'"' -f2)" >> $GITHUB_ENV
+      - name: Set version from tag
+        run: |
+          ETL_VERSION=$(echo $GITHUB_REF_NAME | sed 's/^v//')
+          echo "ETL_VERSION=$ETL_VERSION" >> $GITHUB_ENV
+          sed -i "s/0\.0\.0/$ETL_VERSION/" cumulus_etl/__init__.py
 
       - name: Get Docker metadata
         id: meta

--- a/.github/workflows/pypi.yaml
+++ b/.github/workflows/pypi.yaml
@@ -20,6 +20,11 @@ jobs:
         python -m pip install --upgrade pip
         pip install build
 
+    - name: Set version from tag
+      run: |
+        ETL_VERSION=$(echo $GITHUB_REF_NAME | sed 's/^v//')
+        sed -i "s/0\.0\.0/$ETL_VERSION/" cumulus_etl/__init__.py
+
     - name: Build
       run: python -m build
 

--- a/cumulus_etl/__init__.py
+++ b/cumulus_etl/__init__.py
@@ -1,3 +1,3 @@
 """Turns FHIR data into de-identified & aggregated records"""
 
-__version__ = "2.3.1"
+__version__ = "0.0.0"


### PR DESCRIPTION
This makes it easier to release versions without needing to update the hardcoded version in the repo. Just release from github when it makes sense to.


### Checklist
- [x] Consider if documentation (like in `docs/`) needs to be updated
- [x] Consider if tests should be added
