### PR TITLE
init: create skeleton completion tables too

### DIFF
--- a/tests/init/test_init_cli.py
+++ b/tests/init/test_init_cli.py
@@ -34,6 +34,8 @@ class TestInit(utils.AsyncTestCase):
         self.assertIn("patient", dirs)
         self.assertIn("medicationrequest", dirs)
         self.assertIn("medication", dirs)  # secondary table
+        self.assertIn("etl__completion_encounters", dirs)  # custom ETL table
+        self.assertIn("etl__completion", dirs)  # another custom ETL table
         self.assertIn("JobConfig", dirs)  # so that the dir is flagged as an ETL dir by 'convert'
 
         # Are folder contents what we expect?


### PR DESCRIPTION
(in addition to normal resource tables)

The kidney study was expecting the encounter completion table. Might as well help it along.


### Checklist
- [x] Consider if documentation (like in `docs/`) needs to be updated
- [x] Consider if tests should be added
