### PR TITLE
Cutover CI to `uv`

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -40,15 +40,18 @@ jobs:
 
       - name: Install dependencies
         run: |
-          python -m pip install --upgrade pip
-          pip install .[tests]
+          python -m pip install uv
+          uv venv
+          uv pip install .[tests]
 
       - name: Test with pytest
         run: |
+          source .venv/bin/activate
           python -m pytest --cov=cumulus_etl --cov-report=xml
 
       - name: Log missing coverage
         run: |
+          source .venv/bin/activate
           coverage report -m --skip-covered
 
       - name: Check coverage report
@@ -121,11 +124,14 @@ jobs:
 
       - name: Install linters
         run: |
-          python -m pip install --upgrade pip
-          pip install .[dev]
+          python -m pip install --upgrade uv
+          uv venv
+          uv pip install .[dev]
 
       - name: Run ruff
-        run: ruff check --output-format=github .
+        run: |
+          source .venv/bin/activate
+          ruff check --output-format=github .
 
   bdf-validation:
     name: BDF validation

--- a/.github/workflows/pypi.yaml
+++ b/.github/workflows/pypi.yaml
@@ -20,8 +20,9 @@ jobs:
 
     - name: Install dependencies
       run: |
-        python -m pip install --upgrade pip
-        pip install build
+        python -m pip install uv
+        uv venv
+        uv pip install build
 
     - name: Set version from tag
       run: |
@@ -30,7 +31,9 @@ jobs:
         [ -s changes.txt ] || exit 1  # validate that we successfully set the version
 
     - name: Build
-      run: python -m build
+      run: |
+        source .venv/bin/activate
+        python -m build
 
     - name: Publish
       uses: pypa/gh-action-pypi-publish@release/v1

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,8 +3,10 @@
 FROM python:3.11 AS cumulus-etl-test
 COPY --from=eclipse-temurin:21-jre /opt/java/openjdk /opt/java/openjdk
 COPY . /app
+RUN pip3 install uv
+RUN uv venv
 RUN --mount=type=cache,target=/root/.cache \
-  pip3 install /app/[tests]
+  uv install /app/[tests]
 RUN rm -r /app
 
 ENV JAVA_HOME=/opt/java/openjdk
@@ -15,8 +17,10 @@ FROM python:3.11 AS cumulus-etl
 COPY --from=eclipse-temurin:21-jre /opt/java/openjdk /opt/java/openjdk
 
 # Ship pre-downloaded nltk files, used by philter
-RUN pip3 install nltk
-RUN python3 -m nltk.downloader -d /usr/local/share/nltk_data averaged_perceptron_tagger
+RUN pip3 install uv
+RUN uv venv
+RUN uv pip install nltk
+RUN uv run python3 -m nltk.downloader -d /usr/local/share/nltk_data averaged_perceptron_tagger
 
 COPY . /app
 
@@ -26,9 +30,9 @@ RUN [ -z "$ETL_VERSION" ] || sed -i "s/1\!0\.0\.0/$ETL_VERSION/" /app/cumulus_et
 RUN grep __version__ /app/cumulus_etl/__init__.py
 
 RUN --mount=type=cache,target=/root/.cache \
-  pip3 install /app
+  uv pip install /app
 RUN rm -r /app
 
 ENV JAVA_HOME=/opt/java/openjdk
 
-ENTRYPOINT ["cumulus-etl"]
+ENTRYPOINT ["uv", "run", "cumulus-etl"]


### PR DESCRIPTION
For speed reasons, and to workaround aioboto version churn, we'll use `uv` for package installation in ci jobs.


### Checklist
- [X] Consider if documentation (like in `docs/`) needs to be updated
- [X] Consider if tests should be added
