### PR TITLE
etl: add --no-table-optimization flag, for when you want to go fast

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -45,7 +45,7 @@ jobs:
 
       - name: Test with pytest
         run: |
-          python -m pytest -n auto --cov=cumulus_etl --cov-report=xml
+          python -m pytest --cov=cumulus_etl --cov-report=xml
 
       - name: Log missing coverage
         run: |

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -45,7 +45,7 @@ jobs:
 
       - name: Test with pytest
         run: |
-          python -m pytest --cov=cumulus_etl --cov-report=xml
+          python -m pytest -n auto --cov=cumulus_etl --cov-report=xml
 
       - name: Log missing coverage
         run: |

--- a/cumulus_etl/deid/scrub-rules.toml
+++ b/cumulus_etl/deid/scrub-rules.toml
@@ -63,7 +63,7 @@ language = "val"
 data = "mask-note"
 url = "mask-note"
 size = "val"
-hash = "val"
+# skip hash (low research value, but *could* be used to reverse-validate notes)
 # skip title
 creation = "val"
 

--- a/cumulus_etl/etl/cli.py
+++ b/cumulus_etl/etl/cli.py
@@ -31,6 +31,13 @@ def define_etl_parser(parser: argparse.ArgumentParser) -> None:
         action="store_true",
         help="run tasks even if their resources are not present",
     )
+    parser.add_argument(
+        "--no-table-optimization",
+        dest="table_optimization",
+        action="store_false",
+        help="skips preparing output tables for faster SQL queries, "
+        "helpful if you are doing lots of ETL runs in a row and want to save some time",
+    )
     cli_utils.add_task_selection(parser)
 
     cli_utils.add_aws(parser)
@@ -123,6 +130,7 @@ async def etl_main(args: argparse.Namespace) -> None:
         deleted_ids=loader_results.deleted_ids,
         export_group_name=export_group,
         export_datetime=export_datetime,
+        format_kwargs={"optimize_table": args.table_optimization},
     )
     common.write_json(config.path_config(), config.as_json(), indent=4)
 

--- a/cumulus_etl/formats/base.py
+++ b/cumulus_etl/formats/base.py
@@ -30,6 +30,7 @@ class Format(abc.ABC):
         group_field: str | None = None,
         uniqueness_fields: Collection[str] | None = None,
         update_existing: bool = True,
+        optimize_table: bool = True,
     ):
         """
         Initialize a new Format class
@@ -41,12 +42,14 @@ class Format(abc.ABC):
          See the comments for the EtlTask.group_field class attribute for more context.
         :param uniqueness_fields: a set of fields that together identify a unique row (defaults to {"id"})
         :param update_existing: whether to update existing rows or (if False) to ignore them and leave them in place
+        :param optimize_table: whether to take extra time to optimize the output tables
         """
         self.root = root
         self.dbname = dbname
         self.group_field = group_field
         self.uniqueness_fields = uniqueness_fields or {"id"}
         self.update_existing = update_existing
+        self.optimize_table = optimize_table
 
     def write_records(self, batch: Batch) -> bool:
         """

--- a/cumulus_etl/formats/deltalake.py
+++ b/cumulus_etl/formats/deltalake.py
@@ -154,13 +154,15 @@ class DeltaLakeFormat(Format):
 
     def finalize(self) -> None:
         """Performs any necessary cleanup after all batches have been written"""
+        if not self.optimize_table:
+            return
+
         table = self._load_table()
         if not table:
             return
 
         try:
             table.optimize().executeCompaction()  # pool small files for better query performance
-            table.generate("symlink_format_manifest")
             table.vacuum()  # Clean up unused data files older than retention policy (default 7 days)
         except Exception:
             logging.exception("Could not finalize Delta Lake table %s", self.dbname)

--- a/tests/etl/test_etl_cli.py
+++ b/tests/etl/test_etl_cli.py
@@ -344,6 +344,14 @@ class TestEtlJobFlow(BaseEtlSimple):
         with self.assert_fatal_exit(errors.FEATURE_REMOVED):
             await self.run_etl(flag)
 
+    async def test_passes_on_table_optimization_arg(self):
+        with (
+            self.assertRaises(RuntimeError),
+            mock.patch("cumulus_etl.etl.pipeline.etl_job", side_effect=RuntimeError) as mock_etl,
+        ):
+            await self.run_etl("--no-table-optimization", tasks=["patient"])
+        self.assertEqual(mock_etl.call_args[0][0]._format_kwargs, {"optimize_table": False})
+
 
 class TestEtlJobConfig(BaseEtlSimple):
     """Test case for the job config logging data"""

--- a/tests/formats/test_deltalake.py
+++ b/tests/formats/test_deltalake.py
@@ -445,8 +445,13 @@ class TestDeltaLake(utils.AsyncTestCase):
         self.assertEqual(
             mock_table.optimize.return_value.executeCompaction.call_args_list, [mock.call()]
         )
-        self.assertEqual(mock_table.generate.call_args_list, [mock.call("symlink_format_manifest")])
         self.assertEqual(mock_table.vacuum.call_args_list, [mock.call()])
+
+    def test_finalize_skip_optimizations(self):
+        deltalake = DeltaLakeFormat(self.root, "patient", optimize_table=False)
+        with mock.patch("delta.DeltaTable.forPath", side_effect=ValueError):
+            # won't blow up because we don't try to load table - finalize is a no-op
+            deltalake.finalize()
 
     def test_finalize_cannot_load_table(self):
         """Verify that we gracefully handle failing to read an existing table when finalizing."""


### PR DESCRIPTION
By default, the ETL will do some Delta Lake optimization after every table is finished writing. Specifically, it will compact files, z-order them, and delete old unreferenced files.

These optimizations are geared for the reading side of things, and just general cleanup.

But, this can take a fair amount of time if you are running back to back ETLs for different groups of patients. Each optimization pass can take a few minutes, and if you are about to write more data to the table, is kind of pointless.

So this flag gives power users a way to speed up such ETL batches of runs by passing the flag on most of the runs, and only doing optimizations on the last run.

Now, while the optimizations are designed to help reads, there is the possibility that they are speeding up the writes too. But I believe not as much as just not doing the optimize in the first place. 

There is another commit I tossed in here:
- When running our de-identification scrubs, don't let `Attachment.hash` through - it's clinical value is low and there's a theoretical possibility the SHA1 hash could be found even weaker down the line and/or something nefarious - no real attack vector in mind, just thinking that there's not much benefit to it and maybe there's a possibility of something bad (like SHA1 gets totally broken and someone can brute-force notes until they get a match?)

### Checklist
- [x] Consider if documentation (like in `docs/`) needs to be updated
- [x] Consider if tests should be added
