### PR TITLE
nlp: when selecting from a large athena table, prompt user

### DIFF
--- a/cumulus_etl/cli_utils.py
+++ b/cumulus_etl/cli_utils.py
@@ -1,6 +1,7 @@
 """Helper methods for CLI parsing."""
 
 import argparse
+import enum
 import itertools
 import os
 import re
@@ -281,3 +282,24 @@ def process_input_dir(folder: str) -> str:
     if folder == "%EXAMPLE-NLP%" and not os.path.exists(folder):
         return os.path.join(os.path.dirname(__file__), "etl/studies/example/ndjson")
     return folder
+
+
+class PromptResponse(enum.Flag):
+    # Break these into so many conditions to help avoid spaghetti code of "if" conditions.
+    # With this, you can do one simple match tree, hopefully.
+    OVERRIDDEN = 1
+    NON_INTERACTIVE = 2
+    APPROVED = 4
+    # Combos:
+    SKIPPED = 3  # combo of OVERRIDEN and NON_INTERACTIVE
+
+
+def prompt(msg: str, override: bool = False) -> PromptResponse:
+    if override:
+        return PromptResponse.SKIPPED
+    elif not rich.get_console().is_interactive:
+        return PromptResponse.NON_INTERACTIVE
+    elif rich.prompt.Confirm.ask(msg, default=False):
+        return PromptResponse.APPROVED
+    else:
+        raise SystemExit(0)

--- a/cumulus_etl/etl/nlp/cli.py
+++ b/cumulus_etl/etl/nlp/cli.py
@@ -48,13 +48,11 @@ async def nlp_main(args: argparse.Namespace) -> None:
         scrubber = deid.Scrubber(args.dir_phi)
 
         # Let the user know how many documents got selected, so there are no big cost surprises.
-        # But skip it if we aren't in a TTY or the user provided an override flag.
-        should_confirm = rich.get_console().is_interactive and not args.allow_large_selection
         count = await check_input_size(scrubber.codebook, results.path, res_filter)
-        if should_confirm:
-            if not rich.prompt.Confirm.ask(f"Run NLP on {count:,} notes?", default=False):
-                raise SystemExit
-        else:
+        response = cli_utils.prompt(
+            f"Run NLP on {count:,} notes?", override=args.allow_large_selection
+        )
+        if response in cli_utils.PromptResponse.SKIPPED:
             rich.print(f"Running NLP on {count:,} notes…")
 
         config_args = {"ctakes_overrides": args.ctakes_overrides, "resource_filter": res_filter}


### PR DESCRIPTION
This is instead of only allowing the --allow-large-selection flag as a way of continuing - which is used in multiple selection checks. Now you can just press "y" to continue.

Fixes https://github.com/smart-on-fhir/cumulus-etl/issues/452

### Checklist
- [x] Consider if documentation (like in `docs/`) needs to be updated
- [x] Consider if tests should be added
