### PR TITLE
Adds a float32 pyarrow case in mapping pydantic/json schemas to pyarrow

### DIFF
--- a/cumulus_etl/etl/tasks/nlp_task.py
+++ b/cumulus_etl/etl/tasks/nlp_task.py
@@ -386,6 +386,8 @@ class BaseModelTask(BaseNlpTask):
             return pyarrow.bool_()
         elif issubclass(annotation, int):
             return pyarrow.int32()
+        if issubclass(annotation, float):
+            return pyarrow.float32()
         elif issubclass(annotation, enum.Enum):
             return pyarrow.string()  # for now, assume all enums are strings
         elif issubclass(annotation, pydantic.BaseModel):

--- a/cumulus_etl/etl/tasks/nlp_task.py
+++ b/cumulus_etl/etl/tasks/nlp_task.py
@@ -386,7 +386,7 @@ class BaseModelTask(BaseNlpTask):
             return pyarrow.bool_()
         elif issubclass(annotation, int):
             return pyarrow.int32()
-        if issubclass(annotation, float):
+        elif issubclass(annotation, float):
             return pyarrow.float32()
         elif issubclass(annotation, enum.Enum):
             return pyarrow.string()  # for now, assume all enums are strings

--- a/tests/etl/test_tasks.py
+++ b/tests/etl/test_tasks.py
@@ -344,7 +344,6 @@ class TestTaskCompletion(TaskTestCase):
         self.assertTrue(summaries[0].had_errors)
 
 
-@ddt.ddt
 class TestModelTask(TaskTestCase):
     """Test case for model task methods"""
 
@@ -359,7 +358,6 @@ class TestModelTask(TaskTestCase):
 
         fields = Model.model_fields
         schema = tasks.BaseModelTask.convert_pydantic_fields_to_pyarrow(fields)
-        print(schema)
         self.assertEqual(
             pyarrow.struct(
                 [

--- a/tests/etl/test_tasks.py
+++ b/tests/etl/test_tasks.py
@@ -4,6 +4,8 @@ import os
 from unittest import mock
 
 import ddt
+import pyarrow
+import pydantic
 
 from cumulus_etl import common, errors
 from cumulus_etl.etl import tasks
@@ -340,3 +342,32 @@ class TestTaskCompletion(TaskTestCase):
         self.make_json("Device", "A")
         summaries = await basic_tasks.DeviceTask(self.job_config, self.scrubber).run()
         self.assertTrue(summaries[0].had_errors)
+
+
+@ddt.ddt
+class TestModelTask(TaskTestCase):
+    """Test case for model task methods"""
+
+    async def test_convert_pydantic_fields_to_pyarrow(self):
+        """Verify that we can convert pydantic fields to pyarrow types"""
+
+        class Model(pydantic.BaseModel):
+            string_field: str
+            boolean_field: bool
+            integer_field: int
+            float_field: float
+
+        fields = Model.model_fields
+        schema = tasks.BaseModelTask.convert_pydantic_fields_to_pyarrow(fields)
+        print(schema)
+        self.assertEqual(
+            pyarrow.struct(
+                [
+                    pyarrow.field("string_field", pyarrow.string()),
+                    pyarrow.field("boolean_field", pyarrow.bool_()),
+                    pyarrow.field("integer_field", pyarrow.int32()),
+                    pyarrow.field("float_field", pyarrow.float32()),
+                ]
+            ),
+            schema,
+        )

--- a/tests/formats/test_deltalake.py
+++ b/tests/formats/test_deltalake.py
@@ -170,8 +170,8 @@ class TestDeltaLake(utils.AsyncTestCase):
                 {"id": "missing-date-update", "meta": {}, "value": 2},
                 {"id": "missing-date-both", "meta": {}, "value": 2},
                 {"id": "missing-meta-table", "meta": {"lastUpdated": now}, "value": 2},
-                {"id": "missing-meta-update", "meta": {}, "value": 2},
-                {"id": "missing-meta-both", "meta": {}, "value": 2},
+                {"id": "missing-meta-update", "value": 2},
+                {"id": "missing-meta-both", "value": 2},
                 {"id": "unmatched-table", "value": 1},
                 {"id": "unmatched-update", "value": 2},
             ]


### PR DESCRIPTION
Seems like we thought we already supported this based on some mocked cli tests, but we didn't! Feels a bit small to add a regression test, but I'll take a stab at one if we think that's necessary just LMK. 

### Checklist
- [x] Consider if documentation (like in `docs/`) needs to be updated
- [x] Consider if tests should be added
