### PR TITLE
fix: update to label studio SDK v1 API, adding support for new auth

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,7 @@ dependencies = [
     "fsspec[http,s3]",
     "httpx",
     "inscriptis",
-    "label-studio-sdk",
+    "label-studio-sdk >= 1",
     "nltk >= 3.9",
     "openai",
     "oracledb",


### PR DESCRIPTION
The SDK is actually on v2, but v1 completely changed the API and we never adapted. It hasn't mattered until now, but they are now deprecating the old auth tokens and using oauth now, and that new code path is only supported in the v1 API.

(v2 has no relevant changes for us, so we can run on v2 just fine)


### Checklist
- [x] Consider if documentation (like in `docs/`) needs to be updated
- [x] Consider if tests should be added
