### PR TITLE
`upload-notes` now exposes arguments to limit uploads by chart count

### DIFF
--- a/cumulus_etl/etl/cli.py
+++ b/cumulus_etl/etl/cli.py
@@ -131,7 +131,7 @@ async def etl_main(args: argparse.Namespace) -> None:
         deleted_ids=loader_results.deleted_ids,
         export_group_name=export_group,
         export_datetime=export_datetime,
-        exclusions=','.join(args.exclusions),
+        exclusions=",".join(args.exclusions),
         format_kwargs={"optimize_table": args.table_optimization},
     )
     config.path_config().write_json(config.as_json(), indent=4)

--- a/cumulus_etl/etl/config.py
+++ b/cumulus_etl/etl/config.py
@@ -96,7 +96,7 @@ class JobConfig:
             "export_timestamp": self.export_datetime and self.export_datetime.isoformat(),
             "export_url": self.export_url,
             "codebook_id": self.codebook_id,
-            "exclusions": self.exclusions
+            "exclusions": self.exclusions,
         }
 
 

--- a/cumulus_etl/etl/pipeline.py
+++ b/cumulus_etl/etl/pipeline.py
@@ -67,9 +67,9 @@ def add_common_etl_args(
         dest="exclusions",
         action="append",
         help="Resource type(s) to be excluded from completion tracking (comma separated, "
-            "use '--task help' to see full list)",
-        default = [],
-        ),
+        "use '--task help' to see full list)",
+        default=[],
+    )
 
     cli_utils.add_auth(parser)
     cli_utils.add_debugging(parser)
@@ -108,7 +108,7 @@ def print_config(
         table.add_row("Errors path:", args.errors_to)
     table.add_row("Current time:", f"{common.timestamp_datetime(job_datetime)} UTC")
     table.add_row("Batch size:", f"{args.batch_size:,}")
-    table.add_row("Excluded resources:",", ".join(sorted(r for r in args.exclusions)))
+    table.add_row("Excluded resources:", ", ".join(sorted(r for r in args.exclusions)))
     table.add_row("Tasks:", ", ".join(sorted(t.name for t in all_tasks)))
     if "comment" in args and args.comment:
         table.add_row("Comment:", args.comment)

--- a/cumulus_etl/etl/tasks/base.py
+++ b/cumulus_etl/etl/tasks/base.py
@@ -266,7 +266,7 @@ class EtlTask:
                     "export_url": self.task_config.export_url,
                     "etl_version": cumulus_etl.__version__,
                     "etl_time": self.task_config.timestamp.isoformat(),
-                    "excluded_resources": self.task_config.exclusions
+                    "excluded_resources": self.task_config.exclusions,
                 }
                 for output in self.outputs
                 if not output.get_name(self).startswith("etl__")

--- a/cumulus_etl/upload_notes/cli.py
+++ b/cumulus_etl/upload_notes/cli.py
@@ -3,13 +3,14 @@
 import argparse
 import dataclasses
 import datetime
+import random
 from collections.abc import Callable, Collection
 
 import cumulus_fhir_support as cfs
 import rich
 
 from cumulus_etl import cli_utils, common, deid, errors, fhir, nlp
-from cumulus_etl.upload_notes import labeling, selector
+from cumulus_etl.upload_notes import labeling, manifest, selector
 from cumulus_etl.upload_notes.labelstudio import LabelStudioClient, LabelStudioNote
 
 PHILTER_DISABLE = "disable"
@@ -261,6 +262,20 @@ def group_notes_by_unique_id(notes: Collection[LabelStudioNote]) -> list[LabelSt
     return grouped_notes
 
 
+def sample_notes(
+    aggregated_notes: list[LabelStudioNote], args: argparse.Namespace
+) -> list[LabelStudioNote]:
+    """
+    Randomly down-sample chart-aggregated notes to at most args.count.
+
+    The cap counts final Label Studio charts, i.e. it is applied after grouping (with the default
+    encounter grouping, one chart may contain several notes).
+    """
+    if not args.count or len(aggregated_notes) <= args.count:
+        return aggregated_notes
+    return random.Random(args.seed).sample(aggregated_notes, args.count)  # noqa: S311
+
+
 async def push_to_label_studio(
     notes: Collection[LabelStudioNote], access_token: str, args: argparse.Namespace
 ) -> None:
@@ -310,6 +325,20 @@ def define_upload_notes_parser(parser: argparse.ArgumentParser) -> None:
         choices=["encounter", "none"],
         default="encounter",
         help="how to group together notes into one Label Studio task (default is encounter)",
+    )
+
+    group = parser.add_argument_group("sampling")
+    group.add_argument(
+        "--count",
+        type=int,
+        metavar="N",
+        help="upload at most this many charts (randomly sampled if more are selected; "
+        "a chart is a group of notes, or a single note with --grouping=none)",
+    )
+    group.add_argument(
+        "--seed",
+        type=int,
+        help="random number generator seed, for consistent --count results",
     )
 
     cli_utils.add_aws(parser, athena=True)
@@ -400,6 +429,18 @@ async def upload_notes_main(args: argparse.Namespace) -> None:
     # Read token file early for quick error feedback
     access_token = args.ls_token.read_text().strip()
 
+    # Check that --count is positive, and warn if --export-to is not set (so no manifest will be saved)
+    if args.count is not None:
+        if args.count <= 0:
+            errors.fatal(
+                f"Count must be a positive number, not '{args.count}'.", errors.ARGS_INVALID
+            )
+        if not args.export_to:
+            rich.print(
+                "Warning: --export-to is not set, so no uploaded_notes.csv manifest will be saved."
+                "To see which charts were uploaded you'll have to confirm with Label Studio."
+            )
+
     match args.grouping:
         case "encounter":
             get_unique_id = _get_unique_id_for_encounter_grouping
@@ -423,8 +464,13 @@ async def upload_notes_main(args: argparse.Namespace) -> None:
     # It's safe to philter notes after labeling because philter does not change character counts
     philter_notes(notes, args)
     notes = sort_notes(notes)
-    notes = group_notes_by_unique_id(notes)
-    await push_to_label_studio(notes, access_token, args)
+    # Group notes by unique ID (encounter or none, depending on args.grouping)
+    aggregated_notes = group_notes_by_unique_id(notes)
+    # Cap the number of uploaded charts (applied after grouping, so --count counts final charts).
+    aggregated_notes = sample_notes(aggregated_notes, args)
+    # Record which notes we're about to upload (before push, since push may skip existing tasks).
+    manifest.write_upload_manifest(aggregated_notes, args.export_to)
+    await push_to_label_studio(aggregated_notes, access_token, args)
 
 
 async def run_upload_notes(parser: argparse.ArgumentParser, argv: list[str]) -> None:

--- a/cumulus_etl/upload_notes/manifest.py
+++ b/cumulus_etl/upload_notes/manifest.py
@@ -1,0 +1,52 @@
+"""Writing a manifest of which notes were uploaded to Label Studio"""
+
+import csv
+from collections.abc import Collection
+
+import cumulus_fhir_support as cfs
+
+from cumulus_etl.upload_notes.labelstudio import LabelStudioNote
+
+MANIFEST_FILENAME = "uploaded_notes.csv"
+
+# Columns written to the manifest. `note_ref` matches what --select-by-csv expects, so the
+# manifest can be fed straight back in as a selection input.
+MANIFEST_COLUMNS = [
+    "note_ref",
+    "anon_note_ref",
+    "patient_id",
+    "anon_patient_id",
+    "encounter_id",
+    "anon_encounter_id",
+    "unique_id",
+]
+
+
+def write_upload_manifest(notes: Collection[LabelStudioNote], export_to: cfs.FsPath | None) -> None:
+    """
+    Writes a CSV recording which real notes were uploaded, into the export folder.
+
+    One row per real note (a grouped chart can contain several). Only written when the user asked
+    to keep the exported documents via --export-to; otherwise the export folder is a temp dir that
+    gets deleted after use.
+    """
+    if not export_to:
+        return
+
+    manifest_path = export_to.joinpath(MANIFEST_FILENAME)
+    with manifest_path.open("w", newline="") as f:
+        writer = csv.writer(f)
+        writer.writerow(MANIFEST_COLUMNS)
+        for note in notes:
+            for note_ref, anon_note_ref in note.doc_mappings.items():
+                writer.writerow(
+                    [
+                        note_ref,
+                        anon_note_ref,
+                        note.patient_id,
+                        note.anon_patient_id,
+                        note.encounter_id or "",
+                        note.anon_encounter_id or "",
+                        note.unique_id,
+                    ]
+                )

--- a/docs/chart-review.md
+++ b/docs/chart-review.md
@@ -75,6 +75,24 @@ to make it easier to reference back to your EHR or Athena data.
 If grouping by encounter doesn't make sense for your task,
 you can turn it off with `--grouping=none`.
 
+### Capping the Number of Charts
+
+Sometimes you have more charts selected than you actually want to review
+(for example, you oversampled for an earlier NLP stage but only want a fixed number for
+an inter-rater agreement study).
+
+Pass `--count=N` to upload at most `N` charts.
+If more than `N` charts are available, a random sample of `N` is uploaded.
+The count is applied *after* grouping, so it counts the final Label Studio charts — with the
+default encounter grouping, one chart may contain several notes. (Use `--grouping=none` if you
+want the count to apply to individual notes.)
+
+Add `--seed=NUMBER` for a reproducible sample.
+
+If you'd rather sample separately, the standalone `sample` command can produce a `.csv` that you
+feed back in with `--select-by-csv`. (Note that `sample` selects individual notes, whereas
+`--count` here selects grouped charts.)
+
 ## Downloading Notes
 
 Ideally your notes are already downloaded and inlined into your DiagnosticReport or
@@ -134,6 +152,11 @@ just confirming the correct documents were chosen.
 Pass in an argument like `--export-to /host/export` to save the NDJSON for the selected documents
 in the given folder. (Note this does not save the clinical note text unless it is already inline
 -- this is just saving the DocumentReference resources).
+
+When you use `--export-to`, upload mode also writes an `uploaded_notes.csv` manifest into that
+folder, recording exactly which notes were uploaded (both real and anonymized note IDs, plus
+patient and encounter IDs). This is handy for auditing a capped upload, and the `note_ref` column
+can be fed straight back into a later run with `--select-by-csv`.
 
 ## Pre-Labeling Notes
 

--- a/tests/upload_notes/test_manifest.py
+++ b/tests/upload_notes/test_manifest.py
@@ -1,0 +1,72 @@
+"""Tests for upload_notes/manifest.py"""
+
+import cumulus_fhir_support as cfs
+
+from cumulus_etl import common
+from cumulus_etl.upload_notes import manifest
+from cumulus_etl.upload_notes.labelstudio import LabelStudioNote
+from tests.utils import AsyncTestCase
+
+
+class TestUploadManifest(AsyncTestCase):
+    """Tests for the uploaded-notes manifest writer."""
+
+    @staticmethod
+    def make_note(**kwargs) -> LabelStudioNote:
+        defaults = {
+            "unique_id": "Encounter/23",
+            "patient_id": "P1",
+            "anon_patient_id": "anonP1",
+            "encounter_id": "23",
+            "anon_encounter_id": "anon23",
+        }
+        defaults.update(kwargs)
+        return LabelStudioNote(**defaults)
+
+    def read_manifest(self, folder: str) -> list[dict]:
+        with common.read_csv(cfs.FsPath(f"{folder}/{manifest.MANIFEST_FILENAME}")) as reader:
+            return list(reader)
+
+    ##################
+    # Actual Tests
+    def test_writes_one_row_per_real_note(self):
+        """A grouped chart expands to one manifest row per contained note"""
+        tmpdir = self.make_tempdir()
+        note = self.make_note(
+            doc_mappings={
+                "DocumentReference/43": "DocumentReference/anon43",
+                "DiagnosticReport/us": "DiagnosticReport/anonus",
+            },
+        )
+
+        manifest.write_upload_manifest([note], cfs.FsPath(tmpdir))
+
+        rows = self.read_manifest(tmpdir)
+        self.assertEqual(manifest.MANIFEST_COLUMNS, list(rows[0].keys()))
+        self.assertEqual(
+            {"DocumentReference/43", "DiagnosticReport/us"}, {row["note_ref"] for row in rows}
+        )
+        row = next(r for r in rows if r["note_ref"] == "DocumentReference/43")
+        self.assertEqual("DocumentReference/anon43", row["anon_note_ref"])
+        self.assertEqual("P1", row["patient_id"])
+        self.assertEqual("Encounter/23", row["unique_id"])
+
+    def test_no_export_dir_is_a_noop(self):
+        """Without an export folder, nothing is written and no error is raised"""
+        # Should simply do nothing (the export folder is a temp dir deleted after use).
+        manifest.write_upload_manifest([self.make_note(doc_mappings={"a": "b"})], None)
+
+    def test_missing_encounter_is_blank(self):
+        """Notes without an encounter get empty encounter columns, not the string 'None'"""
+        tmpdir = self.make_tempdir()
+        note = self.make_note(
+            encounter_id=None,
+            anon_encounter_id=None,
+            doc_mappings={"DocumentReference/43": "DocumentReference/anon43"},
+        )
+
+        manifest.write_upload_manifest([note], cfs.FsPath(tmpdir))
+
+        rows = self.read_manifest(tmpdir)
+        self.assertEqual("", rows[0]["encounter_id"])
+        self.assertEqual("", rows[0]["anon_encounter_id"])

--- a/tests/upload_notes/test_upload_cli.py
+++ b/tests/upload_notes/test_upload_cli.py
@@ -401,6 +401,68 @@ class TestUploadNotes(AsyncTestCase):
         await self.run_upload_notes(overwrite=overwrite)
         self.assertEqual(overwrite, self.ls_client.push_tasks.call_args[1]["overwrite"])
 
+    def get_pushed_charts(self) -> list:
+        return self.ls_client.push_tasks.call_args[0][0]
+
+    ## Tests on --count and --seed, which limit how many charts get uploaded
+    async def test_count_caps_uploads(self):
+        """--count limits how many charts get uploaded"""
+        # Default encounter grouping turns the 4 notes into 2 charts.
+        await self.run_upload_notes("--count=1", "--seed=1")
+        self.assertEqual(1, len(self.get_pushed_charts()))
+
+    async def test_count_is_reproducible_with_seed(self):
+        """The same --count and --seed pick the same charts"""
+        await self.run_upload_notes("--count=1", "--seed=1")
+        first = self.get_pushed_refs()
+        # Second run needs a fresh export dir (make_export_dir requires an empty target)
+        await self.run_upload_notes("--count=1", "--seed=1", f"--export-to={self.make_tempdir()}")
+        self.assertEqual(first, self.get_pushed_refs())
+
+    async def test_count_larger_than_available(self):
+        """--count larger than the chart count uploads everything, without error"""
+        await self.run_upload_notes("--count=100", "--seed=1")
+        self.assertEqual(2, len(self.get_pushed_charts()))
+        self.assertEqual(4, len(self.get_pushed_refs()))
+
+    async def test_count_is_applied_after_grouping(self):
+        """--count counts final charts, not individual notes"""
+        # 4 notes group into 2 encounter charts, so --count=2 keeps both charts (all 4 notes) --
+        # proving the cap counts charts rather than notes.
+        await self.run_upload_notes("--count=2", "--seed=1")
+        self.assertEqual(2, len(self.get_pushed_charts()))
+        self.assertEqual(4, len(self.get_pushed_refs()))
+
+        # Without grouping, each note is its own chart, so --count=2 keeps only 2 notes.
+        await self.run_upload_notes(
+            "--count=2", "--seed=1", "--grouping=none", f"--export-to={self.make_tempdir()}"
+        )
+        self.assertEqual(2, len(self.get_pushed_charts()))
+        self.assertEqual(2, len(self.get_pushed_refs()))
+
+    @ddt.data("0", "-1")
+    async def test_bad_count(self, count):
+        """--count must be a positive number"""
+        with self.assertRaises(SystemExit) as cm:
+            await self.run_upload_notes(f"--count={count}")
+        self.assertEqual(errors.ARGS_INVALID, cm.exception.code)
+
+    async def test_manifest_written(self):
+        """A manifest of uploaded notes is written into the export folder"""
+        await self.run_upload_notes()
+
+        with common.read_csv(cfs.FsPath(f"{self.export_path}/uploaded_notes.csv")) as reader:
+            rows = list(reader)
+
+        # One row per uploaded real note, matching what we pushed to Label Studio
+        self.assertEqual(self.get_pushed_refs(), {row["note_ref"] for row in rows})
+
+        # And the anonymized note ref round-trips through the codebook
+        by_ref = {row["note_ref"]: row for row in rows}
+        self.assertEqual(
+            f"DocumentReference/{ANON_43}", by_ref["DocumentReference/43"]["anon_note_ref"]
+        )
+
     @ddt.data(
         ({}, True),  # default args
         ({"philter": "redact"}, True),

--- a/tests/upload_notes/test_upload_cli.py
+++ b/tests/upload_notes/test_upload_cli.py
@@ -1,6 +1,8 @@
 """Tests for upload_notes/cli.py"""
 
 import base64
+import contextlib
+import io
 import itertools
 import os
 import shutil
@@ -75,16 +77,18 @@ class TestUploadNotes(AsyncTestCase):
         no_philter=None,
         overwrite=False,
         skip_init_checks=True,
+        export_to=True,
     ) -> None:
         args = [
             "upload-notes",
             input_path or self.input_path,
             "https://localhost/labelstudio",
             phi_path or self.phi_path,
-            f"--export-to={self.export_path}",
             "--ls-project=21",
             f"--ls-token={self.token_path}",
         ]
+        if export_to:
+            args += [f"--export-to={self.export_path}"]
         if skip_init_checks:
             args += ["--skip-init-checks"]
         if anon_docrefs:
@@ -446,6 +450,20 @@ class TestUploadNotes(AsyncTestCase):
         with self.assertRaises(SystemExit) as cm:
             await self.run_upload_notes(f"--count={count}")
         self.assertEqual(errors.ARGS_INVALID, cm.exception.code)
+
+    async def test_count_without_export_to_warns(self):
+        """--count with no --export-to warns that no manifest will be saved"""
+        stdout = io.StringIO()
+        with contextlib.redirect_stdout(stdout):
+            await self.run_upload_notes("--count=1", "--seed=1", export_to=False)
+        self.assertIn("Warning: --export-to is not set", stdout.getvalue())
+
+    async def test_no_count_without_export_to_does_not_warn(self):
+        """Without --count, no --export-to warning is printed"""
+        stdout = io.StringIO()
+        with contextlib.redirect_stdout(stdout):
+            await self.run_upload_notes(export_to=False)
+        self.assertNotIn("Warning: --export-to is not set", stdout.getvalue())
 
     async def test_manifest_written(self):
         """A manifest of uploaded notes is written into the export folder"""


### PR DESCRIPTION
The `upload-notes` command now takes some new arguments to enable user-defined limits on how many charts are uploaded to a labelstudio project, closing #559. New Arguments include: 
- `count`: How many charts (after grouping, if requested) should be uploaded to the labelstudio instance
- `seed`: Random seed used in sampling, to provide deterministic sampling when desired.

Docs are updated accordingly. I also introduce the idea of creating a manifest after note-selection is done if there is an `--export-to` directory specified. This can be a helpful artifact for replicability, and any PHI concerns should be side-stepped by the dir will already have exported patient PHI in it. 

If you notice the weird irrelevant file changes, it's because I ran `ruff format`. Shocked that these changes didn't impact CI, but presumably the formatting isn't mandated. If you feel strongly we can roll them back. 

### Checklist
- [x] Consider if documentation (like in `docs/`) needs to be updated
- [x] Consider if tests should be added
