### PR TITLE
ci: stop pulling newer docker image and use built regression image

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -101,6 +101,7 @@ jobs:
 
           # Run the NLP task
           docker compose run --rm \
+            --pull never \
             --volume $DATADIR:/in \
             cumulus-etl \
             nlp \


### PR DESCRIPTION
### Checklist
- [x] Consider if documentation (like in `docs/`) needs to be updated
- [x] Consider if tests should be added
