### PR TITLE
upload-notes: update note headers to include author information

### DIFF
--- a/cumulus_etl/etl/config.py
+++ b/cumulus_etl/etl/config.py
@@ -41,7 +41,7 @@ class JobConfig:
         deleted_ids: dict[str, set[str]] | None = None,
         resource_filter: deid.FilterFunc = None,
     ):
-        self._dir_input_orig = dir_input_orig
+        self.dir_input_orig = dir_input_orig
         self.dir_input = dir_input_deid
         self._dir_output = dir_output
         self.dir_phi = dir_phi
@@ -81,7 +81,7 @@ class JobConfig:
 
     def as_json(self):
         return {
-            "dir_input": self._dir_input_orig,  # the original folder, rather than the temp dir holding deid files
+            "dir_input": self.dir_input_orig,  # the original folder, rather than the temp dir holding deid files
             "dir_output": self._dir_output,
             "dir_phi": self.dir_phi,
             "path": self.path_config(),

--- a/cumulus_etl/etl/tasks/nlp_task.py
+++ b/cumulus_etl/etl/tasks/nlp_task.py
@@ -272,9 +272,8 @@ class BaseModelTask(BaseNlpTask):
             "%JSON-SCHEMA%", json.dumps(cls.response_format.model_json_schema())
         )
 
-    @classmethod
-    def get_user_prompt(cls, note_text: str) -> str:
-        prompt = cls.user_prompt or "%CLINICAL-NOTE%"
+    def get_user_prompt(self, note_text: str) -> str:
+        prompt = self.user_prompt or "%CLINICAL-NOTE%"
         return prompt.replace("%CLINICAL-NOTE%", note_text)
 
     def post_process(self, parsed: dict, details: NoteDetails) -> None:

--- a/cumulus_etl/fhir/__init__.py
+++ b/cumulus_etl/fhir/__init__.py
@@ -5,6 +5,8 @@ from .fhir_utils import (
     FhirUrl,
     download_reference,
     get_clinical_note,
+    get_clinical_note_role_info,
+    get_concept_user_text,
     linked_resources,
     parse_content_type,
     parse_datetime,

--- a/cumulus_etl/upload_notes/labelstudio.py
+++ b/cumulus_etl/upload_notes/labelstudio.py
@@ -37,7 +37,7 @@ class Highlight:
 
 @dataclasses.dataclass
 class LabelStudioNote:
-    """Holds all the data that Label Studio will need for a single note (or a single grouped encounter note)"""
+    """Holds all the data that Label Studio will need for a single note (or a grouped note)"""
 
     unique_id: str  # used to uniquely identify this note on the server
     patient_id: str
@@ -47,14 +47,16 @@ class LabelStudioNote:
     text: str = ""  # text of the note, sent to Label Studio
     date: datetime.datetime | None = None  # date of the note
 
-    # A title is only used when combining notes into one big encounter note. It's not sent to Label Studio.
-    title: str = ""
+    # A header holds some user-visible metadata to show above each note.
+    # It's not sent to Label Studio.
+    header: str = ""
 
-    # Doc mappings is a dict of real DocRef ID -> anonymized DocRef ID of all contained notes, in order
+    # Doc mappings is an ordered dict of real ID -> anonymized ID of all contained notes
     doc_mappings: dict[str, str] = dataclasses.field(default_factory=dict)
 
-    # Doc spans indicate which bits of the text come from which DocRef - it will map real DocRef ID to a pair of
-    # "first character" (0-based) and "last character" (0-based, exclusive) - just like cTAKES match text spans.
+    # Doc spans indicate which bits of the text come from which note - it will map a real ID to a
+    # pair of "first character" (0-based) and "last character" (0-based, exclusive) - just like
+    # cTAKES match text spans.
     doc_spans: dict[str, tuple[int, int]] = dataclasses.field(default_factory=dict)
 
     # Matches found by cTAKES

--- a/tests/covid_symptom/test_covid_gpt.py
+++ b/tests/covid_symptom/test_covid_gpt.py
@@ -58,7 +58,7 @@ class TestCovidSymptomGptResultsTask(NlpModelTestCase):
         await task.run()
 
         # Confirm we send the correct params to the server
-        prompt = covid_symptom.CovidSymptomNlpResultsGpt35Task.get_user_prompt("foo")
+        prompt = task.get_user_prompt("foo")
         self.assertEqual(
             hashlib.md5(prompt.encode("utf8")).hexdigest(),
             "8c5025f98a6cfc94dfedbf10a82396ae",  # catch unexpected prompt changes


### PR DESCRIPTION
It also now flags whether it's a document or diagnostic report. All authors and their practitioner role info are included, if found in the original source folder.

Old headers:
```
CT report of head/neck injury
10/16/2025
########################################
########################################


note text


########################################
########################################
Doctor's note
10/16/2025
########################################
########################################


Second note text
```

New headers:
```
########################################
# Diagnostic Report
# Type: X-Ray report of head/neck injury
# Date: 10/16/2025
# Performers:
# * Jorge Smith
#   - Role: Technician
#   - Specialty: X-Rays
########################################



note text


########################################
# Document
# Type: Doctor's note
# Date: 10/16/2025
# Authors:
# * Carol Bargers
#    - Role: MD
#    - Specialty: Sports Medicine
#    - Specialty: Family Medicine
########################################


Second note text
```

### Checklist
- [x] Consider if documentation (like in `docs/`) needs to be updated
- [x] Consider if tests should be added
