### PR TITLE
fix(upload-notes): search for existing notes in batches

### DIFF
--- a/cumulus_etl/upload_notes/cli.py
+++ b/cumulus_etl/upload_notes/cli.py
@@ -353,7 +353,7 @@ def group_notes_by_unique_id(notes: Collection[LabelStudioNote]) -> list[LabelSt
 async def push_to_label_studio(
     notes: Collection[LabelStudioNote], access_token: str, labels: dict, args: argparse.Namespace
 ) -> None:
-    common.print_header(f"Pushing {len(notes)} charts to Label Studio...")
+    common.print_header(f"Pushing {len(notes):,} charts to Label Studio.")
     ls_client = LabelStudioClient(args.label_studio_url, access_token, args.ls_project, labels)
     await ls_client.push_tasks(notes, overwrite=args.overwrite)
 


### PR DESCRIPTION
This avoids a Label Studio error that our URI is too long because it includes thousands of note IDs.

While there, I added progress bars for the searching and uploading steps, which should help with feedback when there are a lot of notes.


### Checklist
- [x] Consider if documentation (like in `docs/`) needs to be updated
- [x] Consider if tests should be added
