### PR TITLE
feat: have NLP tasks read in DxReports as well as DocRefs

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -102,11 +102,10 @@ jobs:
           docker compose run --rm \
             --volume $DATADIR:/in \
             cumulus-etl \
+            nlp \
             /in/input \
             /in/run-output \
             /in/phi \
-            --export-group nlp-test \
-            --export-timestamp 2024-08-29 \
             --output-format=ndjson \
             --task covid_symptom__nlp_results
 

--- a/cumulus_etl/etl/nlp/cli.py
+++ b/cumulus_etl/etl/nlp/cli.py
@@ -112,10 +112,9 @@ def get_cohort_filter(args: argparse.Namespace) -> Callable[[deid.Codebook, dict
 
     def res_filter(codebook: deid.Codebook, resource: dict) -> bool:
         match resource["resourceType"]:
-            # TODO: uncomment once we support DxReport NLP (coming soon)
-            # case "DiagnosticReport":
-            #     id_pool = dxreport_ids
-            #     patient_ref = resource.get("subject", {}).get("reference")
+            case "DiagnosticReport":
+                id_pool = dxreport_ids
+                patient_ref = resource.get("subject", {}).get("reference")
             case "DocumentReference":
                 id_pool = docref_ids
                 patient_ref = resource.get("subject", {}).get("reference")

--- a/cumulus_etl/etl/studies/covid_symptom/covid_ctakes.py
+++ b/cumulus_etl/etl/studies/covid_symptom/covid_ctakes.py
@@ -32,7 +32,7 @@ async def covid_symptoms_extract(
     :return: list of NLP results encoded as FHIR observations
     """
     try:
-        docref_id, encounter_id, subject_id = nlp.get_docref_info(docref)
+        note_ref, encounter_id, subject_id = nlp.get_note_info(docref)
     except KeyError as exc:
         logging.warning(exc)
         return None
@@ -62,7 +62,7 @@ async def covid_symptoms_extract(
         )
     except Exception as exc:
         logging.warning(
-            "Could not extract symptoms for docref %s (%s): %s", docref_id, type(exc).__name__, exc
+            "Could not extract symptoms for %s (%s): %s", note_ref, type(exc).__name__, exc
         )
         return None
 
@@ -95,9 +95,12 @@ async def covid_symptoms_extract(
         )
     except Exception as exc:
         logging.warning(
-            "Could not check polarity for docref %s (%s): %s", docref_id, type(exc).__name__, exc
+            "Could not check polarity for %s (%s): %s", note_ref, type(exc).__name__, exc
         )
         return None
+
+    # We only look at docrefs - get just the ID for use in the symptom fields
+    docref_id = note_ref.removeprefix("DocumentReference/")
 
     # Helper to make a single row (match_value is None if there were no found symptoms at all)
     def _make_covid_symptom_row(row_id: str, match: dict | None) -> dict:

--- a/cumulus_etl/etl/studies/covid_symptom/covid_tasks.py
+++ b/cumulus_etl/etl/studies/covid_symptom/covid_tasks.py
@@ -65,8 +65,11 @@ def is_ed_coding(coding):
     return coding.get("code") in ED_CODES.get(coding.get("system"), {})
 
 
-def is_ed_docref(docref):
+def is_ed_docref(docref) -> bool:
     """Returns true if this is a coding for an emergency department note"""
+    if docref["resourceType"] != "DocumentReference":
+        return False
+
     # We check both type and category for safety -- we aren't sure yet how EHRs are using these fields.
     codings = list(
         itertools.chain.from_iterable([cat.get("coding", []) for cat in docref.get("category", [])])

--- a/cumulus_etl/export/cli.py
+++ b/cumulus_etl/export/cli.py
@@ -32,7 +32,8 @@ async def export_main(args: argparse.Namespace) -> None:
     store.set_user_fs_options(vars(args))
 
     selected_tasks = task_factory.get_selected_tasks(args.task)
-    required_resources = {t.resource for t in selected_tasks}
+    # Combine all task resource sets into one big set of required resources
+    required_resources = set().union(*(t.get_resource_types() for t in selected_tasks))
     using_default_tasks = not args.task
 
     # Fold in manually specified --type args (very similar to --task, but more familiar to folks

--- a/cumulus_etl/nlp/__init__.py
+++ b/cumulus_etl/nlp/__init__.py
@@ -2,7 +2,7 @@
 
 from .extract import TransformerModel, ctakes_extract, ctakes_httpx_client, list_polarity
 from .openai import Gpt4Model, Gpt4oModel, Gpt5Model, Gpt35Model, GptOss120bModel, Llama4ScoutModel
-from .utils import cache_wrapper, get_docref_info, is_docref_valid
+from .utils import cache_wrapper, get_note_info, is_note_valid
 from .watcher import (
     check_ctakes,
     check_negation_cnlpt,

--- a/cumulus_etl/nlp/utils.py
+++ b/cumulus_etl/nlp/utils.py
@@ -10,28 +10,44 @@ from cumulus_etl import common, deid, fhir, store
 Obj = TypeVar("Obj")
 
 
-def is_docref_valid(codebook: deid.Codebook, docref: dict) -> bool:
-    """Returns True if this docref is not a draft or entered-in-error resource and could be considered for NLP"""
-    del codebook  # only passed in to look like a "resource_filter" callback
-    good_status = docref.get("status") in {"current", None}  # status of DocRef itself
-    # docStatus is status of clinical note attachments
-    good_doc_status = docref.get("docStatus") in {"final", "amended", None}
-    return good_status and good_doc_status
-
-
-def get_docref_info(docref: dict) -> tuple[str, str, str]:
+def is_note_valid(codebook: deid.Codebook, note: dict) -> bool:
     """
-    Returns docref_id, encounter_id, subject_id for the given DocRef.
+    Returns True if this note is not a draft or entered-in-error resource
+
+    i.e. if it's a good candidate for NLP
+    """
+    del codebook  # only passed in to look like a "resource_filter" callback
+
+    match note["resourceType"]:
+        case "DiagnosticReport":
+            valid_status_types = {"final", "amended", "corrected", "appended", "unknown", None}
+            return note.get("status") in valid_status_types
+
+        case "DocumentReference":
+            good_status = note.get("status") in {"current", None}  # status of DocRef itself
+            # docStatus is status of clinical note attachments
+            good_doc_status = note.get("docStatus") in {"final", "amended", None}
+            return good_status and good_doc_status
+
+        case _:  # pragma: no cover
+            return False  # pragma: no cover
+
+
+def get_note_info(note: dict) -> tuple[str, str, str]:
+    """
+    Returns note_ref, encounter_id, subject_id for the given DocRef/DxReport.
 
     Raises KeyError if any of them aren't present.
     """
-    docref_id = docref["id"]
-    encounters = docref.get("context", {}).get("encounter", [])
+    note_ref = f"{note['resourceType']}/{note['id']}"
+    encounters = note.get("context", {}).get("encounter", [])
+    if not encounters:  # check for dxreport encounter field
+        encounters = [note["encounter"]] if "encounter" in note else []
     if not encounters:
-        raise KeyError(f"No encounters for docref {docref_id}")
+        raise KeyError(f"No encounters for note {note_ref}")
     _, encounter_id = fhir.unref_resource(encounters[0])
-    _, subject_id = fhir.unref_resource(docref["subject"])
-    return docref_id, encounter_id, subject_id
+    _, subject_id = fhir.unref_resource(note["subject"])
+    return note_ref, encounter_id, subject_id
 
 
 async def cache_wrapper(

--- a/tests/covid_symptom/test_covid_results.py
+++ b/tests/covid_symptom/test_covid_results.py
@@ -52,9 +52,7 @@ class TestCovidSymptomNlpResultsTask(CtakesMixin, TaskTestCase):
             await task.run()
 
         self.assertEqual(len(cm.output), 1)
-        self.assertRegex(
-            cm.output[0], r"Could not extract symptoms for docref .* \(ValueError\): oops"
-        )
+        self.assertRegex(cm.output[0], r"Could not extract symptoms for .* \(ValueError\): oops")
 
         # Confirm that we skipped the doc
         self.assertEqual(self.format.write_records.call_count, 1)
@@ -71,9 +69,7 @@ class TestCovidSymptomNlpResultsTask(CtakesMixin, TaskTestCase):
             await task.run()
 
         self.assertEqual(len(cm.output), 1)
-        self.assertRegex(
-            cm.output[0], r"Could not check polarity for docref .* \(ValueError\): oops"
-        )
+        self.assertRegex(cm.output[0], r"Could not check polarity for .* \(ValueError\): oops")
 
         # Confirm that we skipped the doc
         self.assertEqual(self.format.write_records.call_count, 1)

--- a/tests/nlp/test_openai.py
+++ b/tests/nlp/test_openai.py
@@ -234,27 +234,26 @@ class TestWithSpansNLPTasks(OpenAITestCase):
         del docref["context"]
         self.prep_docs(docref)
         self.mock_response()
-        await self.assert_failed_doc("No encounters for docref")
+        await self.assert_failed_doc("No encounters for ")
 
     async def test_network_error(self):
         self.prep_docs()
         self.responses.append(openai.APIError("oops", mock.MagicMock(), body=None))
         self.mock_response()
-        await self.assert_failed_doc("Could not connect to NLP server for DocRef .*: oops")
+        await self.assert_failed_doc("NLP failed for .*: oops")
 
     async def test_incomplete_response_error(self):
         self.prep_docs()
         self.mock_response(finish_reason="length")
         self.mock_response()
-        await self.assert_failed_doc("NLP server response didn't complete for DocRef .*: length")
+        await self.assert_failed_doc("NLP server response didn't complete for .*: length")
 
     async def test_bad_json_error(self):
         self.prep_docs()
         self.responses.append(pydantic.ValidationError.from_exception_data("Fake error", []))
         self.mock_response()
         await self.assert_failed_doc(
-            "Could not process answer from NLP server for DocRef 1: "
-            "0 validation errors for Fake error"
+            "NLP failed for DocumentReference/1: 0 validation errors for Fake error"
         )
 
 


### PR DESCRIPTION
This commit adds support for dual-resource tasks and then adds DiagnosticReport to the NLP base task class.

This required some vocabulary alignment, as we used "docref" a lot in places that now can take a docref or a dxreport.
- "note" or "note resource": a DocRef or DxReport resource (dict)
- "note text" or "text": the clinical text inside the note


### Checklist
- [x] Consider if documentation (like in `docs/`) needs to be updated
- [x] Consider if tests should be added
