### PR TITLE
Expand the "example NLP workflow" doc to include chart-review

### DIFF
--- a/cumulus_etl/cli_utils.py
+++ b/cumulus_etl/cli_utils.py
@@ -275,3 +275,9 @@ def user_regex_to_pattern(term: str) -> re.Pattern:
 def user_term_to_pattern(term: str) -> re.Pattern:
     """Takes a user search term and turns it into a clinical-note-appropriate regex"""
     return user_regex_to_pattern(re.escape(term))
+
+
+def process_input_dir(folder: str) -> str:
+    if folder == "%EXAMPLE-NLP%" and not os.path.exists(folder):
+        return os.path.join(os.path.dirname(__file__), "etl/studies/example/ndjson")
+    return folder

--- a/cumulus_etl/etl/pipeline.py
+++ b/cumulus_etl/etl/pipeline.py
@@ -177,8 +177,7 @@ async def run_pipeline(
     # record filesystem options like --s3-region before creating Roots
     store.set_user_fs_options(vars(args))
 
-    if args.dir_input == "%EXAMPLE-NLP%" and not os.path.exists(args.dir_input):
-        args.dir_input = os.path.join(os.path.dirname(__file__), "studies/example/ndjson")
+    args.dir_input = cli_utils.process_input_dir(args.dir_input)
 
     root_input = store.Root(args.dir_input)
     root_output = store.Root(args.dir_output)

--- a/cumulus_etl/id_handling.py
+++ b/cumulus_etl/id_handling.py
@@ -15,7 +15,7 @@ def get_ids_from_csv(
         result = {}
         for row in reader:
             if value := get_value(row):
-                result.setdefault(value, set()).add(tuple(row[field] for field in extra_fields))
+                result.setdefault(value, set()).add(tuple(row.get(field) for field in extra_fields))
         return result
 
 

--- a/docs/nlp/example.md
+++ b/docs/nlp/example.md
@@ -78,7 +78,7 @@ docker compose run --rm \
   %EXAMPLE-NLP% \
   s3://my-output-bucket/ \
   s3://my-phi-bucket/ \
-  --task example_nlp__nlp_gpt4
+  --task example_nlp__nlp_gpt4o
 ```
 
 (If this were a real study, you'd probably do this a bit differently.
@@ -105,15 +105,203 @@ You should see your crawler listed there. Select it, click Run, and wait for it 
 While you're in the AWS console, switch to the Athena service and select the appropriate
 Cumulus workgroup and database.
 
-Then if you make a query like below (assuming you used the GPT4 model),
+Then if you make a query like below (assuming you used the GPT4o model),
 you should see eight results with extracted ages.
 ```sql
-select * from example_nlp__nlp_gpt4
+select * from example_nlp__nlp_gpt4o
 ```
 
 **Congratulations!**
 You've now run NLP on some synthetic clinical notes and uploaded the results to Athena.
-Those extracted ages could now be post-processed by the `example` study to calculate age ranges,
+Those extracted ages can now be post-processed by the `example` study to calculate age ranges,
 and then confirmed with chart review by humans.
 
-At least that's the flow you'd use for a real study.
+## Post-Processing of the NLP Results
+
+Studies will normally need to post-process the results of the NLP,
+which is usually performing some sort of knowledge extraction.
+A study might combine bits of NLP-extracted knowledge together or
+cross-reference with some structured data to create a study finding, or label.
+
+In this example study we are running through,
+we'll post-process the extracted ages into clinically-relevant age range labels.
+Which we will afterward feed into Label Studio for human review.
+
+So let's build the `example_nlp` study (shipped with Cumulus Library, for convenience):
+```sh
+cumulus-library build \
+  --profile my-aws-profile \
+  --database my_database \
+  --workgroup my_workgroup \
+  --target example_nlp
+```
+
+## Human Chart Review
+
+Now let's validate the NLP results with a human review.
+To do this, we'll use Label Studio.
+
+### Label Studio Setup
+
+THe Label Studio project itself has good
+[install documentation](https://labelstud.io/guide/install.html).
+We recommend you follow that and continue here once you have it installed.
+
+You'll also need to prepare a Label Studio project to upload notes into.
+Inside the main Label Studio dashboard, create a new project.
+Give it a name and skip the data import step (we'll do that ourselves in a moment).
+
+When it asks you to set up a labeling template,
+click the "Custom Template" button on the bottom left.
+Enter the following template, which lists the possible labels for our example study.
+```
+<View>
+  <Labels name="label" toName="text">
+    <Label value="infant (0-1)" background="#3584e4"/>
+    <Label value="child (2-12)" background="#2190a4"/>
+    <Label value="adolescent (13-18)" background="#3a944a"/>
+    <Label value="young adult (19-24)" background="#c88800"/>
+    <Label value="adult (25-44)" background="#ed5b00"/>
+    <Label value="middle aged (45-64)" background="#e62d42"/>
+    <Label value="aged (65+)" background="#d56199"/>
+    <Label value="unknown" background="#6f8396"/>
+  </Labels>
+  <Text name="text" value="$text"/>
+</View>
+```
+
+### Upload Your Notes
+
+Now you'll want to fill in your new project with the annotated clinical notes.
+Take a note of the project number (in the project's URL) and replace the number below,
+along with the other arguments for your site.
+```sh
+export AWS_PROFILE=my-aws-profile
+docker compose run --rm \
+  cumulus-etl upload-notes \
+  %EXAMPLE-NLP% \
+  https://my-label-studio-host/ \
+  s3://my-phi-bucket/ \
+  --ls-project xx \
+  --ls-token /path/to/token.txt \
+  --athena-workgroup my_workgroup \
+  --athena-database my_database \
+  --label-by-athena-table example_nlp__range_labels
+```
+
+### Review the Charts
+
+Refresh the project page in Label Studio and you should see a few notes in Label Studio.
+Clicking on one should show a highlighted block of text with a labeled age range.
+
+Add your own label to each of the notes.
+You do this by clicking on the label at the top that you want to add,
+then highlighting a region of text.
+Then click the Submit button to finalize it.
+
+You may agree or not with the NLP results.
+In fact, even if the NLP is perfect here, why don't you intentionally disagree a few times.
+It will make the number crunching below more interesting.
+
+Once you have annotated all the notes, you have finished your chart review!
+
+## Calculate Agreement
+
+After any sort of chart review activity,
+you'll want to measure the agreement between your reviewers/annotators.
+
+We've built a tool called `chart-review` that can generate some nice statistics for this.
+
+But first, let's gather up all our chart annotations.
+
+### Export Annotations
+
+Let's download those Label Studio annotations you made.
+In Label Studio, click Export in the project and choose the default JSON format.
+Save this file as `labelstudio-export.json`
+
+Because the Label Studio export doesn't include all the NLP annotations,
+you'll have to download those separately too, to be able to compare them to your annotations.
+- Go to AWS Athena.
+- Run a query like `select note_ref, label from example_nlp__range_labels`
+- Download the result as `gpt4o.csv` (or whatever your model name was)
+  - (If you ran multiple NLP models, you'll want to add a `where origin = '...'` to the
+    above query and save each model's results in its own CSV file.)
+
+OK, now you have everything you need.
+
+### Create a Chart Review Config File
+
+Chart Review doesn't need much configuration,
+but you'll need to tell it where these exported NLP annotations are.
+
+Create a `config.yaml` file alongside the exported annotations, with the following contents:
+```yaml
+annotators:
+  gpt4o:
+    filename: gpt4o.csv
+```
+
+### Running Chart Review
+
+First, install the tool with `pipx install chart-review`.
+
+Then, in the same folder as the other files, run `chart-review` without any arguments.
+You should see ouput similar to:
+```
+~$ chart-review
+╭───────────┬─────────────┬───────────╮
+│ Annotator │ Chart Count │ Chart IDs │
+├───────────┼─────────────┼───────────┤
+│ 1         │ 8           │ 1305–1312 │
+│ gpt4o     │ 8           │ 1305–1312 │
+╰───────────┴─────────────┴───────────╯
+```
+
+"Annotator 1" (or whatever number you see) is you, as your Label Studio ID.
+You can give yourself a convenient name by editing `config.yaml` again to look like:
+```yaml
+annotators:
+  me: 1
+  gpt4o:
+    filename: gpt4o.csv
+```
+
+Let's run chart-review again:
+```
+~$ chart-review
+╭───────────┬─────────────┬───────────╮
+│ Annotator │ Chart Count │ Chart IDs │
+├───────────┼─────────────┼───────────┤
+│ gpt4o     │ 8           │ 1305–1312 │
+│ me        │ 8           │ 1305–1312 │
+╰───────────┴─────────────┴───────────╯
+```
+
+OK so that's not so impressive. That's some very basic information indeed.
+Let's get some agreement information
+(in this example, I disagreed with the model a fair bit, for demonstration purposes):
+```
+~$ chart-review accuracy me gpt4o
+Comparing 8 charts (1305–1312)
+Truth: me
+Annotator: gpt4o
+Macro F1: 0.25
+
+F1     Sens  Spec   PPV   NPV    Kappa  TP  FN  TN  FP  Label              
+0.333  0.5   0.786  0.25  0.917  0.2    2   2   22  6   *                  
+0      0     0      0     0      0      0   1   7   0   adolescent (13-18) 
+0.667  1.0   0.857  0.5   1.0    0.6    1   0   6   1   child (2-12)       
+0.333  1.0   0.429  0.2   1.0    0.158  1   0   3   4   middle aged (45-64)
+0      0     0      0     0      0      0   1   6   1   young adult (19-24)
+```
+
+Now we can see some F1 scores and all sorts of interesting stats.
+Chart Review has other fun features.
+You can explore its command line options with `--help`.
+
+And that's it! You've gone from some source documents, through NLP, through human chart review,
+and finally you calculated how well NLP agreed with you, the human.
+
+In a real study, obviously all these steps would be more interesting than this toy example.
+But the flow of data through the Cumulus pipeline would have the same shape.

--- a/tests/upload_notes/test_upload_labelstudio.py
+++ b/tests/upload_notes/test_upload_labelstudio.py
@@ -88,7 +88,7 @@ class TestUploadLabelStudio(AsyncTestCase):
                 },
                 "predictions": [
                     {
-                        "model_version": "Cumulus cTAKES",
+                        "model_version": "cTAKES",
                         "result": [
                             # Note that fever does not show up,
                             # as it was not in our initial CUI mapping (in push_tasks)
@@ -119,7 +119,7 @@ class TestUploadLabelStudio(AsyncTestCase):
                         ],
                     },
                     {
-                        "model_version": "Cumulus Philter",
+                        "model_version": "Philter",
                         "result": [
                             {
                                 "from_name": "mylabel",
@@ -255,8 +255,16 @@ class TestUploadLabelStudio(AsyncTestCase):
     async def test_push_highlights(self):
         note = self.make_note(philter_label=False, ctakes=False)
         note.highlights = {
-            "Label1": [ctakesclient.typesystem.Span(7, 11), ctakesclient.typesystem.Span(12, 16)],
-            "Label2": [ctakesclient.typesystem.Span(7, 11)],
+            "First Source": {
+                "Label1": [
+                    ctakesclient.typesystem.Span(7, 11),
+                    ctakesclient.typesystem.Span(12, 16),
+                ],
+                "Label2": [ctakesclient.typesystem.Span(7, 11)],
+            },
+            "Second Source": {
+                "Label1": [ctakesclient.typesystem.Span(7, 11)],
+            },
         }
         await self.push_tasks(note)
         self.assertEqual(
@@ -274,7 +282,7 @@ class TestUploadLabelStudio(AsyncTestCase):
                 },
                 "predictions": [
                     {
-                        "model_version": "Cumulus Labels",
+                        "model_version": "First Source",
                         "result": [
                             {
                                 "from_name": "mylabel",
@@ -307,6 +315,23 @@ class TestUploadLabelStudio(AsyncTestCase):
                                 "value": {
                                     "end": 11,
                                     "labels": ["Label2"],
+                                    "score": 1.0,
+                                    "start": 7,
+                                    "text": "note",
+                                },
+                            },
+                        ],
+                    },
+                    {
+                        "model_version": "Second Source",
+                        "result": [
+                            {
+                                "from_name": "mylabel",
+                                "to_name": "mytext",
+                                "type": "labels",
+                                "value": {
+                                    "end": 11,
+                                    "labels": ["Label1"],
                                     "score": 1.0,
                                     "start": 7,
                                     "text": "note",


### PR DESCRIPTION
Also added support for the "origin" field on an NLP label table. This lets us keep track of which model provided NLP info all the way through Label Studio and into chart-review.


### Checklist
- [x] Consider if documentation (like in `docs/`) needs to be updated
- [x] Consider if tests should be added
