### PR TITLE
feat(upload-notes): include notes without encounters

### DIFF
--- a/cumulus_etl/upload_notes/labelstudio.py
+++ b/cumulus_etl/upload_notes/labelstudio.py
@@ -23,8 +23,8 @@ class LabelStudioNote:
 
     patient_id: str
     anon_patient_id: str
-    encounter_id: str  # real Encounter ID
-    anon_encounter_id: str  # anonymized Encounter ID
+    encounter_id: str  # real Encounter ID (or a self-ref like DocRef/xxx if no encounter is found)
+    anon_encounter_id: str | None  # anonymized Encounter ID
     text: str = ""  # text of the note, sent to Label Studio
     date: datetime.datetime | None = None  # date of the note
 


### PR DESCRIPTION
The unique identifier "enc_id" field will include a self-reference like "DocumentReference/abc" to identify the same note over multiple runs.

Brief history here:
- We originally uploaded notes individually
- Then after several requests to group notes by encounter, it was determined that that made the most clinical-review sense, so we made that the way upload-notes works
- When that change was made, I just had us drop all non-encounter notes on the floor, thinking it was an obscure edge case
- Other partner sites seem to have more of these notes than I expected. So let's upload them again, but with a unique fake encounter identifier (just a self-reference ID) so they won't be grouped with other notes.

### Checklist
- [x] Consider if documentation (like in `docs/`) needs to be updated
- [x] Consider if tests should be added
