### PR TITLE
Allow explicit resource exclusion

### DIFF
--- a/bdf.yaml
+++ b/bdf.yaml
@@ -43,7 +43,7 @@ output:
     dataStandard:
       - Stratified counts of FHIR elements
     proprietary: true
-    source: "TODO"
+    source: https://github.com/smart-on-fhir/cumulus-library
 
 license:
   license_type: Apache-2.0
@@ -52,7 +52,7 @@ license:
 funding:
   source: ONC, CDC, ARPA-H
   agreement: Not specified
-  link: ""
+  link: https://arpa-h.gov/explore-funding/programs/arpa-h-bdf-toolbox
 
 domains:
   - Anything in the EHR

--- a/cumulus_etl/completion/schema.py
+++ b/cumulus_etl/completion/schema.py
@@ -53,6 +53,7 @@ def completion_schema() -> pyarrow.Schema:
             pyarrow.field("etl_version", pyarrow.string()),
             # See note above for why this isn't a pyarrow.timestamp() field.
             pyarrow.field("etl_time", pyarrow.string()),
+            pyarrow.field("excluded_resources", pyarrow.string()),
         ]
     )
 
@@ -65,5 +66,6 @@ def completion_encounters_schema() -> pyarrow.Schema:
             pyarrow.field("group_name", pyarrow.string()),
             # See note above for why this isn't a pyarrow.timestamp() field.
             pyarrow.field("export_time", pyarrow.string()),
+            pyarrow.field("excluded_resources", pyarrow.string()),
         ]
     )

--- a/cumulus_etl/etl/cli.py
+++ b/cumulus_etl/etl/cli.py
@@ -95,7 +95,7 @@ def handle_completion_args(
         )
     # These next two errors can be briefer because the user clearly knows about the args.
     elif missing_datetime:
-        errors.fatal("Missing --export-datetime argument.", errors.COMPLETION_ARG_MISSING)
+        errors.fatal("Missing --export-timestamp argument.", errors.COMPLETION_ARG_MISSING)
     elif missing_group_name:
         errors.fatal("Missing --export-group argument.", errors.COMPLETION_ARG_MISSING)
 
@@ -131,6 +131,7 @@ async def etl_main(args: argparse.Namespace) -> None:
         deleted_ids=loader_results.deleted_ids,
         export_group_name=export_group,
         export_datetime=export_datetime,
+        exclusions=','.join(args.exclusions),
         format_kwargs={"optimize_table": args.table_optimization},
     )
     config.path_config().write_json(config.as_json(), indent=4)

--- a/cumulus_etl/etl/config.py
+++ b/cumulus_etl/etl/config.py
@@ -38,6 +38,7 @@ class JobConfig:
         export_url: str | None = None,
         deleted_ids: dict[str, set[str]] | None = None,
         resource_filter: cfs.NoteFilter | None = None,
+        exclusions: list[str] | None = None,
         format_kwargs: dict | None = None,
     ):
         self.dir_input_orig = dir_input_orig
@@ -59,6 +60,7 @@ class JobConfig:
         self.export_url = export_url
         self.deleted_ids = deleted_ids or {}
         self.resource_filter = resource_filter
+        self.exclusions = exclusions
 
         # initialize format class
         self._dir_output.makedirs()
@@ -94,6 +96,7 @@ class JobConfig:
             "export_timestamp": self.export_datetime and self.export_datetime.isoformat(),
             "export_url": self.export_url,
             "codebook_id": self.codebook_id,
+            "exclusions": self.exclusions
         }
 
 

--- a/cumulus_etl/etl/pipeline.py
+++ b/cumulus_etl/etl/pipeline.py
@@ -62,6 +62,14 @@ def add_common_etl_args(
         type=cfs.FsPath,
         help="where to put resources that could not be processed",
     )
+    parser.add_argument(
+        "--exclude-resources",
+        dest="exclusions",
+        action="append",
+        help="Resource type(s) to be excluded from completion tracking (comma separated, "
+            "use '--task help' to see full list)",
+        default = [],
+        ),
 
     cli_utils.add_auth(parser)
     cli_utils.add_debugging(parser)
@@ -100,6 +108,7 @@ def print_config(
         table.add_row("Errors path:", args.errors_to)
     table.add_row("Current time:", f"{common.timestamp_datetime(job_datetime)} UTC")
     table.add_row("Batch size:", f"{args.batch_size:,}")
+    table.add_row("Excluded resources:",", ".join(sorted(r for r in args.exclusions)))
     table.add_row("Tasks:", ", ".join(sorted(t.name for t in all_tasks)))
     if "comment" in args and args.comment:
         table.add_row("Comment:", args.comment)
@@ -164,7 +173,7 @@ async def prepare_pipeline(
     root_input = cli_utils.process_input_dir(args.dir_input)
     args.dir_phi.makedirs()  # create PHI folder, if needed
 
-    selected_tasks = task_factory.get_selected_tasks(args.task, nlp=nlp)
+    selected_tasks = task_factory.get_selected_tasks(args.task, nlp=nlp, exclusions=args.exclusions)
     is_default_tasks = not args.task
 
     # Print configuration

--- a/cumulus_etl/etl/studies/covid_symptom/covid_tasks.py
+++ b/cumulus_etl/etl/studies/covid_symptom/covid_tasks.py
@@ -7,6 +7,7 @@ import ctakesclient
 import cumulus_fhir_support as cfs
 import pyarrow
 import pydantic
+import rich
 from ctakesclient.transformer import TransformerModel
 
 from cumulus_etl import feedback, nlp
@@ -121,7 +122,7 @@ class BaseCovidCtakesTask(tasks.BaseNlpTask):
         bsv_path = cfs.FsPath(ctakesclient.filesystem.covid_symptoms_path())
         success = nlp.restart_ctakes_with_bsv(self.task_config.ctakes_overrides, bsv_path)
         if not success:
-            print("  Skipping.")
+            rich.print("  Skipping.")
             self.summaries[0].had_errors = True
         return success
 

--- a/cumulus_etl/etl/tasks/base.py
+++ b/cumulus_etl/etl/tasks/base.py
@@ -266,6 +266,7 @@ class EtlTask:
                     "export_url": self.task_config.export_url,
                     "etl_version": cumulus_etl.__version__,
                     "etl_time": self.task_config.timestamp.isoformat(),
+                    "excluded_resources": self.task_config.exclusions
                 }
                 for output in self.outputs
                 if not output.get_name(self).startswith("etl__")

--- a/cumulus_etl/etl/tasks/basic_tasks.py
+++ b/cumulus_etl/etl/tasks/basic_tasks.py
@@ -56,6 +56,7 @@ class EncounterTask(tasks.EtlTask):
                 "encounter_id": encounter["id"],
                 "group_name": self.task_config.export_group_name,
                 "export_time": self.task_config.export_datetime.isoformat(),
+                "excluded_resources": self.task_config.exclusions,
             }
             yield completion_info, encounter
 

--- a/cumulus_etl/etl/tasks/task_factory.py
+++ b/cumulus_etl/etl/tasks/task_factory.py
@@ -84,15 +84,18 @@ def get_selected_tasks(
     names: Iterable[str] | None = None,
     *,
     nlp: bool = False,
+    exclusions: Iterable[str] = []
 ) -> list[type[AnyTask]]:
     """
     Returns classes for every selected task.
 
     :param names: an exact list of which tasks to select
     :param nlp: whether we are selecting from NLP or normal tasks
+    :param exclude: a list of resources to explicitly exclude from a task list
     :returns: a list of selected EtlTask subclasses, to instantiate and run
     """
     names = set(cli_utils.expand_comma_list_arg(names, casefold=True))
+    exclusions = set(cli_utils.expand_comma_list_arg(exclusions, casefold=True))
 
     # If we are in NLP mode, we can only select NLP tasks and vice versa.
     all_tasks = get_nlp_tasks() if nlp else get_default_tasks()
@@ -116,6 +119,10 @@ def get_selected_tasks(
         rich.print(f"Unknown task '{unknown_names.pop()}' requested.")
         _print_task_names(all_tasks)
         raise SystemExit(errors.TASK_UNKNOWN)
+    if unknown_names := exclusions - all_task_names - other_task_names:
+        rich.print(f"Unknown task '{unknown_names.pop()}' requested for exclusion.")
+        _print_task_names(all_tasks)
+        raise SystemExit(errors.TASK_UNKNOWN)
     if names - all_task_names:
         errors.fatal(
             "Cannot mix NLP and non-NLP tasks in the same run. "
@@ -124,6 +131,8 @@ def get_selected_tasks(
         )
 
     tasks = [task for task in all_tasks if task.name in names]
+    if exclusions:
+        tasks = [task for task in tasks if task.name not in exclusions]
 
     if nlp:
         models = {getattr(t, "client_class", None) for t in tasks}

--- a/cumulus_etl/etl/tasks/task_factory.py
+++ b/cumulus_etl/etl/tasks/task_factory.py
@@ -81,17 +81,14 @@ def get_default_tasks() -> list[type[AnyTask]]:
 
 
 def get_selected_tasks(
-    names: Iterable[str] | None = None,
-    *,
-    nlp: bool = False,
-    exclusions: Iterable[str] = []
+    names: Iterable[str] | None = None, *, nlp: bool = False, exclusions: Iterable[str] = []
 ) -> list[type[AnyTask]]:
     """
     Returns classes for every selected task.
 
     :param names: an exact list of which tasks to select
     :param nlp: whether we are selecting from NLP or normal tasks
-    :param exclude: a list of resources to explicitly exclude from a task list
+    :param exclusions: a list of resources to explicitly exclude from a task list
     :returns: a list of selected EtlTask subclasses, to instantiate and run
     """
     names = set(cli_utils.expand_comma_list_arg(names, casefold=True))
@@ -108,9 +105,10 @@ def get_selected_tasks(
 
     # What to do if user didn't provide any constraints?
     if not names:
-        return get_default_tasks()
+        all_tasks = get_default_tasks()
+        names = set([x.name for x in all_tasks])
 
-    # They did list names, so now we validate those names and select those tasks.
+    # Now we validate those names and select those tasks, along with checking exclusion cases
 
     # Check for unknown names the user gave us
     all_task_names = {t.name for t in all_tasks}
@@ -131,14 +129,12 @@ def get_selected_tasks(
         )
 
     tasks = [task for task in all_tasks if task.name in names]
-    if exclusions:
+    if exclusions != {}:
         tasks = [task for task in tasks if task.name not in exclusions]
-
     if nlp:
         models = {getattr(t, "client_class", None) for t in tasks}
         if len(models) > 1:
             errors.fatal("Only one kind of NLP model can be run at once.", errors.TASK_TOO_MANY)
-
     return tasks
 
 

--- a/cumulus_etl/loaders/i2b2/extract.py
+++ b/cumulus_etl/loaders/i2b2/extract.py
@@ -3,6 +3,8 @@
 import logging
 from collections.abc import Iterator
 
+import rich
+
 from cumulus_etl import common
 from cumulus_etl.loaders.i2b2.schema import ObservationFact, PatientDimension, VisitDimension
 
@@ -14,11 +16,11 @@ def extract_csv(path_csv: str) -> Iterator[dict]:
     """
     try:
         with common.read_csv(path_csv) as reader:
-            print(f"Reading csv {path_csv}...")
+            rich.print(f"Reading csv {path_csv}...")
             yield from reader
-            print(f"Done reading {path_csv}.")
+            rich.print(f"Done reading {path_csv}.")
     except FileNotFoundError:
-        print(f"No {path_csv}, skipping.")
+        rich.print(f"No {path_csv}, skipping.")
 
 
 def extract_csv_observation_facts(path_csv: str) -> Iterator[ObservationFact]:

--- a/cumulus_etl/nlp/watcher.py
+++ b/cumulus_etl/nlp/watcher.py
@@ -73,7 +73,6 @@ def wait_for_ctakes_restart():
     connection = socket.create_connection((url.hostname, url.port))
     poller = select.poll()
     # Poll for RDHUP to watch for remote disconnect (death or remote timeout)
-    print(select.__dict__)
     try:
         poller.register(connection, select.POLLRDHUP)
     # Does our operating system/python build not support POLLRDHUP? If so, we'll try to

--- a/cumulus_etl/nlp/watcher.py
+++ b/cumulus_etl/nlp/watcher.py
@@ -73,7 +73,17 @@ def wait_for_ctakes_restart():
     connection = socket.create_connection((url.hostname, url.port))
     poller = select.poll()
     # Poll for RDHUP to watch for remote disconnect (death or remote timeout)
-    poller.register(connection, select.POLLRDHUP)
+    print(select.__dict__)
+    try:
+        poller.register(connection, select.POLLRDHUP)
+    # Does our operating system/python build not support POLLRDHUP? If so, we'll try to
+    # catch this via an alternate mechanism. 
+    # Generally speaking, we expect ETL to be run on a Linux machine, so this is not
+    # recommended - but cTAKES is not frequently used anyway, so it is a non-issue for
+    # most cases.
+    except AttributeError:
+        poller.register(connection, select.POLLHUP)
+
 
     # *** Yield to caller ***
     yield

--- a/cumulus_etl/nlp/watcher.py
+++ b/cumulus_etl/nlp/watcher.py
@@ -76,13 +76,12 @@ def wait_for_ctakes_restart():
     try:
         poller.register(connection, select.POLLRDHUP)
     # Does our operating system/python build not support POLLRDHUP? If so, we'll try to
-    # catch this via an alternate mechanism. 
+    # catch this via an alternate mechanism.
     # Generally speaking, we expect ETL to be run on a Linux machine, so this is not
     # recommended - but cTAKES is not frequently used anyway, so it is a non-issue for
     # most cases.
-    except AttributeError:
+    except AttributeError:  # pragma: no cover
         poller.register(connection, select.POLLHUP)
-
 
     # *** Yield to caller ***
     yield

--- a/cumulus_etl/upload_notes/cli.py
+++ b/cumulus_etl/upload_notes/cli.py
@@ -6,6 +6,7 @@ import datetime
 from collections.abc import Callable, Collection
 
 import cumulus_fhir_support as cfs
+import rich
 
 from cumulus_etl import cli_utils, common, deid, errors, fhir, nlp
 from cumulus_etl.upload_notes import labeling, selector
@@ -92,7 +93,7 @@ async def read_notes_from_ndjson(
         try:
             text = cfs.get_text_from_note_res(resource)
         except Exception:
-            print(f"Skipping {note_ref}: no text found.")
+            rich.print(f"Skipping {note_ref}: no text found.")
             continue
 
         # Grab a bunch of the metadata
@@ -406,7 +407,7 @@ async def upload_notes_main(args: argparse.Namespace) -> None:
             get_unique_id = _get_unique_id_for_no_grouping
 
     common.print_header()
-    print("Preparing metadata…")  # i.e. the codebook
+    rich.print("Preparing metadata…")  # i.e. the codebook
 
     with deid.Codebook(args.dir_phi) as codebook:
         ndjson_folder = gather_resources(args.dir_input, codebook, args)

--- a/cumulus_etl/upload_notes/labelstudio.py
+++ b/cumulus_etl/upload_notes/labelstudio.py
@@ -10,6 +10,7 @@ from collections.abc import AsyncIterator, Collection, Iterable
 
 import label_studio_sdk as ls
 import label_studio_sdk.data_manager as lsdm
+import rich
 
 from cumulus_etl import batching, errors, feedback
 
@@ -84,11 +85,11 @@ class LabelStudioClient:
         # Should we delete existing entries?
         if existing_tasks:
             if overwrite:
-                print(f"Overwriting {len(existing_tasks):,} existing charts.")
+                rich.print(f"Overwriting {len(existing_tasks):,} existing charts.")
                 for task_id in existing_tasks.values():
                     self._client.tasks.delete(task_id)
             else:
-                print(f"Skipping {len(existing_tasks):,} existing charts.")
+                rich.print(f"Skipping {len(existing_tasks):,} existing charts.")
                 notes = [note for note in notes if note.unique_id not in existing_tasks]
 
         # OK, import away!
@@ -100,7 +101,7 @@ class LabelStudioClient:
             async for batch in self._batch_with_progress("Uploading charts…", new_notes, 300):
                 self._client.projects.import_tasks(self._project.id, request=batch)
             if new_task_count:
-                print(f"Imported {new_task_count:,} new charts.")
+                rich.print(f"Imported {new_task_count:,} new charts.")
 
     async def _search_for_existing_tasks(self, unique_ids: Collection[str]) -> dict[str, int]:
         existing_tasks = []

--- a/docs/bulk-exports.md
+++ b/docs/bulk-exports.md
@@ -84,6 +84,22 @@ For example, maybe exporting Observations is too slow unless you slice by catego
 Just make sure that after you export all the Observations separately,
 you then combine them again into one big Observation folder before running Cumulus ETL.
 
+### Resource availability
+
+By default, Cumulus ETL assumes that you are going to have exported data for every
+[supported resource](https://docs.smarthealthit.org/cumulus/resources.html)
+available when you run the ETL. If supported resources are missing, then encounters
+will be marked as incomplete (since it looks the same as a partial group export).
+
+If you don't have a specific resource available, you can deal with this in one of two ways:
+
+1. By using `--allow-missing-resources`, the ETL will not block on files not being available - 
+but this may cause issues with downstream consumers. We recommend you only use this as a debugging
+tool if you are working on export issues.
+2. By using `--exclude-resources=[comma seperated list of resources]`, the ETL will explicitly note
+that some resources were expected to not be present. Downstream consumers can check which resources
+are not expected and then adjust appropriately based on this context.
+
 ## Archiving Exports
 
 Exports can take a long time, and it's often convenient to archive the results.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -58,6 +58,13 @@ cumulus-etl = "cumulus_etl.cli:main_cli"
 requires = ["flit_core >=3.12,<4"]
 build-backend = "flit_core.buildapi"
 
+[tool.coverage.run]
+omit = [
+    # i2b2 support is legacy, so we won't flag on coverage there
+    "cumulus-etl/loaders/i2b2/*"
+]
+
+
 [tool.flit.sdist]
 include = [
     "docs/",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -81,6 +81,7 @@ select = [
     "PLE",  # pylint errors
     "RUF",  # the ruff developer's own rules
     "S",  # bandit security warnings
+    "T201", #checks for print statements
     "UP",  # alert you when better syntax is available in your python version
 ]
 ignore = [

--- a/tests/convert/test_convert_cli.py
+++ b/tests/convert/test_convert_cli.py
@@ -266,7 +266,6 @@ class TestConvertOnS3(s3mock.S3Mixin, ConvertTestsBase):
         # Verify results
         self.assertEqual(mock_write.call_count, 1)
         self.assertEqual([{"id": "con1"}], mock_write.call_args[0][0].rows)
-        print(os.listdir(f"{self.target_path}"))
         self.assertEqual(
             cfs.FsPath(
                 f"{self.target_path}/JobConfig/2024-08-09__16.32.51/job_config.json"

--- a/tests/data/i2b2/output/etl__completion/etl__completion.000.ndjson
+++ b/tests/data/i2b2/output/etl__completion/etl__completion.000.ndjson
@@ -1,1 +1,1 @@
-{"table_name": "encounter", "group_name": "test-group", "export_time": "2020-10-13T12:00:20-05:00", "etl_version": "1.0.0+test", "etl_time": "2021-09-14T21:23:45+00:00"}
+{"table_name": "encounter", "group_name": "test-group", "export_time": "2020-10-13T12:00:20-05:00", "etl_version": "1.0.0+test", "etl_time": "2021-09-14T21:23:45+00:00", "excluded_resources": ""}

--- a/tests/data/i2b2/output/etl__completion/etl__completion.001.ndjson
+++ b/tests/data/i2b2/output/etl__completion/etl__completion.001.ndjson
@@ -1,1 +1,1 @@
-{"table_name": "patient", "group_name": "test-group", "export_time": "2020-10-13T12:00:20-05:00", "etl_version": "1.0.0+test", "etl_time": "2021-09-14T21:23:45+00:00"}
+{"table_name": "patient", "group_name": "test-group", "export_time": "2020-10-13T12:00:20-05:00", "etl_version": "1.0.0+test", "etl_time": "2021-09-14T21:23:45+00:00", "excluded_resources": ""}

--- a/tests/data/i2b2/output/etl__completion/etl__completion.002.ndjson
+++ b/tests/data/i2b2/output/etl__completion/etl__completion.002.ndjson
@@ -1,1 +1,1 @@
-{"table_name": "condition", "group_name": "test-group", "export_time": "2020-10-13T12:00:20-05:00", "etl_version": "1.0.0+test", "etl_time": "2021-09-14T21:23:45+00:00"}
+{"table_name": "condition", "group_name": "test-group", "export_time": "2020-10-13T12:00:20-05:00", "etl_version": "1.0.0+test", "etl_time": "2021-09-14T21:23:45+00:00", "excluded_resources": ""}

--- a/tests/data/i2b2/output/etl__completion/etl__completion.003.ndjson
+++ b/tests/data/i2b2/output/etl__completion/etl__completion.003.ndjson
@@ -1,1 +1,1 @@
-{"table_name": "documentreference", "group_name": "test-group", "export_time": "2020-10-13T12:00:20-05:00", "etl_version": "1.0.0+test", "etl_time": "2021-09-14T21:23:45+00:00"}
+{"table_name": "documentreference", "group_name": "test-group", "export_time": "2020-10-13T12:00:20-05:00", "etl_version": "1.0.0+test", "etl_time": "2021-09-14T21:23:45+00:00", "excluded_resources": ""}

--- a/tests/data/i2b2/output/etl__completion/etl__completion.004.ndjson
+++ b/tests/data/i2b2/output/etl__completion/etl__completion.004.ndjson
@@ -1,1 +1,1 @@
-{"table_name": "medicationrequest", "group_name": "test-group", "export_time": "2020-10-13T12:00:20-05:00", "etl_version": "1.0.0+test", "etl_time": "2021-09-14T21:23:45+00:00"}
+{"table_name": "medicationrequest", "group_name": "test-group", "export_time": "2020-10-13T12:00:20-05:00", "etl_version": "1.0.0+test", "etl_time": "2021-09-14T21:23:45+00:00", "excluded_resources": ""}

--- a/tests/data/i2b2/output/etl__completion/etl__completion.005.ndjson
+++ b/tests/data/i2b2/output/etl__completion/etl__completion.005.ndjson
@@ -1,1 +1,1 @@
-{"table_name": "observation", "group_name": "test-group", "export_time": "2020-10-13T12:00:20-05:00", "etl_version": "1.0.0+test", "etl_time": "2021-09-14T21:23:45+00:00"}
+{"table_name": "observation", "group_name": "test-group", "export_time": "2020-10-13T12:00:20-05:00", "etl_version": "1.0.0+test", "etl_time": "2021-09-14T21:23:45+00:00", "excluded_resources": ""}

--- a/tests/data/i2b2/output/etl__completion_encounters/etl__completion_encounters.000.ndjson
+++ b/tests/data/i2b2/output/etl__completion_encounters/etl__completion_encounters.000.ndjson
@@ -1,2 +1,2 @@
-{"encounter_id": "82ebb5bb976239c0a7c3b37f50362b58b9c210b35753bb82fbb477f93c43b423", "export_time": "2020-10-13T12:00:20-05:00", "group_name": "test-group"}
-{"encounter_id": "fb29ea2a68ca2e1e4bbe22bdeedf021d94ec89f7e3d38ecbe908a8f2b3d89687", "export_time": "2020-10-13T12:00:20-05:00", "group_name": "test-group"}
+{"encounter_id": "82ebb5bb976239c0a7c3b37f50362b58b9c210b35753bb82fbb477f93c43b423", "export_time": "2020-10-13T12:00:20-05:00", "group_name": "test-group", "excluded_resources": ""}
+{"encounter_id": "fb29ea2a68ca2e1e4bbe22bdeedf021d94ec89f7e3d38ecbe908a8f2b3d89687", "export_time": "2020-10-13T12:00:20-05:00", "group_name": "test-group", "excluded_resources": ""}

--- a/tests/data/simple/batched-output/etl__completion/etl__completion.000.ndjson
+++ b/tests/data/simple/batched-output/etl__completion/etl__completion.000.ndjson
@@ -1,1 +1,1 @@
-{"table_name": "encounter", "group_name": "test-group", "export_time": "2020-10-13T12:00:20-05:00", "export_url": "https://example.org/fhir/$export", "etl_version": "1.0.0+test", "etl_time": "2021-09-14T21:23:45+00:00"}
+{"table_name": "encounter", "group_name": "test-group", "export_time": "2020-10-13T12:00:20-05:00", "export_url": "https://example.org/fhir/$export", "etl_version": "1.0.0+test", "etl_time": "2021-09-14T21:23:45+00:00","excluded_resources": ""}

--- a/tests/data/simple/batched-output/etl__completion/etl__completion.001.ndjson
+++ b/tests/data/simple/batched-output/etl__completion/etl__completion.001.ndjson
@@ -1,1 +1,1 @@
-{"table_name": "patient", "group_name": "test-group", "export_time": "2020-10-13T12:00:20-05:00", "export_url": "https://example.org/fhir/$export", "etl_version": "1.0.0+test", "etl_time": "2021-09-14T21:23:45+00:00"}
+{"table_name": "patient", "group_name": "test-group", "export_time": "2020-10-13T12:00:20-05:00", "export_url": "https://example.org/fhir/$export", "etl_version": "1.0.0+test", "etl_time": "2021-09-14T21:23:45+00:00","excluded_resources": ""}

--- a/tests/data/simple/batched-output/etl__completion/etl__completion.002.ndjson
+++ b/tests/data/simple/batched-output/etl__completion/etl__completion.002.ndjson
@@ -1,1 +1,1 @@
-{"table_name": "condition", "group_name": "test-group", "export_time": "2020-10-13T12:00:20-05:00", "export_url": "https://example.org/fhir/$export", "etl_version": "1.0.0+test", "etl_time": "2021-09-14T21:23:45+00:00"}
+{"table_name": "condition", "group_name": "test-group", "export_time": "2020-10-13T12:00:20-05:00", "export_url": "https://example.org/fhir/$export", "etl_version": "1.0.0+test", "etl_time": "2021-09-14T21:23:45+00:00","excluded_resources": ""}

--- a/tests/data/simple/batched-output/etl__completion/etl__completion.003.ndjson
+++ b/tests/data/simple/batched-output/etl__completion/etl__completion.003.ndjson
@@ -1,1 +1,1 @@
-{"table_name": "documentreference", "group_name": "test-group", "export_time": "2020-10-13T12:00:20-05:00", "export_url": "https://example.org/fhir/$export", "etl_version": "1.0.0+test", "etl_time": "2021-09-14T21:23:45+00:00"}
+{"table_name": "documentreference", "group_name": "test-group", "export_time": "2020-10-13T12:00:20-05:00", "export_url": "https://example.org/fhir/$export","etl_time": "2021-09-14T21:23:45+00:00", "etl_version": "1.0.0+test","excluded_resources": ""}

--- a/tests/data/simple/batched-output/etl__completion/etl__completion.004.ndjson
+++ b/tests/data/simple/batched-output/etl__completion/etl__completion.004.ndjson
@@ -1,1 +1,1 @@
-{"table_name": "medicationrequest", "group_name": "test-group", "export_time": "2020-10-13T12:00:20-05:00", "export_url": "https://example.org/fhir/$export", "etl_version": "1.0.0+test", "etl_time": "2021-09-14T21:23:45+00:00"}
+{"table_name": "medicationrequest", "group_name": "test-group", "export_time": "2020-10-13T12:00:20-05:00", "export_url": "https://example.org/fhir/$export", "etl_version": "1.0.0+test", "etl_time": "2021-09-14T21:23:45+00:00","excluded_resources": ""}

--- a/tests/data/simple/batched-output/etl__completion/etl__completion.005.ndjson
+++ b/tests/data/simple/batched-output/etl__completion/etl__completion.005.ndjson
@@ -1,1 +1,1 @@
-{"table_name": "observation", "group_name": "test-group", "export_time": "2020-10-13T12:00:20-05:00", "export_url": "https://example.org/fhir/$export", "etl_version": "1.0.0+test", "etl_time": "2021-09-14T21:23:45+00:00"}
+{"table_name": "observation", "group_name": "test-group", "export_time": "2020-10-13T12:00:20-05:00", "export_url": "https://example.org/fhir/$export", "etl_version": "1.0.0+test", "etl_time": "2021-09-14T21:23:45+00:00","excluded_resources": ""}

--- a/tests/data/simple/batched-output/etl__completion/etl__completion.006.ndjson
+++ b/tests/data/simple/batched-output/etl__completion/etl__completion.006.ndjson
@@ -1,1 +1,1 @@
-{"table_name": "procedure", "group_name": "test-group", "export_time": "2020-10-13T12:00:20-05:00", "export_url": "https://example.org/fhir/$export", "etl_version": "1.0.0+test", "etl_time": "2021-09-14T21:23:45+00:00"}
+{"table_name": "procedure", "group_name": "test-group", "export_time": "2020-10-13T12:00:20-05:00", "export_url": "https://example.org/fhir/$export", "etl_version": "1.0.0+test", "etl_time": "2021-09-14T21:23:45+00:00","excluded_resources": ""}

--- a/tests/data/simple/batched-output/etl__completion/etl__completion.007.ndjson
+++ b/tests/data/simple/batched-output/etl__completion/etl__completion.007.ndjson
@@ -1,1 +1,1 @@
-{"table_name": "servicerequest", "group_name": "test-group", "export_time": "2020-10-13T12:00:20-05:00", "export_url": "https://example.org/fhir/$export", "etl_version": "1.0.0+test", "etl_time": "2021-09-14T21:23:45+00:00"}
+{"table_name": "servicerequest", "group_name": "test-group", "export_time": "2020-10-13T12:00:20-05:00", "export_url": "https://example.org/fhir/$export", "etl_version": "1.0.0+test", "etl_time": "2021-09-14T21:23:45+00:00","excluded_resources": ""}

--- a/tests/data/simple/batched-output/etl__completion_encounters/etl__completion_encounters.000.ndjson
+++ b/tests/data/simple/batched-output/etl__completion_encounters/etl__completion_encounters.000.ndjson
@@ -1,1 +1,1 @@
-{"encounter_id": "08f0ebd4-950c-ddd9-ce97-b5bdf073eed1", "export_time": "2020-10-13T12:00:20-05:00", "group_name": "test-group"}
+{"encounter_id": "08f0ebd4-950c-ddd9-ce97-b5bdf073eed1", "export_time": "2020-10-13T12:00:20-05:00", "group_name": "test-group","excluded_resources": ""}

--- a/tests/data/simple/batched-output/etl__completion_encounters/etl__completion_encounters.001.ndjson
+++ b/tests/data/simple/batched-output/etl__completion_encounters/etl__completion_encounters.001.ndjson
@@ -1,1 +1,1 @@
-{"encounter_id": "af1e6186-3f9a-1fa9-3c73-cfa56c84a056", "export_time": "2020-10-13T12:00:20-05:00", "group_name": "test-group"}
+{"encounter_id": "af1e6186-3f9a-1fa9-3c73-cfa56c84a056", "export_time": "2020-10-13T12:00:20-05:00", "group_name": "test-group","excluded_resources": ""}

--- a/tests/data/simple/output/etl__completion/etl__completion.000.ndjson
+++ b/tests/data/simple/output/etl__completion/etl__completion.000.ndjson
@@ -1,1 +1,1 @@
-{"table_name": "encounter", "group_name": "test-group", "export_time": "2020-10-13T12:00:20-05:00", "export_url": "https://example.org/fhir/$export", "etl_version": "1.0.0+test", "etl_time": "2021-09-14T21:23:45+00:00"}
+{"table_name": "encounter", "group_name": "test-group", "export_time": "2020-10-13T12:00:20-05:00", "export_url": "https://example.org/fhir/$export", "etl_version": "1.0.0+test", "etl_time": "2021-09-14T21:23:45+00:00", "excluded_resources": ""}

--- a/tests/data/simple/output/etl__completion/etl__completion.001.ndjson
+++ b/tests/data/simple/output/etl__completion/etl__completion.001.ndjson
@@ -1,1 +1,1 @@
-{"table_name": "patient", "group_name": "test-group", "export_time": "2020-10-13T12:00:20-05:00", "export_url": "https://example.org/fhir/$export", "etl_version": "1.0.0+test", "etl_time": "2021-09-14T21:23:45+00:00"}
+{"table_name": "patient", "group_name": "test-group", "export_time": "2020-10-13T12:00:20-05:00", "export_url": "https://example.org/fhir/$export", "etl_version": "1.0.0+test", "etl_time": "2021-09-14T21:23:45+00:00", "excluded_resources": ""}

--- a/tests/data/simple/output/etl__completion/etl__completion.002.ndjson
+++ b/tests/data/simple/output/etl__completion/etl__completion.002.ndjson
@@ -1,1 +1,1 @@
-{"table_name": "allergyintolerance", "group_name": "test-group", "export_time": "2020-10-13T12:00:20-05:00", "export_url": "https://example.org/fhir/$export", "etl_version": "1.0.0+test", "etl_time": "2021-09-14T21:23:45+00:00"}
+{"table_name": "allergyintolerance", "group_name": "test-group", "export_time": "2020-10-13T12:00:20-05:00", "export_url": "https://example.org/fhir/$export", "etl_version": "1.0.0+test", "etl_time": "2021-09-14T21:23:45+00:00", "excluded_resources": ""}

--- a/tests/data/simple/output/etl__completion/etl__completion.003.ndjson
+++ b/tests/data/simple/output/etl__completion/etl__completion.003.ndjson
@@ -1,1 +1,1 @@
-{"table_name": "condition", "group_name": "test-group", "export_time": "2020-10-13T12:00:20-05:00", "export_url": "https://example.org/fhir/$export", "etl_version": "1.0.0+test", "etl_time": "2021-09-14T21:23:45+00:00"}
+{"table_name": "condition", "group_name": "test-group", "export_time": "2020-10-13T12:00:20-05:00", "export_url": "https://example.org/fhir/$export", "etl_version": "1.0.0+test", "etl_time": "2021-09-14T21:23:45+00:00", "excluded_resources": ""}

--- a/tests/data/simple/output/etl__completion/etl__completion.004.ndjson
+++ b/tests/data/simple/output/etl__completion/etl__completion.004.ndjson
@@ -1,1 +1,1 @@
-{"table_name": "device", "group_name": "test-group", "export_time": "2020-10-13T12:00:20-05:00", "export_url": "https://example.org/fhir/$export", "etl_version": "1.0.0+test", "etl_time": "2021-09-14T21:23:45+00:00"}
+{"table_name": "device", "group_name": "test-group", "export_time": "2020-10-13T12:00:20-05:00", "export_url": "https://example.org/fhir/$export", "etl_version": "1.0.0+test", "etl_time": "2021-09-14T21:23:45+00:00", "excluded_resources": ""}

--- a/tests/data/simple/output/etl__completion/etl__completion.005.ndjson
+++ b/tests/data/simple/output/etl__completion/etl__completion.005.ndjson
@@ -1,1 +1,1 @@
-{"table_name": "diagnosticreport", "group_name": "test-group", "export_time": "2020-10-13T12:00:20-05:00", "export_url": "https://example.org/fhir/$export", "etl_version": "1.0.0+test", "etl_time": "2021-09-14T21:23:45+00:00"}
+{"table_name": "diagnosticreport", "group_name": "test-group", "export_time": "2020-10-13T12:00:20-05:00", "export_url": "https://example.org/fhir/$export", "etl_version": "1.0.0+test", "etl_time": "2021-09-14T21:23:45+00:00", "excluded_resources": ""}

--- a/tests/data/simple/output/etl__completion/etl__completion.006.ndjson
+++ b/tests/data/simple/output/etl__completion/etl__completion.006.ndjson
@@ -1,1 +1,1 @@
-{"table_name": "documentreference", "group_name": "test-group", "export_time": "2020-10-13T12:00:20-05:00", "export_url": "https://example.org/fhir/$export", "etl_version": "1.0.0+test", "etl_time": "2021-09-14T21:23:45+00:00"}
+{"table_name": "documentreference", "group_name": "test-group", "export_time": "2020-10-13T12:00:20-05:00", "export_url": "https://example.org/fhir/$export", "etl_version": "1.0.0+test", "etl_time": "2021-09-14T21:23:45+00:00", "excluded_resources": ""}

--- a/tests/data/simple/output/etl__completion/etl__completion.007.ndjson
+++ b/tests/data/simple/output/etl__completion/etl__completion.007.ndjson
@@ -1,1 +1,1 @@
-{"table_name": "episodeofcare", "group_name": "test-group", "export_time": "2020-10-13T12:00:20-05:00", "export_url": "https://example.org/fhir/$export", "etl_version": "1.0.0+test", "etl_time": "2021-09-14T21:23:45+00:00"}
+{"table_name": "episodeofcare", "group_name": "test-group", "export_time": "2020-10-13T12:00:20-05:00", "export_url": "https://example.org/fhir/$export", "etl_version": "1.0.0+test", "etl_time": "2021-09-14T21:23:45+00:00", "excluded_resources": ""}

--- a/tests/data/simple/output/etl__completion/etl__completion.008.ndjson
+++ b/tests/data/simple/output/etl__completion/etl__completion.008.ndjson
@@ -1,1 +1,1 @@
-{"table_name": "immunization", "group_name": "test-group", "export_time": "2020-10-13T12:00:20-05:00", "export_url": "https://example.org/fhir/$export", "etl_version": "1.0.0+test", "etl_time": "2021-09-14T21:23:45+00:00"}
+{"table_name": "immunization", "group_name": "test-group", "export_time": "2020-10-13T12:00:20-05:00", "export_url": "https://example.org/fhir/$export", "etl_version": "1.0.0+test", "etl_time": "2021-09-14T21:23:45+00:00", "excluded_resources": ""}

--- a/tests/data/simple/output/etl__completion/etl__completion.009.ndjson
+++ b/tests/data/simple/output/etl__completion/etl__completion.009.ndjson
@@ -1,1 +1,1 @@
-{"table_name": "location", "group_name": "test-group", "export_time": "2020-10-13T12:00:20-05:00", "export_url": "https://example.org/fhir/$export", "etl_version": "1.0.0+test", "etl_time": "2021-09-14T21:23:45+00:00"}
+{"table_name": "location", "group_name": "test-group", "export_time": "2020-10-13T12:00:20-05:00", "export_url": "https://example.org/fhir/$export", "etl_version": "1.0.0+test", "etl_time": "2021-09-14T21:23:45+00:00", "excluded_resources": ""}

--- a/tests/data/simple/output/etl__completion/etl__completion.010.ndjson
+++ b/tests/data/simple/output/etl__completion/etl__completion.010.ndjson
@@ -1,1 +1,1 @@
-{"table_name": "medication", "group_name": "test-group", "export_time": "2020-10-13T12:00:20-05:00", "export_url": "https://example.org/fhir/$export", "etl_version": "1.0.0+test", "etl_time": "2021-09-14T21:23:45+00:00"}
+{"table_name": "medication", "group_name": "test-group", "export_time": "2020-10-13T12:00:20-05:00", "export_url": "https://example.org/fhir/$export", "etl_version": "1.0.0+test", "etl_time": "2021-09-14T21:23:45+00:00", "excluded_resources": ""}

--- a/tests/data/simple/output/etl__completion/etl__completion.011.ndjson
+++ b/tests/data/simple/output/etl__completion/etl__completion.011.ndjson
@@ -1,1 +1,1 @@
-{"table_name": "medicationdispense", "group_name": "test-group", "export_time": "2020-10-13T12:00:20-05:00", "export_url": "https://example.org/fhir/$export", "etl_version": "1.0.0+test", "etl_time": "2021-09-14T21:23:45+00:00"}
+{"table_name": "medicationdispense", "group_name": "test-group", "export_time": "2020-10-13T12:00:20-05:00", "export_url": "https://example.org/fhir/$export", "etl_version": "1.0.0+test", "etl_time": "2021-09-14T21:23:45+00:00", "excluded_resources": ""}

--- a/tests/data/simple/output/etl__completion/etl__completion.012.ndjson
+++ b/tests/data/simple/output/etl__completion/etl__completion.012.ndjson
@@ -1,1 +1,1 @@
-{"table_name": "medicationrequest", "group_name": "test-group", "export_time": "2020-10-13T12:00:20-05:00", "export_url": "https://example.org/fhir/$export", "etl_version": "1.0.0+test", "etl_time": "2021-09-14T21:23:45+00:00"}
+{"table_name": "medicationrequest", "group_name": "test-group", "export_time": "2020-10-13T12:00:20-05:00", "export_url": "https://example.org/fhir/$export", "etl_version": "1.0.0+test", "etl_time": "2021-09-14T21:23:45+00:00", "excluded_resources": ""}

--- a/tests/data/simple/output/etl__completion/etl__completion.013.ndjson
+++ b/tests/data/simple/output/etl__completion/etl__completion.013.ndjson
@@ -1,1 +1,1 @@
-{"table_name": "observation", "group_name": "test-group", "export_time": "2020-10-13T12:00:20-05:00", "export_url": "https://example.org/fhir/$export", "etl_version": "1.0.0+test", "etl_time": "2021-09-14T21:23:45+00:00"}
+{"table_name": "observation", "group_name": "test-group", "export_time": "2020-10-13T12:00:20-05:00", "export_url": "https://example.org/fhir/$export", "etl_version": "1.0.0+test", "etl_time": "2021-09-14T21:23:45+00:00", "excluded_resources": ""}

--- a/tests/data/simple/output/etl__completion/etl__completion.014.ndjson
+++ b/tests/data/simple/output/etl__completion/etl__completion.014.ndjson
@@ -1,1 +1,1 @@
-{"table_name": "organization", "group_name": "test-group", "export_time": "2020-10-13T12:00:20-05:00", "export_url": "https://example.org/fhir/$export", "etl_version": "1.0.0+test", "etl_time": "2021-09-14T21:23:45+00:00"}
+{"table_name": "organization", "group_name": "test-group", "export_time": "2020-10-13T12:00:20-05:00", "export_url": "https://example.org/fhir/$export", "etl_version": "1.0.0+test", "etl_time": "2021-09-14T21:23:45+00:00", "excluded_resources": ""}

--- a/tests/data/simple/output/etl__completion/etl__completion.015.ndjson
+++ b/tests/data/simple/output/etl__completion/etl__completion.015.ndjson
@@ -1,1 +1,1 @@
-{"table_name": "practitioner", "group_name": "test-group", "export_time": "2020-10-13T12:00:20-05:00", "export_url": "https://example.org/fhir/$export", "etl_version": "1.0.0+test", "etl_time": "2021-09-14T21:23:45+00:00"}
+{"table_name": "practitioner", "group_name": "test-group", "export_time": "2020-10-13T12:00:20-05:00", "export_url": "https://example.org/fhir/$export", "etl_version": "1.0.0+test", "etl_time": "2021-09-14T21:23:45+00:00", "excluded_resources": ""}

--- a/tests/data/simple/output/etl__completion/etl__completion.016.ndjson
+++ b/tests/data/simple/output/etl__completion/etl__completion.016.ndjson
@@ -1,1 +1,1 @@
-{"table_name": "practitionerrole", "group_name": "test-group", "export_time": "2020-10-13T12:00:20-05:00", "export_url": "https://example.org/fhir/$export", "etl_version": "1.0.0+test", "etl_time": "2021-09-14T21:23:45+00:00"}
+{"table_name": "practitionerrole", "group_name": "test-group", "export_time": "2020-10-13T12:00:20-05:00", "export_url": "https://example.org/fhir/$export", "etl_version": "1.0.0+test", "etl_time": "2021-09-14T21:23:45+00:00", "excluded_resources": ""}

--- a/tests/data/simple/output/etl__completion/etl__completion.017.ndjson
+++ b/tests/data/simple/output/etl__completion/etl__completion.017.ndjson
@@ -1,1 +1,1 @@
-{"table_name": "procedure", "group_name": "test-group", "export_time": "2020-10-13T12:00:20-05:00", "export_url": "https://example.org/fhir/$export", "etl_version": "1.0.0+test", "etl_time": "2021-09-14T21:23:45+00:00"}
+{"table_name": "procedure", "group_name": "test-group", "export_time": "2020-10-13T12:00:20-05:00", "export_url": "https://example.org/fhir/$export", "etl_version": "1.0.0+test", "etl_time": "2021-09-14T21:23:45+00:00", "excluded_resources": ""}

--- a/tests/data/simple/output/etl__completion/etl__completion.018.ndjson
+++ b/tests/data/simple/output/etl__completion/etl__completion.018.ndjson
@@ -1,1 +1,1 @@
-{"table_name": "servicerequest", "group_name": "test-group", "export_time": "2020-10-13T12:00:20-05:00", "export_url": "https://example.org/fhir/$export", "etl_version": "1.0.0+test", "etl_time": "2021-09-14T21:23:45+00:00"}
+{"table_name": "servicerequest", "group_name": "test-group", "export_time": "2020-10-13T12:00:20-05:00", "export_url": "https://example.org/fhir/$export", "etl_version": "1.0.0+test", "etl_time": "2021-09-14T21:23:45+00:00", "excluded_resources": ""}

--- a/tests/data/simple/output/etl__completion/etl__completion.019.ndjson
+++ b/tests/data/simple/output/etl__completion/etl__completion.019.ndjson
@@ -1,1 +1,1 @@
-{"table_name": "specimen", "group_name": "test-group", "export_time": "2020-10-13T12:00:20-05:00", "export_url": "https://example.org/fhir/$export", "etl_version": "1.0.0+test", "etl_time": "2021-09-14T21:23:45+00:00"}
+{"table_name": "specimen", "group_name": "test-group", "export_time": "2020-10-13T12:00:20-05:00", "export_url": "https://example.org/fhir/$export", "etl_version": "1.0.0+test", "etl_time": "2021-09-14T21:23:45+00:00", "excluded_resources": ""}

--- a/tests/data/simple/output/etl__completion_encounters/etl__completion_encounters.000.ndjson
+++ b/tests/data/simple/output/etl__completion_encounters/etl__completion_encounters.000.ndjson
@@ -1,2 +1,2 @@
-{"encounter_id": "08f0ebd4-950c-ddd9-ce97-b5bdf073eed1", "export_time": "2020-10-13T12:00:20-05:00", "group_name": "test-group"}
-{"encounter_id": "af1e6186-3f9a-1fa9-3c73-cfa56c84a056", "export_time": "2020-10-13T12:00:20-05:00", "group_name": "test-group"}
+{"encounter_id": "08f0ebd4-950c-ddd9-ce97-b5bdf073eed1", "export_time": "2020-10-13T12:00:20-05:00", "group_name": "test-group", "excluded_resources": ""}
+{"encounter_id": "af1e6186-3f9a-1fa9-3c73-cfa56c84a056", "export_time": "2020-10-13T12:00:20-05:00", "group_name": "test-group", "excluded_resources": ""}

--- a/tests/etl/base.py
+++ b/tests/etl/base.py
@@ -57,6 +57,7 @@ class BaseEtlSimple(ctakesmock.CtakesMixin, utils.TreeCompareMixin, utils.AsyncT
         export_timestamp: str = "2020-10-13T12:00:20-05:00",
         skip_init_checks: bool = True,
         nlp: bool | None = None,
+        exclusions: str | None = None,
     ) -> None:
         if nlp is None:
             nlp = tasks and any("__" in task for task in tasks)
@@ -88,6 +89,9 @@ class BaseEtlSimple(ctakesmock.CtakesMixin, utils.TreeCompareMixin, utils.AsyncT
             args.append("--philter")
         if errors_to:
             args.append(f"--errors-to={errors_to}")
+        if exclusions:
+            args.append(f"--exclude-resources={','.join(exclusions)}")
+
         await cli.main(args)
 
     def enforce_consistent_uuids(self):

--- a/tests/etl/test_etl_cli.py
+++ b/tests/etl/test_etl_cli.py
@@ -117,7 +117,7 @@ class TestEtlJobFlow(BaseEtlSimple):
     async def test_excluded_tasks(self):
         # Grab all observations before we mock anything
         loaded = loaders.FhirNdjsonLoader(cfs.FsPath(self.input_path)).load_resources(
-            {"Encounter","Observation", "Patient"}, progress=feedback.Progress()
+            {"Encounter", "Observation", "Patient"}, progress=feedback.Progress()
         )
 
         def fake_load_resources(internal_self, resources, progress):
@@ -128,24 +128,32 @@ class TestEtlJobFlow(BaseEtlSimple):
 
         with mock.patch.object(loaders.FhirNdjsonLoader, "load_resources", new=fake_load_resources):
             await self.run_etl(
-                tasks=["encounter","observation", "patient", "condition"], 
-                exclusions=["patient", "condition"]
+                tasks=["encounter", "observation", "patient", "condition"],
+                exclusions=["patient", "condition"],
             )
 
         # Confirm we didn't write patients
         self.assertEqual(
-            {"etl__completion", "etl__completion_encounters", "observation", "encounter", "JobConfig"},
+            {
+                "etl__completion",
+                "etl__completion_encounters",
+                "observation",
+                "encounter",
+                "JobConfig",
+            },
             set(os.listdir(self.output_path)),
         )
         self.assertEqual(
             ["observation.000.ndjson"], os.listdir(os.path.join(self.output_path, "observation"))
         )
         with open(f"{self.output_path}/etl__completion/etl__completion.000.ndjson") as f:
-            output= json.loads(f.read())
-            assert output["excluded_resources"] == 'patient,condition'
-        with open(f"{self.output_path}/etl__completion_encounters/etl__completion_encounters.000.ndjson") as f:
-            output= json.loads(f.readline())
-            assert output["excluded_resources"] == 'patient,condition'
+            output = json.loads(f.read())
+            assert output["excluded_resources"] == "patient,condition"
+        with open(
+            f"{self.output_path}/etl__completion_encounters/etl__completion_encounters.000.ndjson"
+        ) as f:
+            output = json.loads(f.readline())
+            assert output["excluded_resources"] == "patient,condition"
 
     async def test_cannot_mix_nlp_and_fhir_tasks(self):
         with self.assertRaises(SystemExit) as cm:
@@ -423,6 +431,7 @@ class TestEtlJobConfig(BaseEtlSimple):
                 "export_group_name": "test-group",
                 "export_timestamp": "2020-10-13T12:00:20-05:00",
                 "export_url": "https://example.org/fhir/$export",
+                "exclusions": "",
             },
             config_file,
         )

--- a/tests/etl/test_etl_cli.py
+++ b/tests/etl/test_etl_cli.py
@@ -114,6 +114,40 @@ class TestEtlJobFlow(BaseEtlSimple):
             ["patient.000.ndjson"], os.listdir(os.path.join(self.output_path, "patient"))
         )
 
+    async def test_excluded_tasks(self):
+        # Grab all observations before we mock anything
+        loaded = loaders.FhirNdjsonLoader(cfs.FsPath(self.input_path)).load_resources(
+            {"Encounter","Observation", "Patient"}, progress=feedback.Progress()
+        )
+
+        def fake_load_resources(internal_self, resources, progress):
+            del internal_self
+            # Confirm we did not try to load patients
+            self.assertEqual({"Observation", "Encounter"}, resources)
+            return loaded
+
+        with mock.patch.object(loaders.FhirNdjsonLoader, "load_resources", new=fake_load_resources):
+            await self.run_etl(
+                tasks=["encounter","observation", "patient", "condition"], 
+                exclusions=["patient", "condition"]
+            )
+
+        # Confirm we didn't write patients
+        self.assertEqual(
+            {"etl__completion", "etl__completion_encounters", "observation", "encounter", "JobConfig"},
+            set(os.listdir(self.output_path)),
+        )
+        self.assertEqual(
+            ["observation.000.ndjson"], os.listdir(os.path.join(self.output_path, "observation"))
+        )
+        with open(f"{self.output_path}/etl__completion/etl__completion.000.ndjson") as f:
+            output= json.loads(f.read())
+            assert output["excluded_resources"] == 'patient,condition'
+        with open(f"{self.output_path}/etl__completion_encounters/etl__completion_encounters.000.ndjson") as f:
+            output= json.loads(f.readline())
+            print(output)
+            assert output["excluded_resources"] == 'patient,condition'
+
     async def test_cannot_mix_nlp_and_fhir_tasks(self):
         with self.assertRaises(SystemExit) as cm:
             await self.run_etl(tasks=["covid_symptom__nlp_results", "patient"])

--- a/tests/etl/test_etl_cli.py
+++ b/tests/etl/test_etl_cli.py
@@ -50,6 +50,11 @@ class TestEtlJobFlow(BaseEtlSimple):
             await self.run_etl(tasks=["blarg"])
         self.assertEqual(errors.TASK_UNKNOWN, cm.exception.code)
 
+    async def test_unknown_exclusion(self):
+        with self.assertRaises(SystemExit) as cm:
+            await self.run_etl(exclusions=["blarg"])
+        self.assertEqual(errors.TASK_UNKNOWN, cm.exception.code)
+
     async def test_help_task(self):
         with self.assertRaises(SystemExit) as cm:
             await self.run_etl(tasks=["patient", "help"])

--- a/tests/etl/test_etl_cli.py
+++ b/tests/etl/test_etl_cli.py
@@ -145,7 +145,6 @@ class TestEtlJobFlow(BaseEtlSimple):
             assert output["excluded_resources"] == 'patient,condition'
         with open(f"{self.output_path}/etl__completion_encounters/etl__completion_encounters.000.ndjson") as f:
             output= json.loads(f.readline())
-            print(output)
             assert output["excluded_resources"] == 'patient,condition'
 
     async def test_cannot_mix_nlp_and_fhir_tasks(self):

--- a/tests/etl/test_tasks.py
+++ b/tests/etl/test_tasks.py
@@ -237,11 +237,13 @@ class TestTaskCompletion(TaskTestCase):
                     "encounter_id": self.codebook.db.encounter("FirstBatch.A"),
                     "group_name": "test-group",
                     "export_time": "2012-10-10T05:30:12+00:00",
+                    "excluded_resources": None,
                 },
                 {
                     "encounter_id": self.codebook.db.encounter("FirstBatch.B"),
                     "group_name": "test-group",
                     "export_time": "2012-10-10T05:30:12+00:00",
+                    "excluded_resources": None,
                 },
             ],
             comp_enc_batches[0].rows,
@@ -252,6 +254,7 @@ class TestTaskCompletion(TaskTestCase):
                     "encounter_id": self.codebook.db.encounter("SecondBatch.C"),
                     "group_name": "test-group",
                     "export_time": "2012-10-10T05:30:12+00:00",
+                    "excluded_resources": None,
                 }
             ],
             comp_enc_batches[1].rows,
@@ -267,6 +270,7 @@ class TestTaskCompletion(TaskTestCase):
                     "export_url": self.export_url,
                     "etl_version": "1.0.0+test",
                     "etl_time": "2021-09-14T21:23:45+00:00",
+                    "excluded_resources": None,
                 }
             ],
             comp_batch.rows,
@@ -299,6 +303,7 @@ class TestTaskCompletion(TaskTestCase):
                     "export_url": self.export_url,
                     "etl_version": "1.0.0+test",
                     "etl_time": "2021-09-14T21:23:45+00:00",
+                    "excluded_resources": None,
                 },
             ],
             comp_batch.rows,
@@ -323,6 +328,7 @@ class TestTaskCompletion(TaskTestCase):
                     "export_url": self.export_url,
                     "etl_version": "1.0.0+test",
                     "etl_time": "2021-09-14T21:23:45+00:00",
+                    "excluded_resources": None,
                 }
             ],
             comp_format.write_records.call_args[0][0].rows,

--- a/tests/nlp/test_models.py
+++ b/tests/nlp/test_models.py
@@ -306,7 +306,6 @@ class TestWithSpansNLPTasks(NlpModelTestCase):
         self.assertEqual(self.format.write_records.call_count, 1)
         batch = self.format.write_records.call_args[0][0]
         self.assertEqual(len(batch.rows), 1)
-        print(batch.rows)
         # First match as expected
         self.assertEqual(
             batch.rows[0]["result"]["immunosuppressive_medication_mentions"][0]["spans"], [(0, 4)]


### PR DESCRIPTION
This supplements `--allow-missing-resources` with a new cli arg, `--exclude-resources`, which allows you to state explicitly that resources should not be present.

It also adds some light fixes for some linux specific behavior, and adjusts one error message to reflect a new arg name.


### Checklist
- [X] Consider if documentation (like in `docs/`) needs to be updated
- [X] Consider if tests should be added
