### PR TITLE
feat(etl): read local Medication resources when processing MedReqs

### DIFF
--- a/cumulus_etl/deid/scrubber.py
+++ b/cumulus_etl/deid/scrubber.py
@@ -313,6 +313,7 @@ class Scrubber:
                 "http://open.epic.com/FHIR/StructureDefinition/extension/clinical-note-post-procedure-diagnosis",
                 "http://open.epic.com/FHIR/StructureDefinition/extension/clinical-note-pre-procedure-diagnosis",
                 "http://open.epic.com/FHIR/StructureDefinition/extension/clinical-note-service",
+                "http://open.epic.com/FHIR/StructureDefinition/extension/edd-at-begin-exam",
                 "http://open.epic.com/FHIR/StructureDefinition/extension/ip-admit-datetime",
                 "http://open.epic.com/FHIR/StructureDefinition/extension/legal-sex",
                 "http://open.epic.com/FHIR/StructureDefinition/extension/log-level-procedure-codes",

--- a/cumulus_etl/fhir/__init__.py
+++ b/cumulus_etl/fhir/__init__.py
@@ -5,6 +5,7 @@ from .fhir_utils import (
     FhirUrl,
     download_reference,
     get_clinical_note,
+    linked_resources,
     parse_content_type,
     parse_datetime,
     ref_resource,

--- a/cumulus_etl/fhir/fhir_utils.py
+++ b/cumulus_etl/fhir/fhir_utils.py
@@ -5,6 +5,7 @@ import datetime
 import email.message
 import re
 import urllib.parse
+from collections.abc import Iterable
 from typing import TYPE_CHECKING
 
 import httpx
@@ -156,6 +157,26 @@ class FhirUrl:
 # Resource downloading
 #
 ######################################################################################################################
+
+
+def linked_resources(resources: Iterable[str]) -> set[str]:
+    """
+    Returns all linked resources that we might care about.
+
+    This is used to look for / download related resources as available.
+    For example, we will want to request FhirClient scopes for these resources.
+    Or scoop these resources up from the input folder.
+    """
+    linked = set()
+    for resource in resources:
+        match resource:
+            case "DiagnosticReport":
+                linked.add("Binary")
+            case "DocumentReference":
+                linked.add("Binary")
+            case "MedicationRequest":
+                linked.add("Medication")
+    return linked
 
 
 async def download_reference(client: "FhirClient", reference: str) -> dict | None:

--- a/cumulus_etl/inliner/cli.py
+++ b/cumulus_etl/inliner/cli.py
@@ -50,7 +50,7 @@ async def inline_main(args: argparse.Namespace) -> None:
 
     common.print_header()
 
-    async with fhir.create_fhir_client_for_cli(args, fhir_root, {"Binary"} | resources) as client:
+    async with fhir.create_fhir_client_for_cli(args, fhir_root, resources) as client:
         await inliner.inliner(client, src_root, resources, mimetypes)
 
 

--- a/cumulus_etl/loaders/fhir/ndjson_loader.py
+++ b/cumulus_etl/loaders/fhir/ndjson_loader.py
@@ -86,6 +86,7 @@ class FhirNdjsonLoader(base.Loader):
         print("Copying ndjson input files…")
         tmpdir = tempfile.TemporaryDirectory()
         filenames = common.ls_resources(input_root, resources, warn_if_empty=True)
+        filenames += common.ls_resources(input_root, fhir.linked_resources(resources))
         for filename in filenames:
             input_root.get(filename, f"{tmpdir.name}/")
             # Decompress any *.gz files, because the MS tool can't understand them

--- a/cumulus_etl/upload_notes/cli.py
+++ b/cumulus_etl/upload_notes/cli.py
@@ -452,7 +452,7 @@ async def upload_notes_main(args: argparse.Namespace) -> None:
     client = fhir.create_fhir_client_for_cli(
         args,
         root_input,
-        {"Binary", "DiagnosticReport", "DocumentReference"},
+        {"DiagnosticReport", "DocumentReference"},
     )
     access_token = common.read_text(args.ls_token).strip()
     labels = ctakesclient.filesystem.map_cui_pref(args.symptoms_bsv)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ dependencies = [
     "aiobotocore < 2.22.0",  # FIXME: temp hotfix for dependency version madness - remove later
     "ctakesclient >= 5.1",
     "cumulus-fhir-support >= 1.2",
-    "delta-spark >= 3.2.1",
+    "delta-spark >= 3.2.1, < 4",
     "fsspec[http,s3]",
     "httpx",
     "inscriptis",

--- a/tests/fhir/test_fhir_client.py
+++ b/tests/fhir/test_fhir_client.py
@@ -476,6 +476,7 @@ IRxyq6i4LnRleQHDKzI0hdZJPEQd3k3RsPC9IsBf0A==
 
     @ddt.data(
         ({"DocumentReference", "Patient"}, {"Binary", "DocumentReference", "Patient"}),
+        ({"MedicationRequest", "Condition"}, {"Medication", "MedicationRequest", "Condition"}),
         ({"Patient"}, {"Patient"}),
     )
     @ddt.unpack


### PR DESCRIPTION
This lets the user pre-download Medication resources and present them to the ETL alongside the MedicationRequest resources. Thus avoiding a download step and letting the ETL be disconnected from the FHIR server during the ETL.

### Checklist
- [x] Consider if documentation (like in `docs/`) needs to be updated
- [x] Consider if tests should be added
