### PR TITLE
fix(deid): when stripping Epic's custom system codes, leave a note

### DIFF
--- a/tests/deid/test_deid_scrubber.py
+++ b/tests/deid/test_deid_scrubber.py
@@ -227,6 +227,7 @@ class TestScrubber(utils.AsyncTestCase):
                             "system": "urn:oid:1.2.840.114350.1.2.3.4.5",
                             "version": "2.0",
                             "userSelected": True,
+                            **MASKED_EXTENSION,
                         },
                         {
                             "system": "urn:oid:1.2.840.9.8.7.6.5",


### PR DESCRIPTION
Add a "masked" data-absent-reason extension behind when we drop code and display, so tools like data-metrics can know that values did exist.


### Checklist
- [x] Consider if documentation (like in `docs/`) needs to be updated
- [x] Consider if tests should be added
