### PR TITLE
feat(upload-notes): disable Philter by default

### DIFF
--- a/cumulus_etl/upload_notes/cli.py
+++ b/cumulus_etl/upload_notes/cli.py
@@ -368,8 +368,8 @@ def define_upload_notes_parser(parser: argparse.ArgumentParser) -> None:
     parser.add_argument(
         "--philter",
         choices=[PHILTER_DISABLE, PHILTER_REDACT, PHILTER_LABEL],
-        default=PHILTER_REDACT,
-        help="Whether to use philter to redact/tag PHI (default is redact)",
+        default=PHILTER_DISABLE,
+        help="Whether to use philter to redact/tag PHI (default is disable)",
     )
     # Old, simpler version of the above (feel free to remove after May 2024)
     parser.add_argument(

--- a/docs/chart-review.md
+++ b/docs/chart-review.md
@@ -35,7 +35,8 @@ but the rest of this guide will mostly deal with the `upload-notes` mode itself.
 
 At its core, upload mode is just another ETL (extract, transform, load) operation.
 1. It extracts DiagnosticReport and/or DocumentReference resources from your EHR.
-2. It transforms the contained notes via `philter` (and optionally NLP).
+2. By default, it does no transformation, but you can enable some with `--philter=redact`
+   or `--nlp`.
 3. It loads the results into Label Studio.
 
 ### Minimal Command Line
@@ -238,10 +239,8 @@ But you may get better results by adding extra terms and variations in your symp
 
 ## Philter
 
-You may not need `philter` processing.
-Simply pass `--philter=disable` and it will be skipped.
-
-Or alternatively, pass `--philter=label` to highlight rather than redact detected PHI.
+You can scrub PHI from notes using Philter by passing `--philter=redact` or
+simply highlight the PHI with `--philter=label`.
 
 ## Label Studio
 

--- a/tests/upload_notes/test_upload_cli.py
+++ b/tests/upload_notes/test_upload_cli.py
@@ -494,7 +494,7 @@ class TestUploadNotes(CtakesMixin, AsyncTestCase):
             self.assertEqual([], task.ctakes_matches)
 
     @ddt.data(
-        ({}, True),  # default args
+        ({}, False),  # default args
         ({"philter": "redact"}, True),
         ({"philter": "disable"}, False),
         ({"no_philter": True}, False),


### PR DESCRIPTION
It might surprise folks to see notes affected like this by default. At BCH, we typically disable it all the time anyway. Let's go with the simple path by default, but allow it to be enabled.



### Checklist
- [x] Consider if documentation (like in `docs/`) needs to be updated
- [x] Consider if tests should be added
