### PR TITLE
feat(etl): support gzip input files (*.ndjson.gz)

### DIFF
--- a/cumulus_etl/etl/tasks/basic_tasks.py
+++ b/cumulus_etl/etl/tasks/basic_tasks.py
@@ -166,7 +166,7 @@ class MedicationRequestTask(tasks.EtlTask):
                     os.path.join(self.task_config.dir_errors, self.name), create=True
                 )
                 error_path = error_root.joinpath("medication-fetch-errors.ndjson")
-                with common.NdjsonWriter(error_path, "a") as writer:
+                with common.NdjsonWriter(error_path, append=True) as writer:
                     writer.write(resource)
 
             return None

--- a/cumulus_etl/etl/tasks/nlp_task.py
+++ b/cumulus_etl/etl/tasks/nlp_task.py
@@ -57,7 +57,7 @@ class BaseNlpTask(EtlTask):
             return
         error_root = store.Root(os.path.join(self.task_config.dir_errors, self.name), create=True)
         error_path = error_root.joinpath("nlp-errors.ndjson")
-        with common.NdjsonWriter(error_path, "a") as writer:
+        with common.NdjsonWriter(error_path, append=True) as writer:
             writer.write(docref)
 
     async def read_notes(

--- a/cumulus_etl/inliner/inliner.py
+++ b/cumulus_etl/inliner/inliner.py
@@ -125,10 +125,11 @@ async def _inline_one_file(
     progress: rich.progress.Progress | None,
     progress_task: rich.progress.TaskID | None,
 ) -> None:
+    compressed = path.casefold().endswith(".gz")
     with tempfile.NamedTemporaryFile() as output_file:
         # Use an ordered NDJSON writer to preserve the order of lines in the input file,
         # which preserves the ability for users to append updated row data to files.
-        with writer.OrderedNdjsonWriter(output_file.name) as output:
+        with writer.OrderedNdjsonWriter(output_file.name, compressed=compressed) as output:
             await reader.peek_ahead_processor(
                 cumulus_fhir_support.read_multiline_json(path, fsspec_fs=fs),
                 partial(

--- a/cumulus_etl/inliner/writer.py
+++ b/cumulus_etl/inliner/writer.py
@@ -12,8 +12,8 @@ class OrderedNdjsonWriter:
     And queued writes may not make it to the target file at all, if interrupted.
     """
 
-    def __init__(self, path: str):
-        self._writer = common.NdjsonWriter(path)
+    def __init__(self, path: str, **kwargs):
+        self._writer = common.NdjsonWriter(path, **kwargs)
         self._queued_rows: dict[int, dict] = {}
         self._current_num: int = 0
 


### PR DESCRIPTION
Now that cumulus-fhir-support can return *.gz files, we need a little extra support in the ETL to process them, because the MS tool doesn't know how to read them.

So we have to decompress them before pushing data through our pipeline.


### Checklist
- [x] Consider if documentation (like in `docs/`) needs to be updated
- [x] Consider if tests should be added
