### PR TITLE
Adds support for Datetime fields as accepted LS input fields

### DIFF
--- a/cumulus_etl/upload_notes/labelstudio.py
+++ b/cumulus_etl/upload_notes/labelstudio.py
@@ -217,8 +217,6 @@ class LabelStudioClient:
                 field = "choices"
             case "datetime":
                 field = "datetime"
-                # Handle Datetime field layout differently
-                match["value"][field] = list(labels)
             case "textarea":
                 field = "text"
             case _:
@@ -228,7 +226,9 @@ class LabelStudioClient:
                 )
 
         # Unless a config tag has special formatting, use the same formatting everywhere
-        if not match["value"][field]:
+        if field == "datetime":
+            match["value"][field] = labels
+        else:
             match["value"][field] = list(labels)
         return match
 

--- a/cumulus_etl/upload_notes/labelstudio.py
+++ b/cumulus_etl/upload_notes/labelstudio.py
@@ -215,6 +215,10 @@ class LabelStudioClient:
                 field = "labels"
             case "choices":
                 field = "choices"
+            case "datetime":
+                field = "datetime"
+                # Handle Datetime field layout differently
+                match["value"][field] = list(labels)
             case "textarea":
                 field = "text"
             case _:
@@ -223,7 +227,9 @@ class LabelStudioClient:
                     errors.LABEL_CONFIG_TYPE_UNKNOWN,
                 )
 
-        match["value"][field] = list(labels)
+        # Unless a config tag has special formatting, use the same formatting everywhere
+        if not match["value"][field]:
+            match["value"][field] = list(labels)
         return match
 
     def _format_highlights_predictions(

--- a/tests/upload_notes/test_upload_labelstudio.py
+++ b/tests/upload_notes/test_upload_labelstudio.py
@@ -430,6 +430,74 @@ class TestUploadLabelStudio(AsyncTestCase):
             self.get_pushed_task(),
         )
 
+    async def test_push_datetime_highlight(self):
+        """Verify we format a DateTime sublabel config tag correctly"""
+        self.mock_config("""
+        <View>
+            <Labels name="mylabel" toName="mytext" value="$mylabel"/>
+            <Text name="mytext" value="$mytext"/>
+            <DateTime name="Sub1" toName="mytext"/>,
+        </View>""")
+        note = self.make_note(philter_label=False)
+        note.highlights = [
+            Highlight(
+                "Label1", (7, 11), "Source", sublabel_name="Sub1", sublabel_value="2020-01-02"
+            ),
+        ]
+        await self.push_tasks(note)
+        self.assertEqual(
+            {
+                "data": {
+                    "text": "Normal note text",
+                    "unique_id": "unique",
+                    "patient_id": "patient",
+                    "anon_patient_id": "patient-anon",
+                    "encounter_id": "enc",
+                    "anon_encounter_id": "enc-anon",
+                    "date": None,
+                    "docref_mappings": {"doc": "doc-anon"},
+                    "docref_spans": {"doc": [0, 16]},
+                    "mylabel": [{"value": "Label1"}],
+                    "label1_sub1_label": "2020-01-02",
+                    "label1_sub1_text": "note",
+                },
+                "predictions": [
+                    {
+                        "model_version": "Source",
+                        "result": [
+                            {
+                                "id": "b3ab0236bd5959891ffe12da4d968b1d",
+                                "from_name": "mylabel",
+                                "to_name": "mytext",
+                                "type": "labels",
+                                "value": {
+                                    "end": 11,
+                                    "labels": ["Label1"],
+                                    "score": 1.0,
+                                    "start": 7,
+                                    "text": "note",
+                                },
+                            },
+                            {
+                                "id": "b3ab0236bd5959891ffe12da4d968b1d",
+                                "from_name": "Sub1",
+                                "to_name": "mytext",
+                                "type": "datetime",
+                                "value": {
+                                    "datetime": ["2020-01-02"],
+                                    "end": 11,
+                                    "score": 1.0,
+                                    "start": 7,
+                                    "text": "note",
+                                },
+                            },
+                        ],
+                    },
+                ],
+            },
+            self.get_pushed_task(),
+        )
+
     async def test_unrecognized_label_name(self):
         note = self.make_note(philter_label=False)
         note.highlights = [


### PR DESCRIPTION
We need support for this field to support some of the new annotations workflows we've been targeting.

### Checklist
- [x] Consider if documentation (like in `docs/`) needs to be updated
- [x] Consider if tests should be added
