### PR TITLE
deltalake: give spark more memory

### DIFF
--- a/cumulus_etl/formats/deltalake.py
+++ b/cumulus_etl/formats/deltalake.py
@@ -69,7 +69,7 @@ class DeltaLakeFormat(Format):
             builder = (
                 pyspark.sql.SparkSession.builder.appName("cumulus-etl")
                 .config("spark.databricks.delta.schema.autoMerge.enabled", "true")
-                .config("spark.driver.memory", "4g")
+                .config("spark.driver.memory", "6g")
                 .config(
                     "spark.sql.catalog.spark_catalog",
                     "org.apache.spark.sql.delta.catalog.DeltaCatalog",


### PR DESCRIPTION
We currently recommend 32GB on the machine you're running, so stealing 2 more gigs for spark seems fine - and BCH at least needs the memory for its Observation table, so 6G is a practical amount.


### Checklist
- [x] Consider if documentation (like in `docs/`) needs to be updated
- [x] Consider if tests should be added
