### PR TITLE
Add a specific try/except block for AWS Authentication issues.

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -31,8 +31,12 @@ This will install the pre-commit hooks for the repo (which automatically enforce
 
 1. First, you'll want to install a Java JDK, for Delta Lake support.
 
-2. Then just run `pytest`.
-All dependencies should have been installed by the `pip install .[dev]` above.
+2. To ensure all test dependencies are installed, run this command:
+```sh
+pip install .[tests]
+```
+
+3. Then just run `pytest`.
 
 ### How to show us the patch
 

--- a/cumulus_etl/formats/base.py
+++ b/cumulus_etl/formats/base.py
@@ -7,6 +7,7 @@ from collections.abc import Collection
 import cumulus_fhir_support as cfs
 
 from cumulus_etl.formats.batch import Batch
+from py4j.protocol import Py4JJavaError
 
 
 class Format(abc.ABC):
@@ -66,6 +67,22 @@ class Format(abc.ABC):
         try:
             self._write_one_batch(batch)
             return True
+        except Py4JJavaError as e:
+            class_name = e.java_exception.getClass().getName()
+
+            nested_exception = e.java_exception.getCause()
+            if nested_exception:
+                class_name = nested_exception.getClass().getName()
+
+            # This exception is generally always nested within an AccessDeniedException
+            # which may indicate issues other than authenticating with AWS.
+            if class_name == "org.apache.hadoop.fs.s3a.auth.NoAuthWithAWSException":
+                raise SystemExit(
+                    "Could not access the S3 bucket to initialize. "
+                    + "Verify AWS_PROFILE is configured before execution."
+                )
+
+            raise
         except Exception:
             logging.exception("Could not process data records")
             return False

--- a/cumulus_etl/formats/base.py
+++ b/cumulus_etl/formats/base.py
@@ -5,9 +5,11 @@ import logging
 from collections.abc import Collection
 
 import cumulus_fhir_support as cfs
+from py4j.protocol import Py4JJavaError
 
 from cumulus_etl.formats.batch import Batch
-from py4j.protocol import Py4JJavaError
+
+AWS_AUTH_EXCEPTION_CLASS_NAME = "org.apache.hadoop.fs.s3a.auth.NoAuthWithAWSException"
 
 
 class Format(abc.ABC):
@@ -74,18 +76,17 @@ class Format(abc.ABC):
             if nested_exception:
                 class_name = nested_exception.getClass().getName()
 
-            # This exception is generally always nested within an AccessDeniedException
-            # which may indicate issues other than authenticating with AWS.
-            if class_name == "org.apache.hadoop.fs.s3a.auth.NoAuthWithAWSException":
+            if class_name == AWS_AUTH_EXCEPTION_CLASS_NAME:
                 raise SystemExit(
-                    "Could not access the S3 bucket to initialize. "
+                    "Could not access the provided S3 bucket. "
                     + "Verify AWS_PROFILE is configured before execution."
                 )
 
-            raise
+            logging.exception("Could not process data records")
         except Exception:
             logging.exception("Could not process data records")
-            return False
+
+        return False
 
     @abc.abstractmethod
     def _write_one_batch(self, batch: Batch) -> None:

--- a/cumulus_etl/formats/base.py
+++ b/cumulus_etl/formats/base.py
@@ -5,7 +5,7 @@ import logging
 from collections.abc import Collection
 
 import cumulus_fhir_support as cfs
-from py4j.protocol import Py4JJavaError
+from py4j import protocol
 
 from cumulus_etl.formats.batch import Batch
 
@@ -69,7 +69,7 @@ class Format(abc.ABC):
         try:
             self._write_one_batch(batch)
             return True
-        except Py4JJavaError as e:
+        except protocol.Py4JJavaError as e:
             class_name = e.java_exception.getClass().getName()
 
             nested_exception = e.java_exception.getCause()

--- a/tests/etl/test_tasks.py
+++ b/tests/etl/test_tasks.py
@@ -7,7 +7,7 @@ import cumulus_fhir_support as cfs
 import ddt
 import pyarrow
 import pydantic
-from py4j.protocol import Py4JJavaError
+from py4j import protocol
 
 from cumulus_etl import common, errors
 from cumulus_etl.etl import tasks
@@ -373,7 +373,7 @@ class TestTaskCompletion(TaskTestCase):
         mock_java_exception.getClass().getName.return_value = "com.example.GenericJavaException"
         mock_java_exception.getCause.return_value = None
 
-        generic_py4j_error = Py4JJavaError("Java error occurred", mock_java_exception)
+        generic_py4j_error = protocol.Py4JJavaError("Java error occurred", mock_java_exception)
 
         summaries = await self._configure_completion_write_task(side_effect=generic_py4j_error)
         self.assertTrue(summaries[0].had_errors)
@@ -389,7 +389,7 @@ class TestTaskCompletion(TaskTestCase):
 
         mock_java_exception.getCause.return_value = mock_nested_exception
 
-        generic_py4j_error = Py4JJavaError("Java error occurred", mock_java_exception)
+        generic_py4j_error = protocol.Py4JJavaError("Java error occurred", mock_java_exception)
 
         with self.assertRaises(SystemExit):
             await self._configure_completion_write_task(

--- a/tests/etl/test_tasks.py
+++ b/tests/etl/test_tasks.py
@@ -12,7 +12,7 @@ from py4j.protocol import Py4JJavaError
 from cumulus_etl import common, errors
 from cumulus_etl.etl import tasks
 from cumulus_etl.etl.tasks import basic_tasks, task_factory
-from cumulus_etl.formats.base import Format
+from cumulus_etl.formats.base import AWS_AUTH_EXCEPTION_CLASS_NAME, Format
 from tests.etl import TaskTestCase
 
 
@@ -383,9 +383,7 @@ class TestTaskCompletion(TaskTestCase):
         mock_java_exception.getClass().getName.return_value = "com.example.GenericJavaException"
 
         mock_nested_exception = mock.MagicMock()
-        mock_nested_exception.getClass().getName.return_value = (
-            "org.apache.hadoop.fs.s3a.auth.NoAuthWithAWSException"
-        )
+        mock_nested_exception.getClass().getName.return_value = AWS_AUTH_EXCEPTION_CLASS_NAME
 
         mock_java_exception.getCause.return_value = mock_nested_exception
         generic_py4j_error = Py4JJavaError("Java error occurred", mock_java_exception)

--- a/tests/etl/test_tasks.py
+++ b/tests/etl/test_tasks.py
@@ -7,10 +7,12 @@ import cumulus_fhir_support as cfs
 import ddt
 import pyarrow
 import pydantic
+from py4j.protocol import Py4JJavaError
 
 from cumulus_etl import common, errors
 from cumulus_etl.etl import tasks
 from cumulus_etl.etl.tasks import basic_tasks, task_factory
+from cumulus_etl.formats.base import Format
 from tests.etl import TaskTestCase
 
 
@@ -349,6 +351,60 @@ class TestTaskCompletion(TaskTestCase):
         self.make_json("Device", "A")
         summaries = await basic_tasks.DeviceTask(self.job_config, self.scrubber).run()
         self.assertTrue(summaries[0].had_errors)
+
+    async def test_py4jjavaerror_during_write(self):
+        """We should exhibit the same behavior as generic exceptions if a py4jerror was thrown."""
+
+        mock_java_exception = mock.MagicMock()
+        mock_java_exception.getClass().getName.return_value = "com.example.GenericJavaException"
+        mock_java_exception.getCause.return_value = None
+
+        generic_py4j_error = Py4JJavaError("Java error occurred", mock_java_exception)
+
+        def make_formatter(dbname: str, **kwargs):
+            mock_formatter = mock.MagicMock(dbname=dbname, **kwargs)
+
+            if dbname == "etl__completion":
+                mock_formatter.write_records.return_value = False
+                mock_formatter._write_one_batch.side_effect = generic_py4j_error
+
+            return mock_formatter
+
+        self.job_config.create_formatter = mock.MagicMock(side_effect=make_formatter)
+
+        self.make_json("Device", "A")
+        summaries = await basic_tasks.DeviceTask(self.job_config, self.scrubber).run()
+        self.assertTrue(summaries[0].had_errors)
+
+    async def test_noauthwithawsexception_during_write(self):
+        """We should raise SystemExit when a Py4J error wraps a nested NoAuthWithAWS exception."""
+
+        mock_java_exception = mock.MagicMock()
+        mock_java_exception.getClass().getName.return_value = "com.example.GenericJavaException"
+
+        mock_nested_exception = mock.MagicMock()
+        mock_nested_exception.getClass().getName.return_value = (
+            "org.apache.hadoop.fs.s3a.auth.NoAuthWithAWSException"
+        )
+
+        mock_java_exception.getCause.return_value = mock_nested_exception
+        generic_py4j_error = Py4JJavaError("Java error occurred", mock_java_exception)
+
+        def make_formatter(dbname: str, **kwargs):
+            mock_formatter = mock.MagicMock(dbname=dbname, **kwargs)
+
+            if dbname == "etl__completion":
+                mock_formatter.write_records = Format.write_records.__get__(mock_formatter)
+                mock_formatter._write_one_batch.side_effect = generic_py4j_error
+
+            return mock_formatter
+
+        self.job_config.create_formatter = mock.MagicMock(side_effect=make_formatter)
+
+        self.make_json("Device", "A")
+
+        with self.assertRaises(SystemExit):
+            await basic_tasks.DeviceTask(self.job_config, self.scrubber).run()
 
 
 class TestModelTask(TaskTestCase):

--- a/tests/etl/test_tasks.py
+++ b/tests/etl/test_tasks.py
@@ -205,6 +205,30 @@ class TestTasks(TaskTestCase):
 class TestTaskCompletion(TaskTestCase):
     """Tests for etl__completion* handling"""
 
+    async def _configure_completion_write_task(
+        self, write_records_result=None, write_records=None, side_effect=None
+    ) -> basic_tasks.DeviceTask:
+        """A helper method to create the mock formatter for
+        completion write tests and then return the DeviceTask to run."""
+
+        def make_formatter(dbname: str, **kwargs):
+            mock_formatter = mock.MagicMock(dbname=dbname, **kwargs)
+
+            if dbname == "etl__completion":
+                mock_formatter.write_records.return_value = write_records_result
+                mock_formatter._write_one_batch.side_effect = side_effect
+
+                if write_records is not None:
+                    mock_formatter.write_records = Format.write_records.__get__(mock_formatter)
+
+            return mock_formatter
+
+        self.job_config.create_formatter = mock.MagicMock(side_effect=make_formatter)
+
+        self.make_json("Device", "A")
+
+        return await basic_tasks.DeviceTask(self.job_config, self.scrubber).run()
+
     async def test_encounter_completion(self):
         """Verify that we write out completion data correctly"""
         self.make_json("Encounter", "FirstBatch.A")
@@ -338,22 +362,12 @@ class TestTaskCompletion(TaskTestCase):
 
     async def test_error_during_write(self):
         """We should flag the task as failed if we can't write completion"""
-
-        # Change the way we mock formatters to insert an error
-        def make_formatter(dbname: str, **kwargs):
-            mock_formatter = mock.MagicMock(dbname=dbname, **kwargs)
-            if dbname == "etl__completion":
-                mock_formatter.write_records.return_value = False
-            return mock_formatter
-
-        self.job_config.create_formatter = mock.MagicMock(side_effect=make_formatter)
-
-        self.make_json("Device", "A")
-        summaries = await basic_tasks.DeviceTask(self.job_config, self.scrubber).run()
+        summaries = await self._configure_completion_write_task(write_records_result=False)
         self.assertTrue(summaries[0].had_errors)
 
     async def test_py4jjavaerror_during_write(self):
-        """We should exhibit the same behavior as generic exceptions if a py4jerror was thrown."""
+        """We should exhibit the same behavior as generic exception handling ifwrite_records_result
+        a Py4JJavaError was thrown without a nested NoAuthWithAWS exception."""
 
         mock_java_exception = mock.MagicMock()
         mock_java_exception.getClass().getName.return_value = "com.example.GenericJavaException"
@@ -361,23 +375,11 @@ class TestTaskCompletion(TaskTestCase):
 
         generic_py4j_error = Py4JJavaError("Java error occurred", mock_java_exception)
 
-        def make_formatter(dbname: str, **kwargs):
-            mock_formatter = mock.MagicMock(dbname=dbname, **kwargs)
-
-            if dbname == "etl__completion":
-                mock_formatter.write_records.return_value = False
-                mock_formatter._write_one_batch.side_effect = generic_py4j_error
-
-            return mock_formatter
-
-        self.job_config.create_formatter = mock.MagicMock(side_effect=make_formatter)
-
-        self.make_json("Device", "A")
-        summaries = await basic_tasks.DeviceTask(self.job_config, self.scrubber).run()
+        summaries = await self._configure_completion_write_task(side_effect=generic_py4j_error)
         self.assertTrue(summaries[0].had_errors)
 
     async def test_noauthwithawsexception_during_write(self):
-        """We should raise SystemExit when a Py4J error wraps a nested NoAuthWithAWS exception."""
+        """We should raise SystemExit when a Py4JJavaError wraps a nested NoAuthWithAWS exception."""
 
         mock_java_exception = mock.MagicMock()
         mock_java_exception.getClass().getName.return_value = "com.example.GenericJavaException"
@@ -386,23 +388,13 @@ class TestTaskCompletion(TaskTestCase):
         mock_nested_exception.getClass().getName.return_value = AWS_AUTH_EXCEPTION_CLASS_NAME
 
         mock_java_exception.getCause.return_value = mock_nested_exception
+
         generic_py4j_error = Py4JJavaError("Java error occurred", mock_java_exception)
 
-        def make_formatter(dbname: str, **kwargs):
-            mock_formatter = mock.MagicMock(dbname=dbname, **kwargs)
-
-            if dbname == "etl__completion":
-                mock_formatter.write_records = Format.write_records.__get__(mock_formatter)
-                mock_formatter._write_one_batch.side_effect = generic_py4j_error
-
-            return mock_formatter
-
-        self.job_config.create_formatter = mock.MagicMock(side_effect=make_formatter)
-
-        self.make_json("Device", "A")
-
         with self.assertRaises(SystemExit):
-            await basic_tasks.DeviceTask(self.job_config, self.scrubber).run()
+            await self._configure_completion_write_task(
+                write_records=True, side_effect=generic_py4j_error
+            )
 
 
 class TestModelTask(TaskTestCase):


### PR DESCRIPTION
Addresses #548 

### Checklist
- [x] Consider if documentation (like in `docs/`) needs to be updated
- [x] Consider if tests should be added

Notes:
- We could pull in a more direct import for referencing the class (vs a hardcoded string) from the jvm package, but this seemed to add a lot of code in comparison to the desired functionality. 
- In each test I ran, it seemed more prudent to handle the more specific "NoAuthWithAWS" exception than the AccessDenied exception because AccessDenied for files can be caused by a multitude of issues, not just the traceback indicated in the issue being addressed. NoAuthWithAWS is always nested within this parent exception.

Test:
- New functionality:
  - Ensure the `AWS_PROFILE` IS NOT set in your development environment / Credentials are not available.
  - Run `init` .. An example:
  ```sh
  docker compose run --build \
  cumulus-etl init \
  s3://your_bucket_name
   ```
  - Verify the error: `Could not access the provided S3 bucket. Verify AWS_PROFILE is configured before execution.` displays in the terminal, and no folders + files were added to the S3 bucket.
- Typical functionality: 
   - Ensure the `AWS_PROFILE` IS set in your development environment / Credentials are available.
   - Run `init` .. An example:
  ```sh
  docker compose run --build \
  cumulus-etl init \
  s3://your_bucket_name
   ```
  - Verify the folder structure and related files have been created in the S3 bucket.

