### PR TITLE
build: fix boto3 dependency hell

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,13 @@
 name = "cumulus-etl"
 requires-python = ">= 3.11"
 dependencies = [
-    "aiobotocore < 2.22.0",  # FIXME: temp hotfix for dependency version madness - remove later
+    # Manually specify aiobotocore with a boto3 extra, to avoid some dependency hell.
+    # (fsspec -> s3fs -> aiobotocore -> botocore are all tightly pinned - adding the boto3 here
+    # avoids a lot of backtracking on pip's part to old versions for some reason).
+    # Search "fsspec aiobotocore boto3" for more details and other frustrated people.
+    # (The 2.14.0 lower bound is to help the resolver align with our boto3 requirements quicker.)
+    "aiobotocore[boto3] >= 2.14.0",
+    "boto3 >= 1.34.131",
     "ctakesclient >= 5.1",
     "cumulus-fhir-support >= 1.6",
     "delta-spark >= 4, < 5",


### PR DESCRIPTION
Previous situation (just actually specifying our real dependencies, like fools):
- aiobotocore-2.21.1, boto3-1.37.1, fsspec-2025.9.0, s3fs-2025.9.0

Adding s3fs[boto3] (which then depends on aiobotocore[boto3]):
- aiobotocore (not used anymore), boto3-1.40.48, fsspec-2025.9.0, s3fs-0.4.2
- This one seems to search far enough back to get an old s3fs before they actually used aiobotocore?

Adding aiobotocore[boto3] (as this PR does):
- aibotocore-2.24.3, boto3-1.40.45, fsspec-2025.9.0, s3fs-2025.9.0
- This is modern versions of all of them. Phew.

I also added boto3 directly because that's a new dependency we actually directly use (in the previous bedrock PR), so it should be in pyproject.

### Checklist
- [x] Consider if documentation (like in `docs/`) needs to be updated
- [x] Consider if tests should be added
