### PR TITLE
nlp: print consumed tokens after each model run

### DIFF
--- a/cumulus_etl/etl/tasks/base.py
+++ b/cumulus_etl/etl/tasks/base.py
@@ -155,6 +155,8 @@ class EtlTask:
                 for formatter in self.formatters:
                     formatter.finalize()
 
+        self.finish_task()
+
         return self.summaries
 
     @classmethod
@@ -445,6 +447,11 @@ class EtlTask:
         :returns: False if this task should be skipped and end immediately
         """
         return True
+
+    def finish_task(self) -> None:
+        """
+        If your subclass needs to do any final cleanup or reporting, override this.
+        """
 
     def pop_current_group_values(self, table_index: int) -> set[str]:
         """

--- a/cumulus_etl/nlp/__init__.py
+++ b/cumulus_etl/nlp/__init__.py
@@ -9,6 +9,7 @@ from .models import (
     Gpt35Model,
     GptOss120bModel,
     Llama4ScoutModel,
+    TokenStats,
     set_nlp_provider,
 )
 from .selection import CsvMatcher, add_note_selection, get_note_filter, query_athena_table


### PR DESCRIPTION
This helps give folks an idea of cost / size of notes.

Example output:
```
 Reading    ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 100% 0:00:11
 Finalizing ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 100% 0:00:00
 1 written to irae__nlp_claude_sonnet45                             

 Token usage:
  New input tokens:                 715    
  Input tokens read from cache:     11,993 
  Output tokens:                    864    
  Estimated cost (as of Oct 2025):  $0.02  
```

This reports per-task (not one big report at the end for all NLP tasks in a given run), because costs are per-model.

A future improvement could be trying to calculate the cost up front (by tokenizing all the notes ourselves ahead of time, or just doing a quick and dirty "each note is roughly XXX * number of notes" calculation) and including it in the "are you sure?" prompt we do for NLP runs.

### Checklist
- [x] Consider if documentation (like in `docs/`) needs to be updated
- [x] Consider if tests should be added
